### PR TITLE
Fix vector array access on neko

### DIFF
--- a/openfl/Vector.hx
+++ b/openfl/Vector.hx
@@ -294,7 +294,21 @@ abstract Vector<T>(VectorData<T>) {
 	
 	@:noCompletion @:arrayAccess public inline function arrayWrite (key:Int, value:T):T {
 		
-		if (key >= this.length && !this.fixed) this.length = key + 1;
+		if (!this.fixed) {
+			
+			if (key >= this.length) {
+				this.length = key + 1;
+			}
+			
+			if (this.data.length < this.length) {
+				
+				var data = new haxe.ds.Vector<T> (this.data.length + 10);
+				haxe.ds.Vector.blit (this.data, 0, data, 0, this.data.length);
+				this.data = data;
+				
+			}
+			
+		}		
 		
 		return this.data[key] = value;
 		

--- a/openfl/_v2/Vector.hx
+++ b/openfl/_v2/Vector.hx
@@ -548,13 +548,28 @@ abstract Vector<T>(VectorData<T>) {
         return this.data[index];
 
     }
-
-
-	@:arrayAccess public inline function set (index:Int, value:T):T {
+	
+	@:arrayAccess public inline function set (key:Int, value:T):T {
 		
-		return this.data[index] = value;
-
-    }
+		if (!this.fixed) {
+			
+			if (key >= this.length) {
+				this.length = key + 1;
+			}
+			
+			if (this.data.length < this.length) {
+				
+				var data = new haxe.ds.Vector<T> (this.data.length + 10);
+				haxe.ds.Vector.blit (this.data, 0, data, 0, this.data.length);
+				this.data = data;
+				
+			}
+			
+		}		
+		
+		return this.data[key] = value;
+		
+	}
 
 
 	@:from static public inline function fromArray<T> (value:Array<T>):Vector<T> {


### PR DESCRIPTION
This commit fixes neko array access write:

``` haxe
var vector = new Vector<Float>();
vector[0] = 100;
trace(vector[0]);
```

Before it was outputing `null` With this commit it outputs the actual content. `100` in this example.
