### PR TITLE
Add fromFile to media.Sound

### DIFF
--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -265,6 +265,13 @@ class Sound extends EventDispatcher {
 	}
 	
 	
+	public static function fromFile (path:String):Sound {
+		
+		return fromAudioBuffer (AudioBuffer.fromFile (path));
+		
+	}
+	
+	
 	/**
 	 * Initiates loading of an external MP3 file from the specified URL. If you
 	 * provide a valid URLRequest object to the Sound constructor, the


### PR DESCRIPTION
Adding this function prevent the user from searching how to load a Sound from a file and/or having to learn about lime's AudioBuffer.