### PR TITLE
Updated Graphics.hx for consistent drawing on js

### DIFF
--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -70,6 +70,9 @@ class Graphics {
 		__positionX = 0;
 		__positionY = 0;
 		
+		#if js
+		moveTo( 0, 0);
+		#end
 	}
 	
 	
@@ -234,6 +237,9 @@ class Graphics {
 		
 		__visible = false;
 		
+		#if js
+		moveTo( 0, 0);
+		#end
 	}
 	
 	


### PR DESCRIPTION
The implementation of Canvas in js does not include an implicit moveTo( 0, 0).
Prior to this change a call to lineTo() on a new() or clear()ed graphics context wouldn't draw anything on an html target. It had the equivalent effect of a moveTo. The docs (http://www.openfl.org/documentation/api/openfl/display/Graphics.html) state: " If you call lineTo() before any calls to the moveTo() method, the default position for the current drawing is(0, 0)."
This change brings consistency between html5 and the other targets.