### PR TITLE
Fix KeyboardEvent.KEY_UP

### DIFF
--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -1264,7 +1264,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 			var keyCode = __convertKeyCode (keyCode);
 			var charCode = keyCode;
 			
-			var event = new KeyboardEvent (KeyboardEvent.KEY_DOWN, true, false, charCode, keyCode, null, modifier.ctrlKey, modifier.altKey, modifier.shiftKey, modifier.metaKey);
+			var event = new KeyboardEvent (type, true, false, charCode, keyCode, null, modifier.ctrlKey, modifier.altKey, modifier.shiftKey, modifier.metaKey);
 			
 			stack.reverse ();
 			__fireEvent (event, stack);


### PR DESCRIPTION
KEY_UP event does not occur
KeyboardEvent.KEY_DOWN occurs instead of KeyboardEvent.KEY_UP