### PR TITLE
The stageWidth/Height were not updating for html5 -Ddom when project win...

### DIFF
--- a/backends/html5/openfl/display/Stage.hx
+++ b/backends/html5/openfl/display/Stage.hx
@@ -472,7 +472,7 @@ class Stage extends Sprite {
 	
 	private function __resize ():Void {
 		
-		if (__element != null && __div == null) {
+		if (__element != null && (__div == null || (__div != null && __fullscreen))) {
 			
 			if (__fullscreen) {
 				


### PR DESCRIPTION
...dow width and height were set to 0, i.e. when __fullscreen is true. It looks like __div == null is still needed for now though, so I left that in.
