### PR TITLE
Fixed webkit transform bug in html5 -Ddom. The -webkit-transform propert...

### DIFF
--- a/backends/html5/openfl/display/DisplayObject.hx
+++ b/backends/html5/openfl/display/DisplayObject.hx
@@ -190,6 +190,17 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		
 		if (setTransform && __worldTransformChanged) {
 			
+			if (renderSession.isWebkitDOM) {
+				// In Chrome, exponential notation is not supported for -webkit-transform
+				
+				__worldTransform.a = Math.round (__worldTransform.a * 1000) / 1000;
+				__worldTransform.b = Math.round (__worldTransform.b * 1000) / 1000;
+				__worldTransform.c = Math.round (__worldTransform.c * 1000) / 1000;
+				__worldTransform.d = Math.round (__worldTransform.d * 1000) / 1000;
+				__worldTransform.tx = Math.round (__worldTransform.tx * 10) / 10;
+				__worldTransform.ty = Math.round (__worldTransform.ty * 10) / 10;
+			}
+			
 			__style.setProperty (renderSession.transformProperty, __worldTransform.to3DString (renderSession.roundPixels), null);
 			
 		}

--- a/backends/html5/openfl/display/Sprite.hx
+++ b/backends/html5/openfl/display/Sprite.hx
@@ -205,6 +205,16 @@ class Sprite extends DisplayObjectContainer {
 					transform.translate (__graphics.__bounds.x, __graphics.__bounds.y);
 					transform = transform.mult (__worldTransform);
 					
+					if (renderSession.isWebkitDOM) {
+						// In Chrome, exponential notation is not supported for -webkit-transform
+					
+						transform.a = Math.round (transform.a * 1000) / 1000;
+						transform.b = Math.round (transform.b * 1000) / 1000;
+						transform.c = Math.round (transform.c * 1000) / 1000;
+						transform.d = Math.round (transform.d * 1000) / 1000;
+						transform.tx = Math.round (transform.tx * 10) / 10;
+						transform.ty = Math.round (transform.ty * 10) / 10;
+					}
 					__style.setProperty (renderSession.transformProperty, transform.to3DString (renderSession.roundPixels), null);
 					
 				}

--- a/backends/html5/openfl/display/Stage.hx
+++ b/backends/html5/openfl/display/Stage.hx
@@ -445,6 +445,7 @@ class Stage extends Sprite {
 		
 		__renderSession.vendorPrefix = prefix.lowercase;
 		__renderSession.transformProperty = (prefix.lowercase == "webkit") ? "-webkit-transform" : "transform";
+		__renderSession.isWebkitDOM = prefix.lowercase == "webkit";
 		__renderSession.transformOriginProperty = (prefix.lowercase == "webkit") ? "-webkit-transform-origin" : "transform-origin";
 		
 	}
@@ -1355,6 +1356,7 @@ class RenderSession {
 	public var transformOriginProperty:String;
 	public var vendorPrefix:String;
 	public var z:Int;
+	public var isWebkitDOM:Bool;
 	//public var smoothProperty:Null<Bool> = null;
 	
 	


### PR DESCRIPTION
...y does not support exponential notation so the individual transform values need to be zeroed when they're close to zero.
