### PR TITLE
Improved performance(memory usage) when drawing large shapes

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -1,6 +1,7 @@
 package openfl._internal.renderer.canvas;
 
 
+import lime.graphics.CanvasRenderContext;
 import openfl._internal.renderer.RenderSession;
 import openfl.display.BitmapData;
 import openfl.display.CapsStyle;
@@ -357,21 +358,12 @@ class CanvasGraphics {
 	
 	
 	public static function render (graphics:Graphics, renderSession:RenderSession):Void {
-		
 		#if js
-		
 		if (graphics.__dirty) {
-			
 			bounds = graphics.__bounds;
 			
-			hasFill = false;
-			hasStroke = false;
-			inPath = false;
-			positionX = 0;
-			positionY = 0;
-			
 			if (!graphics.__visible || graphics.__commands.length == 0 || bounds == null || bounds.width == 0 || bounds.height == 0) {
-				
+
 				graphics.__canvas = null;
 				graphics.__context = null;
 				
@@ -391,6 +383,43 @@ class CanvasGraphics {
 				
 				graphics.__canvas.width = Math.ceil (bounds.width);
 				graphics.__canvas.height = Math.ceil (bounds.height);
+			}
+			renderToContext(graphics, renderSession, graphics.__bounds);
+
+			graphics.__dirty = false;
+		}
+		#end
+	}
+
+	public static function renderTo(targetContext:CanvasRenderContext, graphics:Graphics, renderSession:RenderSession, targetBounds:Rectangle):Void {
+		#if js
+		context = cast targetContext;
+
+		context.save();
+		renderToContext(graphics, renderSession, targetBounds);
+		context.restore();
+		#end
+	}
+
+
+	private static function renderToContext (graphics:Graphics, renderSession:RenderSession, targetBounds:Rectangle):Void {
+		
+		#if js
+		
+		if (graphics != null) {
+			
+			bounds = targetBounds;
+			
+			hasFill = false;
+			hasStroke = false;
+			inPath = false;
+			positionX = 0;
+			positionY = 0;
+
+			if (!graphics.__visible || graphics.__commands.length == 0 || bounds == null || bounds.width == 0 || bounds.height == 0) {
+				
+				
+			} else {
 				
 				var offsetX = bounds.x;
 				var offsetY = bounds.y;
@@ -867,7 +896,6 @@ class CanvasGraphics {
 				
 			}
 			
-			graphics.__dirty = false;
 			closePath (false);
 			
 		}

--- a/openfl/_internal/renderer/canvas/CanvasShape.hx
+++ b/openfl/_internal/renderer/canvas/CanvasShape.hx
@@ -29,6 +29,9 @@ class CanvasShape {
 		#end
 	}
 
+	#if js
+	private static var __renderDirectRect:Rectangle = new Rectangle();
+	#end
 	private static inline function renderDirect (shape:DisplayObject, renderSession:RenderSession):Void {
 		#if js
 		var graphics = shape.__graphics;
@@ -45,7 +48,8 @@ class CanvasShape {
 			context.transform(wt.a, wt.b, wt.c, wt.d,
 				renderSession.roundPixels ? Std.int(wt.tx) : wt.tx,
 				renderSession.roundPixels ? Std.int(wt.ty) : wt.ty);
-			CanvasGraphics.renderTo(context, graphics, renderSession, new Rectangle(0, 0, canvas.width, canvas.height));
+			__renderDirectRect.setTo(0, 0, canvas.width, canvas.height);
+			CanvasGraphics.renderTo(context, graphics, renderSession, __renderDirectRect);
 			context.restore();
 		}
 		#end


### PR DESCRIPTION
Test code:

```
package;
import openfl.display.Sprite;
class Main extends Sprite {
    public function new () {
        super ();
        var R = 20000; // (2*20000)^2 = 1.6GB!
        graphics.beginFill(0x0000ff);
        graphics.drawCircle(stage.stageWidth/2, stage.stageHeight/2+R, R);
        graphics.endFill();
    }
}
```
