### PR TITLE
BitmapData.hx getColorBoundsRect: __toFlashRectangle returns null on non...

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -795,9 +795,8 @@ class BitmapData implements IBitmapDrawable {
 	public function getColorBoundsRect (mask:Int, color:Int, findColor:Bool = true):Rectangle {
 		
 		if (!__isValid) return new Rectangle (0, 0, width, height);
-		
 		var rect = __image.getColorBoundsRect (mask, color, findColor);
-		return rect.__toFlashRectangle ();
+		return new Rectangle(rect.x, rect.y, rect.width, rect.height);
 		
 	}
 	


### PR DESCRIPTION
...-flash targets, better to directly return an openfl.geom.Rectangle right in the function (that's a flash.geom.Rectangle on flash anyway, functionally equivalent to __toFlashRectangle)