### PR TITLE
Somehow fix drawTiles when shape has transformations (scaleX, scaleY), non-zero center point or non-zero x or y coordinates.

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -633,7 +633,7 @@ class CanvasGraphics {
 								if (rect != null && rect.width > 0 && rect.height > 0 && center != null) {
 									
 									context.save ();
-									context.translate (tileData[index], tileData[index + 1]);
+									context.translate (tileData[index] - offsetX, tileData[index + 1] - offsetY);
 									
 									if (useRotation) {
 										

--- a/openfl/_internal/renderer/canvas/CanvasShape.hx
+++ b/openfl/_internal/renderer/canvas/CanvasShape.hx
@@ -19,6 +19,21 @@ class CanvasShape {
 		
 		if (graphics != null) {
 			
+			if (graphics.__drawTilesMode) {
+				var m = shape.__worldTransform.clone();
+				var p = m.deltaTransformPoint(new openfl.geom.Point(shape.__x, shape.__y));
+				m.translate(-p.x, -p.y);
+				m.invert();
+				
+				p = m.transformPoint(new openfl.geom.Point(graphics.__bounds.width, graphics.__bounds.height));
+				graphics.__bounds.width = p.x;
+				graphics.__bounds.height = p.y;
+				
+				graphics.__bounds.x -= shape.__x;
+				graphics.__bounds.y -= shape.__y;
+				graphics.__drawTilesMode = false;
+			}
+			
 			//#if old
 			CanvasGraphics.render (graphics, renderSession);
 			//#else

--- a/openfl/_internal/renderer/canvas/CanvasShape.hx
+++ b/openfl/_internal/renderer/canvas/CanvasShape.hx
@@ -21,7 +21,7 @@ class CanvasShape {
 			
 			if (graphics.__drawTilesMode) {
 				var m = shape.__worldTransform.clone();
-				var p = m.deltaTransformPoint(new openfl.geom.Point(shape.__x, shape.__y));
+				var p = m.deltaTransformPoint(new openfl.geom.Point(m.tx, m.ty));
 				m.translate(-p.x, -p.y);
 				m.invert();
 				
@@ -29,8 +29,8 @@ class CanvasShape {
 				graphics.__bounds.width = p.x;
 				graphics.__bounds.height = p.y;
 				
-				graphics.__bounds.x -= shape.__x;
-				graphics.__bounds.y -= shape.__y;
+				graphics.__bounds.x -= shape.__worldTransform.tx;
+				graphics.__bounds.y -= shape.__worldTransform.ty;
 				graphics.__drawTilesMode = false;
 			}
 			

--- a/openfl/_internal/renderer/dom/DOMShape.hx
+++ b/openfl/_internal/renderer/dom/DOMShape.hx
@@ -25,6 +25,21 @@ class DOMShape {
 			
 			if (graphics.__dirty || shape.__worldAlphaChanged || (shape.__canvas == null && graphics.__canvas != null)) {
 				
+				if (graphics.__drawTilesMode) {
+					var m = shape.__worldTransform.clone();
+					var p = m.deltaTransformPoint(new openfl.geom.Point(shape.__x, shape.__y));
+					m.translate(-p.x, -p.y);
+					m.invert();
+					
+					p = m.transformPoint(new openfl.geom.Point(graphics.__bounds.width, graphics.__bounds.height));
+					graphics.__bounds.width = p.x;
+					graphics.__bounds.height = p.y;
+					
+					graphics.__bounds.x -= shape.__x;
+					graphics.__bounds.y -= shape.__y;
+					graphics.__drawTilesMode = false;
+				}
+				
 				//#if old
 				CanvasGraphics.render (graphics, renderSession);
 				//#else

--- a/openfl/_internal/renderer/dom/DOMShape.hx
+++ b/openfl/_internal/renderer/dom/DOMShape.hx
@@ -27,7 +27,7 @@ class DOMShape {
 				
 				if (graphics.__drawTilesMode) {
 					var m = shape.__worldTransform.clone();
-					var p = m.deltaTransformPoint(new openfl.geom.Point(shape.__x, shape.__y));
+					var p = m.deltaTransformPoint(new openfl.geom.Point(m.tx, m.ty));
 					m.translate(-p.x, -p.y);
 					m.invert();
 					
@@ -35,8 +35,8 @@ class DOMShape {
 					graphics.__bounds.width = p.x;
 					graphics.__bounds.height = p.y;
 					
-					graphics.__bounds.x -= shape.__x;
-					graphics.__bounds.y -= shape.__y;
+					graphics.__bounds.x -= shape.__worldTransform.tx;
+					graphics.__bounds.y -= shape.__worldTransform.ty;
 					graphics.__drawTilesMode = false;
 				}
 				

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -61,6 +61,9 @@ class Graphics {
 	@:noCompletion private var __context:CanvasRenderingContext2D;
 	#end
 	
+	#if html5
+		@:noCompletion public var __drawTilesMode:Bool = false;
+	#end
 	
 	public function new () {
 		
@@ -540,6 +543,10 @@ class Graphics {
 		
 		__inflateBounds (0, 0);
 		__inflateBounds (Lib.current.stage.stageWidth, Lib.current.stage.stageHeight);
+		
+		#if html5
+			__drawTilesMode = true;
+		#end
 		
 		__commands.push (DrawTiles (sheet, tileData, smooth, flags, count));
 		


### PR DESCRIPTION
Without fix:
![drawtiles-bug](https://cloud.githubusercontent.com/assets/85473/5536944/686b8fea-8aaa-11e4-9907-107728cc8d56.gif)
With fix:
![drawtiles-fixed](https://cloud.githubusercontent.com/assets/85473/5536947/6eec9936-8aaa-11e4-9602-57645b8602df.gif)

I use Tilesheet::drawTiles() for my particle engine. Unfortunately, original drawTiles (for html5 target) works correctly only when no scaleX or scaleY applied to parent shape, no center point and shape has x == 0 and y == 0.

This patch is more hack than fix, but it works. Known problem: re-calculated bounds width and height is not correct sometimes, but it doesn't affect visual appearance.