### PR TITLE
Interfaces for events; simpler addEventListener functionality

### DIFF
--- a/openfl/events/IAccelerometer.hx
+++ b/openfl/events/IAccelerometer.hx
@@ -1,0 +1,15 @@
+package events;
+
+import openfl.events.AccelerometerEvent;
+
+/**
+ * The interface for Accelerometer events.
+ */
+interface IAccelerometer 
+{
+	/**
+	 * The function called when the meter on the device is updated.
+	 */
+	public var update:AccelerometerEvent -> Void;
+  
+}

--- a/openfl/events/IAsyncError.hx
+++ b/openfl/events/IAsyncError.hx
@@ -1,0 +1,15 @@
+package events;
+
+import openfl.events.AsyncErrorEvent;
+
+/**
+ * The interface for Async Error events.
+ */
+interface IAsyncError 
+{
+	/**
+	 * The function called when an async error is received by the 
+	 * calling object.
+	 */
+	public var asyncError:AsyncErrorEvent -> Void;
+}

--- a/openfl/events/IContextMenu.hx
+++ b/openfl/events/IContextMenu.hx
@@ -1,0 +1,19 @@
+package events;
+
+import openfl.events.ContextMenuEvent;
+
+/**
+ * The interface for Context Menu events.
+ */
+interface IContextMenu 
+{
+	/**
+	 * The function called when an item in the given context menu is selected.
+	 */
+	public var menuItemSelected:ContextMenuEvent -> Void;
+	
+	/**
+	 * The function called when the given context menu is selected.
+	 */
+	public var menuSelected:ContextMenuEvent -> Void;
+}

--- a/openfl/events/IData.hx
+++ b/openfl/events/IData.hx
@@ -1,0 +1,19 @@
+package events;
+
+import openfl.events.DataEvent;
+
+/**
+ * The interface for Data events.
+ */
+interface IData 
+{
+	/**
+	 * The function called when data is downloading.
+	 */
+	public var data:DataEvent -> Void;
+	
+	/**
+	 * The function called when data has completed uploading.
+	 */
+	public var uploadCompleteData:DataEvent -> Void;
+}

--- a/openfl/events/IError.hx
+++ b/openfl/events/IError.hx
@@ -1,0 +1,14 @@
+package events;
+
+import openfl.events.ErrorEvent;
+
+/**
+ * The interface for Error events.
+ */
+interface IError 
+{
+	/**
+	 * The function called when an error message is thrown.
+	 */
+	public var error:ErrorEvent -> Void;
+}

