### PR TITLE
Event capture added for Event.ADDED_TO_STAGE JS target

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -768,6 +768,16 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	
 	public override function dispatchEvent (event:Event):Bool {
 		
+		if (event.type == Event.ADDED_TO_STAGE){
+			if (parent != null && parent != this) {
+				parent.__targetDispatcher = this;
+				parent.dispatchEvent(event);
+			}
+		}
+		else {
+			event.eventPhase = EventPhase.AT_TARGET;
+		}
+		
 		var result = super.dispatchEvent (event);
 		
 		if (event.__isCancelled) {

--- a/openfl/events/Event.hx
+++ b/openfl/events/Event.hx
@@ -359,7 +359,7 @@ class Event {
 		this.type = type;
 		this.bubbles = bubbles;
 		this.cancelable = cancelable;
-		eventPhase = EventPhase.AT_TARGET;
+		eventPhase = EventPhase.CAPTURING_PHASE;
 		
 	}
 	

--- a/openfl/events/EventDispatcher.hx
+++ b/openfl/events/EventDispatcher.hx
@@ -252,6 +252,8 @@ class EventDispatcher implements IEventDispatcher {
 		
 		event.currentTarget = this;
 		
+		if (event.target == event.currentTarget) event.eventPhase = EventPhase.AT_TARGET;
+		
 		var capture = (event.eventPhase == EventPhase.CAPTURING_PHASE);
 		var index = 0;
 		var listener;


### PR DESCRIPTION
Currently OpenFL doesn't support event capture for the html5 target. The changes in this pull request resolves this issue for Event.ADDED_TO_STAGE. This is a critical fix for the Robotleg Framework https://github.com/robotlegs/openfl-robotlegs-framework. Without this change the framework doesn't work while publishing to html5.