### PR TITLE
Loaderinfo error with url containing parameter

### DIFF
--- a/backends/native/openfl/display/LoaderInfo.hx
+++ b/backends/native/openfl/display/LoaderInfo.hx
@@ -74,8 +74,6 @@ class LoaderInfo extends URLLoader {
 		if (extension.indexOf('?') != -1) 
 			extension = extension.split('?')[0];
 		
-		trace(extension);
-		
 		contentType = switch (extension) {
 			
 			case "swf": "application/x-shockwave-flash";


### PR DESCRIPTION
The extension was equal to everything after the last dot, so if the url contained parameter, the Unrecognized file exception was thrown.