--- a/openfl/events/IEvent.hx
+++ b/openfl/events/IEvent.hx
@@ -1,0 +1,220 @@
+package events;
+
+import openfl.events.Event;
+
+/**
+ * The interface for stage events.
+ */
+interface IEvent 
+{
+	/**
+	 * The function called for when an event-enabled object is
+	 * activated.
+	 */
+	public var activate:Event -> Void;
+	
+	/**
+	 * The function called for when an object is added to this
+	 * object. 
+	 */
+	public var added:Event -> Void;
+	
+	/**
+	 * The function called for when an object is added to the
+	 * stage.
+	 */
+	public var addedToStage:Event -> Void;
+	
+	/**
+	 * The function called when an event is cancelled (ie e.preventDefault())
+	 */
+	public var cancel:Event -> Void;
+	
+	/**
+	 * The function called when the value of an object is changed.
+	 */
+	public var change:Event -> Void;
+	
+	/**
+	 * The function called when an object' send() function is called.
+	 */
+	public var channelMessage:Event -> Void;
+	
+	/**
+	 * The function called when the Channel State's property in an object is
+	 * changed.
+	 */
+	public var channelState:Event -> Void;
+	
+	/**
+	 * The function called when clear is selected from an object's context
+	 * menu or by its related function.
+	 */
+	public var clear:Event -> Void;
+	
+	/**
+	 * The function called when an object's connection is closed.
+	 */
+	public var close:Event -> Void;
+	
+	/**
+	 * The function called when a network object has completed loading.
+	 */
+	public var completed:Event -> Void;
+	
+	/**
+	 * The function called when a network object has established a network connection.
+	 */
+	public var connect:Event -> Void;
+	
+	/**
+	 * The function called when a Stage3D object makes a call to Stage3D.requestContext3D
+	 * or reset via Context3D bound to a Stage3D object.
+	 */
+	public var context3dCreate:Event -> Void;
+	
+	/**
+	 * The function called when an object's copy() function is called.
+	 */
+	public var copy:Event -> Void;
+	
+	/**
+	 * The function called when an object's cut() function is called.
+	 */
+	public var cut:Event -> Void;
+	
+	/**
+	 * The function called when an event-related object is deactivated.
+	 */
+	public var deactive:Event -> Void;
+
+	/**
+	 * The function called when an object enters a new frame. If this
+	 * object has one frame, this will be continuous in relation to frame rate.
+	 */
+	public var enterFrame:Event -> Void;
+	
+	/**
+	 * The function called when an object exits the next frame. If this
+	 * object has one frame, this will be continuous in relation to frame rate.
+	 */
+	public var exitFrame:Event -> Void;
+	
+	/**
+	 * The function called after a frame is constructed and before frame
+	 * scripts are run.
+	 */
+	public var frameConstructed:Event -> Void;
+	
+	/**
+	 * The function called when the stage enters or exits fullscreen mode.
+	 */
+	public var fullscreen:Event -> Void;
+	
+	/**
+	 * The function called when an MP3 sound is loaded, containing ID3 data.
+	 */
+	public var id3:Event -> Void;
+	
+	/**
+	 * The function called when the application is loaded, containing LoadingInfo data.
+	 */
+	public var init:Event -> Void;
+	
+	/**
+	 * The function called when the Stage object when the pointer moves out of the 
+	 * stage area. If the mouse button is pressed, the event is not dispatched.
+	 */
+	public var mouseLeave:Event -> Void;
+	
+	/**
+	 * The function called when a file is opened.
+	 */
+	public var open:Event -> Void;
+	
+	/**
+	 * The function called when the paste() function in the given object is called.
+	 */
+	public var paste:Event -> Void;
+	
+	/**
+	 * The function called when an object is removed from the given object.
+	 */
+	public var removed:Event -> Void;
+	
+	/**
+	 * The function called when an object is removed from the stage.
+	 */
+	public var removeFromStage:Event -> Void;
+	
+	/**
+	 * The function called when an object starts rendering, before it is added to the stage.
+	 * You must call the invalidate() method of the Stage object each time you want a render 
+	 * event to be dispatched.
+	 */
+	public var render:Event -> Void;
+	
+	/**
+	 * The function called when an object is resized.
+	 */
+	public var resize:Event -> Void;
+	
+	/**
+	 * The function called when a TextField is scrolling.
+	 * May also apply to containers who also dispatch this event if scrollbars are enabled.
+	 */
+	public var scroll:Event -> Void;
+	
+	/**
+	 * The function called when an object is selected.
+	 */
+	public var select:Event -> Void;
+	
+	/**
+	 * The function called when all objects in a container is selected.
+	 */
+	public var selectAll:Event -> Void;
+	
+	/**
+	 * The function called when sound has finished playing.
+	 */
+	public var soundComplete:Event -> Void;
+	
+	/**
+	 * The function called when the value of the tabChildren flag has changed.
+	 */
+	public var tabChildrenChanged:Event -> Void;
+	
+	/**
+	 * The function called when the object's tabEnabled flag changes.
+	 */
+	public var tabEnabledChanged:Event -> Void;
+	
+	/**
+	 * The function called when the value of the object's tabIndex property changes.
+	 */
+	public var tabIndexChanged:Event -> Void;
+	
+	/**
+	 * The function called when the mode of the text field changes.
+	 * Only applies to text-enabled objects. Also applies to any object implementing ITextField.
+	 */
+	public var textInteractionModeChange:Event -> Void;
+	
+	/**
+	 * The function called when the LoaderInfo object associated with this application is
+	 * loaded or replaced.
+	 */
+	public var unload:Event -> Void;
+	
+	/**
+	 * The function called when a camera object receives a new frame and is available to
+	 * be copied.
+	 */
+	public var videoFrame:Event -> Void;
+	
+	/**
+	 * The function called when the value of a worker's state changes.
+	 */
+	public var workerState:Event -> Void;
+}

