### PR TITLE
Fixed font issue on Chrome in which the font was not working due to miss...

### DIFF
--- a/backends/html5/templates/html5/template/index.html
+++ b/backends/html5/templates/html5/template/index.html
@@ -41,7 +41,7 @@
 </head>
 <body>
 	::foreach assets::::if (type == "font")::
-	<span style="font-family: ::id::"> </span>::end::::end::
+	<span style="font-family: '::id::'"> </span>::end::::end::
 	
 	<div id="openfl-content"></div>
 	


### PR DESCRIPTION
...ing quotes around font name in the span element.

This is only an issue on the html5 non-dom backend. And this was also occurring on the android version of Chrome so this should fix it there too.
