### PR TITLE
Realised bitmap.clone() via copyPixels() #533

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -244,7 +244,15 @@ class BitmapData implements IBitmapDrawable {
 			
 		} else {
 			
+			#if js
+			
+			var bmd = new BitmapData (width, height, transparent);
+			bmd.copyPixels(this, new Rectangle(0, 0, width, height), new Point(0, 0));
+			return bmd;
+			
+			#else
 			return BitmapData.fromImage (__image.clone (), transparent);
+			#end
 			
 		}
 		


### PR DESCRIPTION
Related to this #533 . Fix for html5.