### PR TITLE
Fixed value correction of percentLoaded never applied

### DIFF
--- a/templates/haxe/NMEPreloader.hx
+++ b/templates/haxe/NMEPreloader.hx
@@ -105,7 +105,7 @@ class NMEPreloader extends Sprite
 		
 		if (percentLoaded > 1)
 		{
-			percentLoaded == 1;
+			percentLoaded = 1;
 		}
 		
 		progress.scaleX = percentLoaded;


### PR DESCRIPTION
The code was creating an unused and anonymous boolean instead of assigning the maximum value to percentLoaded.
A small oversight in what looks like dead code.