### PR TITLE
Update SharedObject.hx

### DIFF
--- a/backends/native/openfl/net/SharedObject.hx
+++ b/backends/native/openfl/net/SharedObject.hx
@@ -214,19 +214,19 @@ class SharedObject extends EventDispatcher {
 			
 			if (StringTools.startsWith (name, "neash.")) {
 				
-				StringTools.replace (name, "neash.", "openfl.");
+				name = StringTools.replace (name, "neash.", "openfl.");
 				
 			}
 			
 			if (StringTools.startsWith (name, "native.")) {
 				
-				StringTools.replace (name, "native.", "openfl.");
+				name = StringTools.replace (name, "native.", "openfl.");
 				
 			}
 			
 			if (StringTools.startsWith (name, "flash.")) {
 				
-				StringTools.replace (name, "flash.", "openfl.");
+				name = StringTools.replace (name, "flash.", "openfl.");
 				
 			}
 			


### PR DESCRIPTION
StringTools replace does not change the value of name, at least on the Flash target.

Also, I believe that the "openfl" namespace is converted to "flash" for the flash target at compilation, so any references to "openfl" in serialized data will not resolve. I did not fix this yet because I am still testing and would like confirmation of that.
