### PR TITLE
Show the name of SharedObject

### DIFF
--- a/backends/native/openfl/net/SharedObject.hx
+++ b/backends/native/openfl/net/SharedObject.hx
@@ -195,7 +195,7 @@ class SharedObject extends EventDispatcher {
 				
 			} catch (e:Dynamic) {
 				
-				trace ("Could not unserialize SharedObject");
+				trace ('Could not unserialize SharedObject: $name');
 				loadedData = { };
 				
 			}


### PR DESCRIPTION
Show the name of SharedObject when failing to unserialize.
