### PR TITLE
Textfield autoSize and wordWrap fixes (for html5-canvas)

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -125,12 +125,7 @@ class CanvasTextField {
 			var negativeSize:Bool = textField.width <= 0 || textField.height <= 0;
 			var noAutoSize:Bool = textField.autoSize == TextFieldAutoSize.NONE;
 			
-			if((textField.__text == null || textField.__text == "") && !textField.background && !textField.border || negativeSize && noAutoSize) {
-				
-				textField.__canvas = null;
-				textField.__context = null;
-				
-			} else if (negativeSize && !noAutoSize && textField.wordWrap) {
+			if((textField.__text == null || textField.__text == "") && !textField.background && !textField.border || negativeSize && noAutoSize /*|| negativeSize && !noAutoSize && textField.wordWrap*/) {
 				
 				textField.__canvas = null;
 				textField.__context = null;
@@ -149,6 +144,8 @@ class CanvasTextField {
 				context = textField.__context;
 				
 				if (textField.__text != null && textField.__text != "") {
+					
+					var fullAutoSize = !textField.wordWrap && textField.autoSize != TextFieldAutoSize.NONE;
 					
 					var measurements = [];
 					var textWidth = 0.0;
@@ -170,7 +167,7 @@ class CanvasTextField {
 							textField.__height = textField.textHeight+4;
 						}
 						
-					} else if (!textField.wordWrap && textField.autoSize != TextFieldAutoSize.NONE)
+					} else if (fullAutoSize)
 					{	
 						measurements =  textField.__measureText ();
 						
@@ -222,6 +219,8 @@ class CanvasTextField {
 						var range;
 						var offsetX = 0.0;
 						
+						if (!fullAutoSize)	measurements =  textField.__measureText ();
+						
 						for (i in 0...textField.__ranges.length) {
 							
 							range = textField.__ranges[i];
@@ -247,9 +246,23 @@ class CanvasTextField {
 					
 					if (textField.wordWrap && !noAutoSize) {
 						
+						textField.__width = 1;
 						textField.__height = 4;
 						
 					} else if (!noAutoSize) {
+						
+						switch(textField.autoSize)
+						{
+							case TextFieldAutoSize.RIGHT:
+									
+									textField.x = textField.__x - 4 * textField.__scaleX;
+									
+							case TextFieldAutoSize.CENTER:
+								
+									textField.x = textField.__x - 2 * textField.__scaleX;
+									
+							default:	0;
+						}
 						
 						textField.__width = 4;
 						textField.__height = 4;

--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -233,6 +233,8 @@ class CanvasTextField {
 					
 				}
 				
+				textField.__dirty = false;
+				
 				return true;
 				
 			}

--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -160,7 +160,7 @@ class CanvasTextField {
 					
 					if (textField.wordWrap && textField.autoSize != TextFieldAutoSize.NONE)
 					{	
-						if (textField.__width <= 4)
+						if (textField.__width < 4)
 						{
 							textField.wordWrap = false;
 							textField.__height = textField.textHeight+4;

--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -183,11 +183,11 @@ class CanvasTextField {
 						{
 							case TextFieldAutoSize.RIGHT:
 									
-									textField.x = textField.x + textField.__width * textField.__scaleX - textWidth - 4;
+									textField.x = textField.__x + textField.__width * textField.__scaleX - textWidth - 4;
 									
 							case TextFieldAutoSize.CENTER:
 								
-									textField.x += textField.__width * textField.__scaleX / 2 - (textWidth + 4) / 2;
+									textField.x = textField.__x + textField.__width * textField.__scaleX / 2 - (textWidth + 4) / 2;
 									
 							default:	0;
 						}

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -417,10 +417,10 @@ class TextField extends InteractiveObject {
 				
 				if (char == "") break;
 				
-				if (char == '\n' || char == '\r' || char == '\t' || char == ' ' || char == '-')
+				if (char == '\n' /*|| char == '\r'*/ || char == '\t' || char == ' ' || char == '-')
 					wordStart = i + 1;
 					
-				if (char == '\n' || char == '\r')
+				if (char == '\n' /*|| char == '\r'*/)
 						lineStart = i + 1;
 				
 				str3 = __text.substring(lineStart, i + 1);
@@ -765,6 +765,8 @@ class TextField extends InteractiveObject {
 	
 	
 	@:noCompletion public function set_text (value:String):String {
+		
+		value = value.split('\r').join('\n');
 		
 		if (__isHTML || __text != value) __dirty = true;
 		__ranges = null;

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -580,7 +580,19 @@ class TextField extends InteractiveObject {
 	
 	@:noCompletion private override function get_height ():Float {
 		
-		return __height * scaleY;
+		if (autoSize != TextFieldAutoSize.NONE && wordWrap) {
+			
+			return __height * scaleX;
+			
+		} else if (autoSize != TextFieldAutoSize.NONE) {
+			
+			return (textHeight + 4) * scaleX;
+			
+		} else {	
+			
+			return __height * scaleX;
+			
+		}
 		
 	}
 	

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -706,7 +706,13 @@ class TextField extends InteractiveObject {
 	
 	@:noCompletion private function get_numLines ():Int {
 		
-		if (text != "" && text != null) {
+		if (wordWrap && __wrappedText != "" && __wrappedText != null)
+		{
+			
+			return __wrappedText.split("\n").length;
+			
+		}else if (text != "" && text != null)
+		{
 			
 			var count = text.split ("\n").length;
 			
@@ -717,7 +723,6 @@ class TextField extends InteractiveObject {
 			}
 			
 			return count;
-			
 		}
 		
 		return 1;

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -47,7 +47,7 @@ class TextField extends InteractiveObject {
 	public var embedFonts:Bool;
 	public var gridFitType:GridFitType;
 	public var htmlText (get, set):String;
-	public var length (default, null):Int;
+	public var length (get, null):Int;
 	public var maxChars:Int;
 	public var maxScrollH (get, null):Int;
 	public var maxScrollV (get, null):Int;
@@ -927,6 +927,10 @@ class TextField extends InteractiveObject {
 		
 	}
 	
+	@:noCompletion inline private function get_length ():Int {
+		
+		return __text == null ? 0 : __text.length;
+	}
 	
 }
 

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -792,7 +792,11 @@ class TextField extends InteractiveObject {
 		if (__canvas != null) {
 			
 			// TODO: Make this more accurate
-			return __textFormat.size * 1.185;
+			if (wordWrap && __wrappedText != null) 
+				return __wrappedText.split('\n').length * __textFormat.size * 1.185;	
+			else if (__text !=null)
+				return __text.split('\n').length * __textFormat.size * 1.185;
+			else return __textFormat.size * 1.185;
 			
 		} else if (__div != null) {
 			

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -583,15 +583,15 @@ class TextField extends InteractiveObject {
 		
 		if (autoSize != TextFieldAutoSize.NONE && wordWrap) {
 			
-			return __height * scaleX;
+			return __height * __scaleY;
 			
 		} else if (autoSize != TextFieldAutoSize.NONE) {
 			
-			return (textHeight + 4) * scaleX;
+			return (textHeight + 4) * __scaleY;
 			
 		} else {	
 			
-			return __height * scaleX;
+			return __height * __scaleY;
 			
 		}
 		

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -867,12 +867,16 @@ class TextField extends InteractiveObject {
 	
 	override public function get_width ():Float {
 		
-		if (autoSize != TextFieldAutoSize.NONE) {
+		if (autoSize != TextFieldAutoSize.NONE && wordWrap) {
+			
+			return __width * scaleX;
+			
+		} else if (autoSize != TextFieldAutoSize.NONE) {
 			
 			//return __width * scaleX;
 			return (textWidth + 4) * scaleX;
 			
-		} else {
+		} else {	
 			
 			return __width * scaleX;
 			

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -325,15 +325,20 @@ class TextField extends InteractiveObject {
 		#if js
 		
 		var lines = text.split('\n');
-		var longest:Int = 0;
-		for (i in 0...lines.length)
-		{
-			if (lines[i].length > lines[longest].length )
-				longest = i;
-		}
+		var current = 0.0;
 		
 		__context.font = __getFont (__textFormat);
-		return __context.measureText(lines[longest]).width;
+		var longest = __context.measureText(lines[0]).width;
+		
+		for (i in 1...lines.length)
+		{
+			current = __context.measureText(lines[i]).width;
+			
+			if (current > longest )
+				longest = current;
+		}
+		
+		return longest;
 		
 		#else
 		

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -571,6 +571,7 @@ class TextField extends InteractiveObject {
 	@:noCompletion private function set_defaultTextFormat (value:TextFormat):TextFormat {
 		
 		//__textFormat = __defaultTextFormat.clone ();
+		if (__textFormat != value) __dirty = true;
 		__textFormat.__merge (value);
 		return value;
 		

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -395,6 +395,8 @@ class TextField extends InteractiveObject {
 		
 		__wrappedText = '';
 		
+		#if js
+		
 		var lineStart:Int = 0;
 		var wordStart:Int = 0;
 		var lineWidth:Float;
@@ -473,6 +475,8 @@ class TextField extends InteractiveObject {
 		{
 			
 		}
+		
+		#end
 		
 		return __wrappedText;
 	}

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -289,8 +289,13 @@ class TextField extends InteractiveObject {
 		
 		if (__ranges == null) {
 			
-			__context.font = __getFont (__textFormat);
-			return [ __context.measureText (__text).width ];
+			// HTML5 measureText().width contains full length of string
+			// where \n or \r included in the result width like character and we need split text
+			// for calculation of width of longest line.
+			// http://jsfiddle.net/kpnu9q0t/
+			
+			if (wordWrap) return [__measureLongestLine(__wrappedText, __textFormat)];
+			else return [__measureLongestLine(__text, __textFormat)] ;
 			
 		} else {
 			
@@ -315,6 +320,27 @@ class TextField extends InteractiveObject {
 		
 	}
 	
+	@:noCompletion private function __measureLongestLine(text:String, format:TextFormat):Float
+	{
+		#if js
+		
+		var lines = text.split('\n');
+		var longest:Int = 0;
+		for (i in 0...lines.length)
+		{
+			if (lines[i].length > lines[longest].length )
+				longest = i;
+		}
+		
+		__context.font = __getFont (__textFormat);
+		return __context.measureText(lines[longest]).width;
+		
+		#else
+		
+		return 0;
+		
+		#end
+	}
 	
 	@:noCompletion private function __measureTextWithDOM ():Void {
 	 	

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -600,6 +600,8 @@ class TextField extends InteractiveObject {
 	
 	@:noCompletion private override function set_height (value:Float):Float {
 		
+		if (value < 0 ) return __height * __scaleY;
+		
 		if (scaleY != 1 || value != __height) {
 			
 			__setTransformDirty ();
@@ -899,6 +901,8 @@ class TextField extends InteractiveObject {
 	
 	
 	override public function set_width (value:Float):Float {
+		
+		if (value < 0) return __width * __scaleX;
 		
 		if (scaleX != 1 || __width != value) {
 			

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -92,6 +92,7 @@ class TextField extends InteractiveObject {
 		__width = 100;
 		__height = 100;
 		__text = "";
+		__wrappedText = "";
 		
 		type = TextFieldType.DYNAMIC;
 		autoSize = TextFieldAutoSize.NONE;
@@ -841,11 +842,11 @@ class TextField extends InteractiveObject {
 		if (__canvas != null) {
 			
 			// TODO: Make this more accurate
-			if (wordWrap && __wrappedText != null) 
+			if (wordWrap && __wrappedText != null && __wrappedText!="") 
 				return __wrappedText.split('\n').length * __textFormat.size * 1.185;	
-			else if (__text !=null)
+			else if (__text !=null && __text != "")
 				return __text.split('\n').length * __textFormat.size * 1.185;
-			else return __textFormat.size * 1.185;
+			else return 0;
 			
 		} else if (__div != null) {
 			

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -867,7 +867,7 @@ class TextField extends InteractiveObject {
 	
 	override public function get_width ():Float {
 		
-		if (autoSize == TextFieldAutoSize.LEFT) {
+		if (autoSize != TextFieldAutoSize.NONE) {
 			
 			//return __width * scaleX;
 			return (textWidth + 4) * scaleX;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,22 +1,22 @@
 Install
 -------
 
-    git clone https://github.com/openfl/openfl-validation
-    haxelib dev openfl-validation openfl-validation
+    git clone https://github.com/openfl/openfl
+    haxelib dev openfl _your_path_to_OpenFL_build_
     haxelib install munit
     
 Testing
 -------------
 
-First, change to the openfl-validation directory:
+First, change to the openfl tests directory:
 
-    cd openfl-validation
+    cd _your_path_to_OpenFL_build_\tests
 
 Next, you can test HTML5 and Flash using munit:
 
     haxelib run munit test
     
-Other targets can be tested using the normal OpenFL test commands:
+Other targets can be tested using the normal OpenFL test commands and munit test command for specific target:
 
     lime test windows
     lime test windows -neko
@@ -29,6 +29,8 @@ Other targets can be tested using the normal OpenFL test commands:
     lime test android
     lime test blackberry
     lime test blackberry -simulator
+	
+	haxelib run munit test -js
 
 Contributing
 -------------

--- a/tests/test/openfl/text/TextFieldTest.hx
+++ b/tests/test/openfl/text/TextFieldTest.hx
@@ -293,6 +293,9 @@ class TextFieldTest {
 		
 		Assert.areEqual (1, textField.numLines);
 		
+		textField.text = "Hello\n\rWorld";
+		
+		Assert.areEqual (3, textField.numLines);
 	}
 	
 	

--- a/tests/test/openfl/text/TextFieldTest.hx
+++ b/tests/test/openfl/text/TextFieldTest.hx
@@ -13,6 +13,8 @@ class TextFieldTest {
 		var textField = new TextField ();
 		textField.text = "Hello";
 		
+		// auto width
+		
 		Assert.areNotEqual (textField.textWidth + 4, textField.width);
 		
 		textField.autoSize = TextFieldAutoSize.LEFT;
@@ -27,6 +29,24 @@ class TextFieldTest {
 		
 		Assert.areEqual (textField.textWidth + 4, textField.width);
 		
+		// auto height
+		
+		textField = new TextField();
+		textField.text = "Hello";
+		
+		Assert.areNotEqual (textField.textHeight + 4, textField.height);
+		
+		textField.autoSize = TextFieldAutoSize.LEFT;
+		
+		Assert.areEqual (textField.textHeight + 4, textField.height);
+		
+		textField.text = "H";
+		
+		Assert.areEqual (textField.textHeight + 4, textField.height);
+		
+		textField.text = "Hello World";
+		
+		Assert.areEqual (textField.textHeight + 4, textField.height);
 	}
 	
 	


### PR DESCRIPTION
About wordWrap
https://github.com/openfl/openfl-html5/issues/17
https://github.com/openfl/openfl/issues/297
About autoSize
http://www.openfl.org/archive/community/programming-haxe/textfield-autosize-center-broken/

And now it is fixed!

Demo project is here https://github.com/T1mL3arn/TextField-fixes-demo

How it looks in Flash

![in flash](https://cloud.githubusercontent.com/assets/9349164/5085046/84495baa-6f59-11e4-9411-0ecb8e8f3c76.PNG)

How fix looks in Opera and Firefox

![opera firefox new code](https://cloud.githubusercontent.com/assets/9349164/5085103/494e8560-6f5a-11e4-808a-7662c26f87c9.PNG)

How it looks without fixes (Firefox throws error, Opera is not)

![opera firefox old code](https://cloud.githubusercontent.com/assets/9349164/5085126/7281d72a-6f5a-11e4-84d0-1807d9a151bc.PNG)

Additionally, in the process of correcting some of the tests have been updated. 
And little fix for text field length getter.

There is also a small "glitch" with changing the text for text field with autoSize=RIGHT/CENTER (I made animation in demo project). If i understood, this occurs because html5 uses requestAnimationFrame method. But text field gets right values for width and x, and after next call of requestAnimationFrame the field will be in the right place.

Also, important note: this fixes works only for simple-formated text, so html text has old behavior!