### PR TITLE
Android needs precision highp.

### DIFF
--- a/openfl/_internal/aglsl/AGLSLParser.hx
+++ b/openfl/_internal/aglsl/AGLSLParser.hx
@@ -20,7 +20,7 @@ class AGLSLParser {
 		var body:String = "";
 		var i:Int = 0;
 		
-		#if html5
+		#if (html5 || android)
 		header += "precision highp float;\n";
 		#end
 		

--- a/openfl/_internal/aglsl/AGLSLParser.hx
+++ b/openfl/_internal/aglsl/AGLSLParser.hx
@@ -20,8 +20,14 @@ class AGLSLParser {
 		var body:String = "";
 		var i:Int = 0;
 		
-		#if (html5 || android)
+		#if html5
 		header += "precision highp float;\n";
+		#elseif (android || ios)
+		if (desc.header.type == "vertex") {
+			
+			header += "precision highp float;\n";
+			
+		}
 		#end
 		
 		var tag = desc.header.type.charAt (0); //TODO


### PR DESCRIPTION
At least in my tests. I also tried iOS but didn't see any issues there. Maybe it's something to do with Android's implementation of OpenGL?

The issue I'm seeing is, when I try to render objects far away from the origin (when the camera is also far from the origin), their position becomes unreliable, causing objects to appear to vibrate. Presumably, these large numbers are getting rounded thanks to the low precision.

An alternative would be to make a static String variable ("AGLSLParser.glslHeader" or something), and add that to the header. Then if you find you need a specific precision, you can set it yourself.