### PR TITLE
Vast improvements in graphics class accuracy for HTML5 backend

### DIFF
--- a/backends/html5/openfl/display/Graphics.hx
+++ b/backends/html5/openfl/display/Graphics.hx
@@ -33,13 +33,13 @@ class Graphics {
 	private var __hasFill:Bool;
 	private var __hasStroke:Bool;
 	private var __inPath:Bool;
-	private var __positionX:Float;
-	private var __positionY:Float;
-	private var __visible:Bool;
-	private var __pendingMatrix:Matrix;
 	private var __inversePendingMatrix:Matrix;
 	private var __pattern:CanvasPattern;
+	private var __pendingMatrix:Matrix;
+	private var __positionX:Float;
+	private var __positionY:Float;
 	private var __setFill:Bool;
+	private var __visible:Bool;
 	
 	
 	public function new () {
@@ -595,7 +595,6 @@ class Graphics {
 									}
 									
 								}
-								
 								
 							}
 							


### PR DESCRIPTION
Contributes towards the resolution of #214

Test project: https://dl.dropboxusercontent.com/u/10641626/Github/OpenFL-TestApp.zip
- Fixes bitmapfill on drawn paths
- Implements matrix transforms on bitmap fills
- Fixes other inconsistencies in the graphics class
- Cleans up the graphics class code

This does remove one optimisation for drawing rectangles where using a pattern fill was not needed, however supporting this optimisation makes the code very messy.

Cutting holes by drawing over the current path is semi-supported, not fully supported due to limitations in HTML5 drawing.

Changing line style mid-fill is not supported due to limitations in HTML5 drawing.
#### Test renderings:

**Flash (Target reference):**
![impl_flash](https://cloud.githubusercontent.com/assets/5081038/3131534/9ef95648-e805-11e3-954f-bd8b51cf4b65.png)

**HTML5 After improvements:**
![impl_html5](https://cloud.githubusercontent.com/assets/5081038/3131537/a3fcecd6-e805-11e3-84cc-19b9275a4c20.png)

**OpenFL 2.0.0 HTML5:**
![impl_orig](https://cloud.githubusercontent.com/assets/5081038/3131541/aa8f2a5a-e805-11e3-8e25-b6704d22bd00.png)
