### PR TITLE
The function hitTestPoint lacks implementation for HTML5

### DIFF
--- a/backends/html5/openfl/display/DisplayObject.hx
+++ b/backends/html5/openfl/display/DisplayObject.hx
@@ -174,7 +174,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	
 	public function hitTestPoint (x:Float, y:Float, shapeFlag:Bool = false):Bool {
 		
-		return false;
+		return getBounds (null).contains (x,y);
 		
 	}
 	


### PR DESCRIPTION
The function hitTestPoint actually lacks implementation for HTML5, it simply returns false. 
