### PR TITLE
Improve openfl.display.BitmapData#getVector performance.

### DIFF
--- a/backends/html5/openfl/display/BitmapData.hx
+++ b/backends/html5/openfl/display/BitmapData.hx
@@ -615,9 +615,10 @@ class BitmapData implements IBitmapDrawable {
 	
 	public function getVector (rect:Rectangle) {
 		var pixels = getPixels(rect);
-		var result = new Vector<UInt>();
-		for (i in 0...Std.int(pixels.length / 4)) {
-			result.push(pixels.readUnsignedInt());
+		var length = Std.int(pixels.length / 4);
+		var result = new Vector<UInt>(length);
+		for (i in 0...length) {
+			result[i] = pixels.readUnsignedInt();
 		}
 		return result;
 	}


### PR DESCRIPTION
Avoid unnecessary array reallocations.
