### PR TITLE
Improve openfl.display.BitmapData#getVector performance.

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -862,11 +862,12 @@ class BitmapData implements IBitmapDrawable {
 	public function getVector (rect:Rectangle) {
 		
 		var pixels = getPixels (rect);
-		var result = new Vector<UInt> ();
+		var length = Std.int (pixels.length / 4);
+		var result = new Vector<UInt> (length, true);
 		
-		for (i in 0...Std.int (pixels.length / 4)) {
+		for (i in 0...length) {
 			
-			result.push (pixels.readUnsignedInt ());
+			result[i] = pixels.readUnsignedInt ();
 			
 		}
 		


### PR DESCRIPTION
Preallocate fixed-size Vector to avoid reallocations on Vector#push.

I've already submitted this as #328 but it seems like it was lost during some refactoring. Current implementation has a terrible performance because of array reallocations & gc runs, and this fix shaves off >50ms for 720p image.