### PR TITLE
Patch to fix Neko getTimer

### DIFF
--- a/openfl/_v2/Lib.hx
+++ b/openfl/_v2/Lib.hx
@@ -440,9 +440,11 @@ class Lib {
 	
 	
 	static public function getTimer ():Int {
-		
-		return Std.int (Timer.stamp() * 1000.0);
-		
+		#if neko
+		return Std.int ( ( Timer.stamp() % 0x7ffff ) * 1000.0);	
+		#else
+		return Std.int ( Timer.stamp() * 1000.0);	
+		#end
 	}
 	
 	


### PR DESCRIPTION
Patch to fix Neko getTimer problem of returning a constant value due to overflowing float to 32bit integer conversion.