### PR TITLE
Fixing Texture uploads from BitmapData, and a TextFormat type issue.

### DIFF
--- a/openfl/_legacy/text/TextFormat.hx
+++ b/openfl/_legacy/text/TextFormat.hx
@@ -13,7 +13,7 @@ package openfl._legacy.text; #if openfl_legacy
 	public var font:String;
 	public var indent:Null<Float>;
 	public var italic:Null<Bool>;
-	public var kerning:Null<Float>;
+	public var kerning:Null<Bool>;
 	public var leading:Null<Float>;
 	public var leftMargin:Null<Float>;
 	public var letterSpacing:Null<Float>;

--- a/openfl/display3D/textures/Texture.hx
+++ b/openfl/display3D/textures/Texture.hx
@@ -51,9 +51,9 @@ class Texture extends TextureBase {
 	
 	
 	public function uploadFromBitmapData (bitmapData:BitmapData, miplevel:Int = 0):Void {
-		
+
 		// TODO: Support upload from UInt8Array directly
-		
+
 		#if openfl_legacy
 		var p = BitmapData.getRGBAPixels (bitmapData);
 		#elseif js
@@ -61,50 +61,81 @@ class Texture extends TextureBase {
 		#else
 		var p = @:privateAccess (bitmapData.__image).data.buffer;
 		#end
-		
+
 		width = bitmapData.width;
 		height = bitmapData.height;
-		uploadFromByteArray (p, 0, miplevel);
-		
-	}
-	
-	
-	public function uploadFromByteArray (data:ByteArray, byteArrayOffset:Int, miplevel:Int = 0):Void {
-		
-		GL.bindTexture (GL.TEXTURE_2D, glTexture);
-		 
-		if (optimizeForRenderToTexture) {
-			
-			GL.pixelStorei (GL.UNPACK_FLIP_Y_WEBGL, 1); 
-			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
-			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST); 			
-			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
-			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE); 
-			
+
+		var source = new UInt8Array (p.length);
+		var endian = p.endian;
+		p.endian = "littleEndian";
+		p.position = 0;
+
+		var i:Int = 0;
+
+		while (p.position < p.length) {
+
+			var c:Int = p.readUnsignedInt ();
+			var a:Int = ((c >>> 24) & 0xFF) + 1;
+
+			var r = (((((c       ) & 0xFF) + 1) * a) >>> 8) - 1;
+			var g = (((((c >>>  8) & 0xFF) + 1) * a) >>> 8) - 1;
+			var b = (((((c >>> 16) & 0xFF) + 1) * a) >>> 8) - 1;
+
+			source[i++] = (r == -1) ? 0 : r;
+			source[i++] = (g == -1) ? 0 : g;
+			source[i++] = (b == -1) ? 0 : b;
+			source[i++] = a - 1;
+
 		}
-		
+		p.endian = endian;
+
+		uploadFromUInt8Array(source, miplevel);
+
+	}
+
+
+	public function uploadFromByteArray (data:ByteArray, byteArrayOffset:Int, miplevel:Int = 0):Void {
+
 		#if js
 		var source = new UInt8Array (data.length);
 		data.position = byteArrayOffset;
-		
+
 		var i:Int = 0;
-		
+
 		while (data.position < data.length) {
-			
+
 			source[i] = data.readUnsignedByte ();
 			i++;
-			
+
 		}
 		#else
 		var source = new UInt8Array (data);
 		#end
-		
-		GL.texImage2D (GL.TEXTURE_2D, miplevel, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, source);
-		GL.bindTexture (GL.TEXTURE_2D, null);
-		
+
+		uploadFromUInt8Array(source, miplevel);
+
 	}
-	
-	
+
+	public function uploadFromUInt8Array (data:UInt8Array, miplevel:Int = 0):Void {
+
+		GL.bindTexture (GL.TEXTURE_2D, glTexture);
+
+		if (optimizeForRenderToTexture) {
+
+			GL.pixelStorei (GL.UNPACK_FLIP_Y_WEBGL, 1);
+			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+
+		}
+
+		GL.texImage2D (GL.TEXTURE_2D, miplevel, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, data);
+		GL.bindTexture (GL.TEXTURE_2D, null);
+
+	}
+
+
 }
 
 


### PR DESCRIPTION
This fixes

https://github.com/away3d/away3d-core-openfl/issues/40
https://github.com/openfl/lime/issues/409

, and many problems that I've been having with blending when rendering to textures. BitmapData is assumed to be premultiplied with alpha, and because OpenFL doesn't, this makes sure that that happens.

One improvement would be to check the lime Image for it's premultipled property, but the Image is private, so maybe that should be exposed on BitmapData, or @:access-ed.

The kerning property is correct in OpenFL 3.x, but legacy/lime-hybrid gives me type errors, so I fixed that as well.

This patch fixes a ton for me, so please merge it.