### PR TITLE
Assets.getBytes() corr for openfl_html5 and pixi

### DIFF
--- a/templates/haxe/DefaultAssetLibrary.hx
+++ b/templates/haxe/DefaultAssetLibrary.hx
@@ -210,19 +210,11 @@ class DefaultAssetLibrary extends AssetLibrary {
 	
 	public override function getBytes (id:String):ByteArray {
 		
-		#if pixi
-		
-		return null;
-		
-		#elseif (flash)
+		#if (flash)
 		
 		return cast (Type.createInstance (className.get (id), []), ByteArray);
-		
-		#elseif openfl_html5
-		
-		return null;
-		
-		#elseif js
+
+		#elseif (js || openfl_html5 || pixi)
 		
 		var bytes:ByteArray = null;
 		var data = ApplicationMain.urlLoaders.get (path.get (id)).data;


### PR DESCRIPTION
openfl_html5 and pixi targets were set to return null from the getBytes() method.

```
#if pixi
    return null;
...
```

Now they're sharing the bytes loading with js target.
