### PR TITLE
Font embedding path fix.

### DIFF
--- a/openfl/Assets.hx
+++ b/openfl/Assets.hx
@@ -1325,7 +1325,10 @@ class Assets {
 						
 						case EConst(CString(filePath)):
 							
-							path = Context.resolvePath (filePath);
+							path = filePath;
+							if (!sys.FileSystem.exists(filePath)) {
+								path = Context.resolvePath (filePath);
+							}
 							
 						default:
 						

--- a/openfl/_legacy/Assets.hx
+++ b/openfl/_legacy/Assets.hx
@@ -1870,7 +1870,11 @@ class Assets {
 						
 						case EConst(CString(filePath)):
 							
-							path = Context.resolvePath (filePath);
+							path = filePath;
+							if (!sys.FileSystem.exists(filePath)) {
+								path = Context.resolvePath (filePath);
+							}
+
 							
 						default:
 						


### PR DESCRIPTION
Fixes a "file not found" error when embedding fonts. This fix was previously applied to embedData (https://github.com/openfl/openfl/pull/261, issue https://github.com/openfl/lime-tools/issues/87) but not embedFont.

Should solve https://github.com/HaxePunk/HaxePunk/issues/360