### PR TITLE
Fix FPS blocks mouse events

### DIFF
--- a/openfl/display/FPS.hx
+++ b/openfl/display/FPS.hx
@@ -25,6 +25,7 @@ class FPS extends TextField {
 		
 		currentFPS = 0;
 		selectable = false;
+		mouseEnabled = false;
 		defaultTextFormat = new TextFormat ("_sans", 12, color);
 		text = "FPS: ";
 		


### PR DESCRIPTION
The FPS display currently blocks mouse events (and in my project, the blocked area is larger than the little display!) Setting mouseEnabled=false fixes it.
