### PR TITLE
Fix to byte order of getRGBAPixels.

### DIFF
--- a/openfl/_v2/display/BitmapData.hx
+++ b/openfl/_v2/display/BitmapData.hx
@@ -266,7 +266,7 @@ class BitmapData implements IBitmapDrawable {
 			
 			v = data.readInt ();
 			data.position = i << 2;
-			data.writeInt ((((v >>> 8) & 0xFF) << 0) | (((v >>> 16) & 0xFF) << 8) | (((v >>> 24) & 0xFF) << 16) | (((v >>> 0) & 0xFF) << 24));
+			data.writeInt ((((v >>> 0) & 0xFF) << 8) | (((v >>> 8) & 0xFF) << 16) | (((v >>> 16) & 0xFF) << 24) | (((v >>> 24) & 0xFF) << 0));
 			
 		}
 		


### PR DESCRIPTION
The bit rotations were swapped incorrectly resulting in the byte order being wrong.