### PR TITLE
BitmapData should pass the alpha and blendMode too.

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1702,7 +1702,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		if (__worldTransform == null) __worldTransform = new Matrix();
 		if (__worldColorTransform == null) __worldColorTransform = new ColorTransform();
-		renderSession.spriteBatch.renderBitmapData(this, true, __worldTransform, __worldColorTransform);
+		renderSession.spriteBatch.renderBitmapData(this, true, __worldTransform, __worldColorTransform, __worldColorTransform.alphaMultiplier, blendMode);
 		
 	}
 	


### PR DESCRIPTION
When rendering into another bitmap via draw()
Fixes #221 (webGL)