### PR TITLE
Fix `alpha` documentation

### DIFF
--- a/flash/display/DisplayObject.hx
+++ b/flash/display/DisplayObject.hx
@@ -133,6 +133,7 @@ package flash.display;
  */
 extern class DisplayObject extends flash.events.EventDispatcher  implements IBitmapDrawable {
 
+	#if !display
 	/**
 	 * The current accessibility options for this display object. If you modify
 	 * the <code>accessibilityProperties</code> property or any of the fields
@@ -144,7 +145,6 @@ extern class DisplayObject extends flash.events.EventDispatcher  implements IBit
 	 * the value of <code>accessibilityProperties</code> is prepopulated with any
 	 * information you entered in the Accessibility panel for that object.</p>
 	 */
-	#if !display
 	var accessibilityProperties : flash.accessibility.AccessibilityProperties;
 	#end
 


### PR DESCRIPTION
On http://www.openfl.org/developer/documentation/api/source/content/flash/display/DisplayObject.html the documentation for `var alpha` is really that of `accessibilityProperties`.

The fix is to exclude the documentation alongside the definition of `accessibilityProperties`.
