### PR TITLE
Fix dynamic sound on Android

### DIFF
--- a/openfl/_v2/media/SoundChannel.hx
+++ b/openfl/_v2/media/SoundChannel.hx
@@ -6,6 +6,7 @@ import openfl.events.EventDispatcher;
 import openfl.events.SampleDataEvent;
 import openfl._v2.media.Sound;
 import openfl.media.SoundTransform;
+import openfl.utils.ByteArray;
 import openfl.Lib;
 
 #if (!audio_thread_disabled && !emscripten)


### PR DESCRIPTION
Call lime_sound_channel_add_data immediately after lime_sound_channel_needs_data, asking for the next samples after the call.

This fix dynamic sound on Android, but perhaps it should be best to fix on the NME side? Because this isn't behaving as expected.

Here's a proof of concept of the bug:

```haxe
	private static inline var FREQUENCY = 1000;
	
	private static var lime_sound_channel_create_dynamic = Lib.load ("lime", "lime_sound_channel_create_dynamic", 2);
	private static var lime_sound_channel_needs_data = Lib.load ("lime", "lime_sound_channel_needs_data", 1);
	private static var lime_sound_channel_add_data = Lib.load ("lime", "lime_sound_channel_add_data", 2);
	private static var lime_sound_channel_get_data_position = Lib.load ("lime", "lime_sound_channel_get_data_position", 1);
	
	private var byte:ByteArray = null;
	private var channel:Dynamic = null; 
	private var iSin:Float = 0;
	
	function test()
	{
		byte = new ByteArray();
		byte.endian = Endian.LITTLE_ENDIAN;
		
		for ( i in 0...8192 ) 
		{
			var val = Math.sin( 2 * Math.PI * (iSin++) * FREQUENCY / 44100 );
			
			byte.writeFloat( val );
			byte.writeFloat( val );
		}
		
		channel = lime_sound_channel_create_dynamic (byte, null);
		
		addEventListener( Event.ENTER_FRAME, ef );
	}
	
	private function ef( event ):Void
	{
		if ( lime_sound_channel_needs_data( channel ) )
		{
			lime_sound_channel_add_data (channel, byte);
			
			byte.position = 0;
			for ( i in 0...8192 ) 
			{
				var val = Math.sin( 2 * Math.PI * (iSin++) * FREQUENCY / 44100 );
				
				byte.writeFloat( val );
				byte.writeFloat( val );
			}
		}
	}
```

If you move the loop before lime_sound_channel_add_data then it won't works and only the first sample are played.