### PR TITLE
Fixes -Ddom scrollRect clipping

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1267,7 +1267,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 			}
 			
 			#if dom
-			__worldClipChanged = ((worldClip == null && __worldClip != null) || (worldClip != null && !worldClip.equals (__worldClip)));
+			__worldClipChanged = (__worldClip != null || (worldClip != null && !worldClip.equals (__worldClip)));
 			__worldClip = worldClip;
 			#end
 			


### PR DESCRIPTION
Observations:
- Firefox respects the canvas and images `style=clip: rect(...)`
- Chrome doesn't respect it on canvas, it does on images :confused: 