### PR TITLE
Bind openfl.external.ExternalInterface#call to proper this in html5 backend.

### DIFF
--- a/backends/html5/openfl/external/ExternalInterface.hx
+++ b/backends/html5/openfl/external/ExternalInterface.hx
@@ -28,6 +28,11 @@ class ExternalInterface {
 		
 		var callResponse:Dynamic = null;
 		
+		var thisArg = functionName.split('.').slice(0, -1).join('.');
+		if (thisArg.length > 0) {
+			functionName += '.bind(${thisArg})';
+		}
+		
 		if (p1 == null) {
 			
 			callResponse = js.Lib.eval (functionName) ();


### PR DESCRIPTION
This change makes ExternalInterface#call in html5 backend work in a similar way to flash backend.

In flash, whenever you call ExternalInterface.call('ns.object.method'), the method will be called with ns.object as 'this'. 
In html5 currently this would be just 'window'.
