### PR TITLE
Fixed -next's BitmapData fill color to work the same as flash and -legac...

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -161,7 +161,14 @@ class BitmapData implements IBitmapDrawable {
 			this.height = height;
 			rect = new Rectangle (0, 0, width, height);
 			
-			if (!transparent) {
+			if (transparent) {
+
+				if ((fillColor & 0xFF000000) == 0) {				
+					fillColor = 0;
+				}
+                
+			}
+			else {
 				
 				fillColor = (0xFF << 24) | (fillColor & 0xFFFFFF);
 				


### PR DESCRIPTION
Fixed -next's BitmapData fill color to work the same as flash and -legacy.

Added unit tests to verify the proper behavior of getPixels(), which helped me discover a couple of problems (one of which Joshua already fixed. ;)

The change to BitmapData.hx matches identical functionality in the _v2 BitmapData.hx.