### PR TITLE
Socket.flush() shouldn't propagate exceptions from sys.net.Socket, but t...

### DIFF
--- a/backends/native/openfl/net/Socket.hx
+++ b/backends/native/openfl/net/Socket.hx
@@ -162,8 +162,13 @@ class Socket extends EventDispatcher implements IDataInput /*implements IDataOut
 			dispatchEvent( new ProgressEvent(ProgressEvent.SOCKET_DATA, false, false, newData.length, 0) );
 		}
 		
-		if( _socket != null )
-			flush();
+		if ( _socket != null ) {
+			try {
+				flush();
+			} catch ( e:IOError ) {
+				dispatchEvent( new IOErrorEvent(IOErrorEvent.IO_ERROR, true, false, e.message) );
+			}
+		}
 	}
 
 	private function cleanSocket(){
@@ -312,12 +317,16 @@ class Socket extends EventDispatcher implements IDataInput /*implements IDataOut
 	//public function writeObject( object:Dynamic ):Void {  _output.writeObject(object); }
 
 	public function flush() {
-		if( _socket == null )
+		if ( _socket == null )
 			throw new IOError("Operation attempted on invalid socket.");
-		if( _output.length > 0 ){
-			_socket.output.write( _output );
-			_output = new ByteArray();
-			_output.endian = endian;
+		if ( _output.length > 0 ){
+			try {
+				_socket.output.write( _output );
+				_output = new ByteArray();
+				_output.endian = endian;
+			} catch ( e:Dynamic ) {
+				throw new IOError("Operation attempted on invalid socket.");
+			}
 		}
 	}
 	


### PR DESCRIPTION
...ransform them into IOError

Socket.onFrame() shouldn't throw errors that won't be able to be catched when called flush(), but it should dispatch an IOErrorEvent
This should avoid crashing the application without the ability to recover when connecting and writing to an address that is not listening
