### PR TITLE
Fix ApplicationMain on nodejs

### DIFF
--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -63,7 +63,7 @@ class ApplicationMain {
 		
 		var result = app.exec ();
 		
-		#if (sys && !emscripten)
+		#if (sys && !nodejs && !emscripten)
 		Sys.exit (result);
 		#end
 		


### PR DESCRIPTION
Calling Sys.exit() will make node exit soon after its launch.