### PR TITLE
Fix loop count difference for flash and html5

### DIFF
--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -433,7 +433,12 @@ class Sound extends EventDispatcher {
 		var source = new AudioSource (__buffer);
 		return new SoundChannel (source);
 		#else
-		var instance = SoundJS.play (__soundID, SoundJS.INTERRUPT_ANY, 0, Std.int (startTime), loops, sndTransform.volume, sndTransform.pan);
+		var instance = 
+		if (loops > 1)
+			SoundJS.play (__soundID, SoundJS.INTERRUPT_ANY, 0, Std.int (startTime), loops-1, sndTransform.volume, sndTransform.pan);
+		else
+			SoundJS.play (__soundID, SoundJS.INTERRUPT_ANY, 0, Std.int (startTime), 0, sndTransform.volume, sndTransform.pan);
+		
 		return new SoundChannel (instance);
 		#end
 		


### PR DESCRIPTION
Example ( I can't test it on any other platform and don't know how it works on them)
```Haxe
var postfix = #if flash '.mp3' #else '.ogg' #end;
var sound = Assets.getSound('assets/sound' + postfix);
// will be played 1 times on flash and 2 times on html5
sound.play(0, 1, new SoundTransform(0.6));
```
The SoundJs uses loops param like a count of repeats, not the count of playbacks. So if we passed loop = 2 then sound will be played 3 times (2 repeats it is one playback and another one repeat and another one repeat).