### PR TITLE
Fix dynamic graphics updates

### DIFF
--- a/openfl/_internal/renderer/dom/DOMShape.hx
+++ b/openfl/_internal/renderer/dom/DOMShape.hx
@@ -23,6 +23,10 @@ class DOMShape {
 		
 		if (shape.stage != null && shape.__worldVisible && shape.__renderable && graphics != null) {
 			
+			if (graphics.__dirty && shape.__canvas != null) {
+				shape.__worldTransformChanged = true;
+			}
+			
 			if (graphics.__dirty || shape.__worldAlphaChanged || (shape.__canvas == null && graphics.__canvas != null)) {
 				
 				//#if old


### PR DESCRIPTION
I update graphics in every screen frame, like this:

``` haxe
graphics.clear();
graphics.beginFill(color, alpha);
graphics.moveTo(x1, y1);
graphics.lineTo(x2, y2);
graphics.curveTo(x3c, y3c, x4a, y4a);
...
graphics.endFill();
```

When I compile to html5 with -Ddom, only first frame renders correctly, in any other frame object has incorrect coordinates:
![domrenderer-bug](https://cloud.githubusercontent.com/assets/85473/5437859/84e0d7e2-8484-11e4-8670-367d948c9370.gif)

With fix:
![domrenderer-correct](https://cloud.githubusercontent.com/assets/85473/5437861/8983504a-8484-11e4-91a4-21b6a9ed130f.gif)

I know that my "fix" is bit of hackish, and probably there is best way to do it.
In any case, I think either my fix should be merged, or better fix should be created.

P. S. I don't check, but probably [html5 dom rotation problem](http://community.openfl.org/t/bug-html5-dom-rotation-problem/321) is related to rendering mechanism.
