### PR TITLE
Fixed crash when parsing AGAL.

### DIFF
--- a/openfl/_internal/aglsl/AGALTokenizer.hx
+++ b/openfl/_internal/aglsl/AGALTokenizer.hx
@@ -17,6 +17,7 @@ class AGALTokenizer {
 	public function decribeAGALByteArray (bytes:ByteArray):Description {
 		
 		var header = new Header ();
+		bytes.position = 0;
 		
 		if (bytes.readUnsignedByte () != 0xa0)  {
 			


### PR DESCRIPTION
The ByteArray's position is not guaranteed to be 0. AGLSLCompiler doesn't set it before calling describeByteArray(), or perhaps AGALMiniAssembler is to blame.

But this is the simplest way to fix it.