### PR TITLE
Guard html5 section against double include.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -79,7 +79,7 @@
 			
 		</section>
 		
-		<section if="html5">
+		<section if="html5" unless="openfl-html5">
 			
 			<set name="openfl-html5" />
 			<haxedef name="openfl-html5" />


### PR DESCRIPTION
This prevents double-include of soundjs, when project depends on openfl,
and also it depends on third-party library, which also depends on openfl.