--- a/openfl/events/IFocus.hx
+++ b/openfl/events/IFocus.hx
@@ -1,0 +1,29 @@
+package events;
+
+import openfl.events.FocusEvent;
+
+/**
+ * The interface for Focus events.
+ */
+interface IFocus 
+{
+	/**
+	 * The function called when an object receives focus.
+	 */
+	public var focusIn:FocusEvent -> Void;
+	
+	/**
+	 * The function called when an object loses focus.
+	 */
+	public var focusOut:FocusEvent -> Void;
+	
+	/**
+	 * The function called when a keyboard event changes.
+	 */
+	public var keyFocusChange:FocusEvent -> Void;
+	
+	/**
+	 * The function called when a mouse event changes.
+	 */
+	public var mouseFocusChange:FocusEvent -> Void;
+}

--- a/openfl/events/IHTTPStatus.hx
+++ b/openfl/events/IHTTPStatus.hx
@@ -1,0 +1,22 @@
+package events;
+
+import openfl.events.HTTPStatusEvent;
+
+/**
+ * The interface for HTTP Status events.
+ */
+interface IHTTPStatus 
+{
+	
+	/**
+	 * The function called when a response is received by the HTTP status
+	 * request. This is called before actual response data is received.
+	 */
+	public var statusResponse:HTTPStatusEvent -> Void;
+	
+	/**
+	 * The function called when data is received by a HTTP status request.
+	 */
+	public var status:HTTPStatusEvent -> Void;
+	
+}

--- a/openfl/events/IIOError.hx
+++ b/openfl/events/IIOError.hx
@@ -1,0 +1,15 @@
+package events;
+
+import openfl.events.IOErrorEvent;
+
+/**
+ * The interface for IO Error events.
+ */
+interface IIOError 
+{
+	/**
+	 * The function called when an error message specific to IO handles
+	 * is thrown.
+	 */
+	public var ioError:IOErrorEvent -> Void;
+}

--- a/openfl/events/IJoystick.hx
+++ b/openfl/events/IJoystick.hx
@@ -1,0 +1,53 @@
+package events;
+
+import openfl.events.JoystickEvent;
+
+/**
+ * The interface for Joystick events.
+ */
+interface IJoystick 
+{
+	
+	/**
+	 * The function called when an analogue stick on the
+	 * joystick alters its axis.
+	 */
+	public var axisMove:JoystickEvent -> Void;
+	
+	/**
+	 * The function called when the analogue stick on the
+	 * joystick moves.
+	 */
+	public var ballMove:JoystickEvent -> Void;
+	
+	/**
+	 * The function called when a button on the joystick
+	 * is pressed down.
+	 */
+	public var buttonDown:JoystickEvent -> Void;
+	
+	/**
+	 * The function called when a button on the joystick
+	 * is released.
+	 */
+	public var buttonUp:JoystickEvent -> Void;
+	
+	/**
+	 * The function called when a joystick device is
+	 * received by the system.
+	 */
+	public var deviceAdded:JoystickEvent -> Void;
+	
+	/**
+	 * The function called when a joystick device is
+	 * no longer detected on the system.
+	 */
+	public var deviceRemoved:JoystickEvent -> Void;
+	
+	/**
+	 * The function called when the Hat on the joystick
+	 * device is moved.
+	 */
+	public var hatMove:JoystickEvent -> Void;
+	
+}

