### PR TITLE
Conflict security change

### DIFF
--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -9,7 +9,7 @@ class ApplicationMain {
 	public static var preloader:openfl.display.Preloader;
 	
 	
-	public static function create ():Void {
+	public static function __internalCreate ():Void {
 		
 		var app = new openfl.display.Application ();
 		app.create (config);
@@ -106,7 +106,7 @@ class ApplicationMain {
 		flash.Lib.embed (null, ::WIN_WIDTH::, ::WIN_HEIGHT::, "::WIN_FLASHBACKGROUND::");
 		#end
 		#else
-		create ();
+		ApplicationMain.__internalCreate ();
 		#end
 		
 	}


### PR DESCRIPTION
Hello,

This change might sounds stupid, but it prevents an haxe compiler problem when the Main class started with a "create" package.

"Type.getClassFields (::APP_MAIN::))"   was replaced by  "Type.getClassFields (create.Main))"  and so conflicted with create method.

Thomas