### PR TITLE
Recursive DisplayObjectContainer.contains(), closes #600

### DIFF
--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -287,21 +287,13 @@ class DisplayObjectContainer extends InteractiveObject {
 	 */
 	public function contains (child:DisplayObject):Bool {
 		
-		#if (haxe_ver > 3.100)
-		
-		return __children.indexOf (child) > -1;
-		
-		#else
-		
-		for (i in __children) {
+		while (child != this && child != null) {
 			
-			if (i == child) return true;
+			child = child.parent;
 			
 		}
 		
-		return false;
-		
-		#end
+		return child == this;
 		
 	}
 	


### PR DESCRIPTION
#600 Original flash method is recursive.

Quickly tested in a project, `dcB` is not added and `connectB` is:
`Log.trace([contains(dcB), contains(connectB), contains(connectB.tf), contains(null), contains(this)]);`
`[false, true,true,false,true]`