--- a/openfl/events/IKeyboard.hx
+++ b/openfl/events/IKeyboard.hx
@@ -1,0 +1,19 @@
+package events;
+
+import openfl.events.KeyboardEvent;
+
+/**
+ * The interface for Keyboard events.
+ */
+interface IKeyboard 
+{
+	/**
+	 * The function to call when a key is released.
+	 */
+	public var keyUp:KeyboardEvent -> Void;
+	
+	/**
+	 * The function to call when a key is down.
+	 */
+	public var keyDown:KeyboardEvent -> Void;
+}

--- a/openfl/events/IMouse.hx
+++ b/openfl/events/IMouse.hx
@@ -1,0 +1,100 @@
+package events;
+
+import openfl.events.MouseEvent;
+
+/**
+ * The interface for Mouse events.
+ */
+interface IMouse 
+{
+	/**
+	 * The function called when the left mouse button is pressed and released on this
+	 * object. Prevents the double-click function.
+	 */
+	public var click:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the middle mouse button is pressed and released twice on
+	 * this object. 
+	 */
+	public var doubleClick:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse wheel or middle button is clicked
+	 * on this object.
+	 */
+	public var middleClick:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse wheel or middle button is pressed
+	 * down on this object.
+	 */
+	public var middleMouseDown:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse wheel or middle button is released
+	 * on this object.
+	 */
+	public var middleMouseUp:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the left mouse button is pressed down on this object.
+	 */
+	public var mouseDown:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse moves over the object.
+	 */
+	public var mouseMove:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse leaves the visible part of this object.
+	 */
+	public var mouseOut:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse enters the visible part of this object.
+	 */
+	public var mouseOver:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the left mouse button is released from this object.
+	 */
+	public var mouseUp:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse wheel moves up or down on this object.
+	 * Use e.delta to receive the direction of the mouse wheel (> 0 is up, < 0 is down)
+	 */
+	public var mouseWheel:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the right mouse button is pressed and released
+	 * on this object.
+	 */
+	public var rightClick:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the right mouse button is pressed on this
+	 * object.
+	 */
+	public var rightMouseDown:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the right mouse button is released on this
+	 * object.
+	 */
+	public var rightMouseUp:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse leaves the container. Child objects
+	 * within the container does not dispatch the rollOut event.
+	 */
+	public var rollOut:MouseEvent -> Void;
+	
+	/**
+	 * The function called when the mouse enters a container object. Child objects
+	 * within the container does not dispatch the rollOver event.
+	 */
+	public var rollOver:MouseEvent -> Void;
+}

--- a/openfl/events/INetStatus.hx
+++ b/openfl/events/INetStatus.hx
@@ -1,0 +1,16 @@
+package events;
+
+import openfl.events.NetStatusEvent;
+
+/**
+ * The interface for Net Status events.
+ */
+interface INetStatus 
+{
+	/**
+	 * The function called when a sound object or microphone device requests
+	 * new audio data.
+	 */
+	public var netStatus:NetStatusEvent -> Void;
+  
+}

--- a/openfl/events/IProgress.hx
+++ b/openfl/events/IProgress.hx
@@ -1,0 +1,20 @@
+package events;
+
+import openfl.events.ProgressEvent;
+
+/**
+ * The interfaces for Progress events.
+ */
+interface IProgress 
+{
+	/**
+	 * The function called while something is being loaded onto the stage.
+	 */
+	public var progress:ProgressEvent -> Void;
+	
+	/**
+	 * The function called while something is downloaded via a socket.
+	 */
+	public var socketData:ProgressEvent -> Void;
+	
+}

