### PR TITLE
Added missing method to easily reset a Float32Array buffer

### DIFF
--- a/openfl/_v2/utils/Float32Array.hx
+++ b/openfl/_v2/utils/Float32Array.hx
@@ -113,6 +113,11 @@ class Float32Array extends ArrayBufferView implements ArrayAccess<Float> {
 		
 	}
 	
+	public inline function __setLength( nbFloat : Int) {
+		length = nbFloat;
+		byteLength = nbFloat << 2;
+		buffer.setLength(byteLength);
+	}
 	
 	public static function fromMatrix (matrix:Matrix3D):Float32Array {
 		


### PR DESCRIPTION
We were missing that very useful method (which used to exist?).
Sounds useful (maybe with @nocompletion)