### PR TITLE
Joystick DEVICE_ADDED and DEVICE_REMOVED references

### DIFF
--- a/openfl/events/JoystickEvent.hx
+++ b/openfl/events/JoystickEvent.hx
@@ -12,6 +12,8 @@ extern class JoystickEvent extends Event
 	static var BUTTON_DOWN:String;
 	static var BUTTON_UP:String;
 	static var HAT_MOVE:String;
+	static var DEVICE_ADDED:String;
+	static var DEVICE_REMOVED:String;
 	
 	var axis:Array<Float>;
 	var device:Int;


### PR DESCRIPTION
Linked to Lime Joystick device added and removed events