--- a/openfl/events/ISecurityError.hx
+++ b/openfl/events/ISecurityError.hx
@@ -1,0 +1,15 @@
+package events;
+
+import openfl.events.SecurityErrorEvent;
+
+/**
+ * The interface for Security Error events.
+ */
+interface ISecurityError 
+{
+	/**
+	 * The function called when a security-related error is thrown.
+	 */
+	public var securityError:SecurityErrorEvent -> Void;
+  
+}

--- a/openfl/events/IText.hx
+++ b/openfl/events/IText.hx
@@ -1,0 +1,20 @@
+package events;
+
+import openfl.events.TextEvent;
+
+/**
+ * The interface for Text events.
+ */
+interface IText 
+{
+	/**
+	 * When a hyperlink is clicked in a given text field, this is
+	 * the calling function. Does not work outside of Flash.
+	 */
+	public var link:TextEvent -> Void;
+	
+	/**
+	 * The function called when the given text field receives input.
+	 */
+	public var input:TextEvent -> Void;
+}

--- a/openfl/events/ITimer.hx
+++ b/openfl/events/ITimer.hx
@@ -1,0 +1,20 @@
+package events;
+
+import openfl.events.TimerEvent;
+
+/**
+ * The interface for Time Events.
+ */
+interface ITimer 
+{
+	/**
+	 * The function called when a timer object elapses.
+	 */
+	public var timer:TimerEvent -> Void;
+	
+	/**
+	 * The function called when the given time on a timer object
+	 * has fully elapsed.
+	 */
+	public var timerComplete:TimerEvent -> Void;
+}

--- a/openfl/events/ITouch.hx
+++ b/openfl/events/ITouch.hx
@@ -1,0 +1,49 @@
+package events;
+
+import openfl.events.TouchEvent;
+
+/**
+ * @author Colour Multimedia Enterprises
+ */
+
+interface ITouch 
+{
+	/** 
+	 * The function called when the device receives touch from the user.
+	 * */
+	public var touchBegin:TouchEvent -> Void;
+	
+	/**
+	 * The function called when the device no longer receives touch from the user.
+	 */
+	public var touchEnd:TouchEvent -> Void;
+	
+	/**
+	 * The function called when the device receives movement from a touch event.
+	 */
+	public var touchMove:TouchEvent -> Void;
+	
+	/**
+	 * The function called when the given object on the device no longer 
+	 * receives touch events.
+	 */
+	public var touchOut:TouchEvent -> Void;
+	
+	/**
+	 * The function called when the given object on the device receive touch events.
+	 */
+	public var touchOver:TouchEvent -> Void;
+	
+	/**
+	 * The function called when a receiving object is dragged outside of a 
+	 * container also receiving touch events.
+	 */
+	public var touchRollOut:TouchEvent -> Void;
+	
+	/**
+	 * The function called when a receiving object is dragged into a container 
+	 * that is about to receive touch events.
+	 */
+	public var touchRollOver:TouchEvent -> Void;
+	
+}

--- a/openfl/events/IUncaughtError.hx
+++ b/openfl/events/IUncaughtError.hx
@@ -1,0 +1,14 @@
+package events;
+
+import openfl.events.UncaughtErrorEvent;
+
+/**
+ * The interface for Uncaught Error events.
+ */
+interface IUncaughtError 
+{
+	/**
+	 * The function called when an error fails to throw.
+	 */
+	public var uncaughtError:UncaughtErrorEvent -> Void;
+}


### PR DESCRIPTION
The simple idea behind this is to allow for a simpler approach to event
handling.

If implemented - literally - by the classes who use these events, a
simple call to something like TextField would be a good addition (it's
more C#-esque).

`myTextField.onMouseDown = tfMouseDown;`

Just a suggestion.

If you like it, I can add implements to the appropriate classes throughout and add the event handlers. Event handling could be as simple as above.

Also, `myTextField.onMouseDown = null;` even easier than `myTextField.removeEventListener(MouseEvent.MOUSE_DOWN, tfMouseDown);`
