### PR TITLE
Fix blurry bitmaps

### DIFF
--- a/openfl/_internal/renderer/AbstractRenderer.hx
+++ b/openfl/_internal/renderer/AbstractRenderer.hx
@@ -36,6 +36,13 @@ class AbstractRenderer {
 		
 	}
 	
+
+	public function setViewport (x:Int, y:Int, width:Int, height:Int):Void {
+		
+		
+		
+	}
+	
 	
 	public function resize (width:Int, height:Int):Void {
 		

--- a/openfl/_internal/renderer/RenderSession.hx
+++ b/openfl/_internal/renderer/RenderSession.hx
@@ -5,7 +5,6 @@ import lime.graphics.CanvasRenderContext;
 import lime.graphics.DOMRenderContext;
 import lime.graphics.GLRenderContext;
 import lime.graphics.opengl.GLFramebuffer;
-import lime.math.Matrix4;
 import openfl._internal.renderer.opengl.utils.BlendModeManager;
 import openfl._internal.renderer.opengl.utils.FilterManager;
 import openfl._internal.renderer.opengl.utils.MaskManager;
@@ -13,6 +12,7 @@ import openfl._internal.renderer.opengl.utils.ShaderManager;
 import openfl._internal.renderer.opengl.utils.SpriteBatch;
 import openfl._internal.renderer.opengl.utils.StencilManager;
 import openfl.display.BlendMode;
+import openfl.geom.Matrix;
 import openfl.geom.Point;
 
 
@@ -22,23 +22,16 @@ class RenderSession {
 	public var context:CanvasRenderContext;
 	public var element:DOMRenderContext;
 	public var gl:GLRenderContext;
-	//public var glProgram:ShaderProgram;
-	//public var mask:Bool;
-	//public var maskManager:MaskManager;
-	public var projectionMatrix:Matrix4;
 	public var renderer:AbstractRenderer;
-	//public var scaleMode:ScaleMode;
 	public var roundPixels:Bool;
 	public var transformProperty:String;
 	public var transformOriginProperty:String;
 	public var vendorPrefix:String;
 	public var z:Int;
-	//public var smoothProperty:Null<Bool> = null;
+	public var projectionMatrix:Matrix;
 	
 	public var drawCount:Int;
 	public var currentBlendMode:BlendMode;
-	public var projection:Point;
-	public var offset:Point;
 	
 	public var shaderManager:ShaderManager;
 	public var maskManager:#if neko MaskManager #else Dynamic #end;

--- a/openfl/_internal/renderer/opengl/GLBitmap.hx
+++ b/openfl/_internal/renderer/opengl/GLBitmap.hx
@@ -15,7 +15,7 @@ class GLBitmap {
 		
 		if (!bitmap.__renderable || bitmap.__worldAlpha <= 0 || bitmap.bitmapData == null || !bitmap.bitmapData.__isValid) return;
 		
-		renderSession.spriteBatch.renderBitmapData(bitmap.bitmapData, bitmap.smoothing, bitmap.__worldTransform, bitmap.__worldColorTransform, bitmap.__worldAlpha, bitmap.blendMode);
+		renderSession.spriteBatch.renderBitmapData(bitmap.bitmapData, bitmap.smoothing, bitmap.__worldTransform, bitmap.__worldColorTransform, bitmap.__worldAlpha, bitmap.blendMode, bitmap.pixelSnapping);
 	}
 	
 	

--- a/openfl/_internal/renderer/opengl/shaders2/DefaultShader.hx
+++ b/openfl/_internal/renderer/opengl/shaders2/DefaultShader.hx
@@ -13,16 +13,13 @@ class DefaultShader extends Shader {
 			'attribute vec2 ${Attrib.TexCoord};',
 			'attribute vec4 ${Attrib.Color};',
 			
-			'uniform vec2 ${Uniform.ProjectionVector};',
-			'uniform vec2 ${Uniform.OffsetVector};',
+			'uniform mat3 ${Uniform.ProjectionMatrix};',
 			
 			'varying vec2 vTexCoord;',
 			'varying vec4 vColor;',
 			
-			'const vec2 center = vec2(-1.0, 1.0);',
-			
 			'void main(void) {',
-			'   gl_Position = vec4( ((${Attrib.Position} + ${Uniform.OffsetVector}) / ${Uniform.ProjectionVector}) + center , 0.0, 1.0);',
+			'   gl_Position = vec4((${Uniform.ProjectionMatrix} * vec3(${Attrib.Position}, 1.0)).xy, 0.0, 1.0);',
 			'   vTexCoord = ${Attrib.TexCoord};',
 			'   vColor = ${Attrib.Color};',
 			'}'
@@ -66,8 +63,7 @@ class DefaultShader extends Shader {
 		getAttribLocation(Attrib.Position);
 		getAttribLocation(Attrib.TexCoord);
 		getAttribLocation(Attrib.Color);
-		getUniformLocation(Uniform.ProjectionVector);
-		getUniformLocation(Uniform.OffsetVector);
+		getUniformLocation(Uniform.ProjectionMatrix);
 		getUniformLocation(Uniform.Sampler);
 		getUniformLocation(Uniform.ColorMultiplier);
 		getUniformLocation(Uniform.ColorOffset);
@@ -84,8 +80,7 @@ class DefaultShader extends Shader {
 
 @:enum private abstract Uniform(String) from String to String {
 	var Sampler = "uSampler0";
-	var ProjectionVector = "uProjectionVector";
-	var OffsetVector = "uOffsetVector";
+	var ProjectionMatrix = "uProjectionMatrix";
 	var Color = "uColor";
 	var Alpha = "uAlpha";
 	var ColorMultiplier = "uColorMultiplier";

--- a/openfl/_internal/renderer/opengl/shaders2/DrawTrianglesShader.hx
+++ b/openfl/_internal/renderer/opengl/shaders2/DrawTrianglesShader.hx
@@ -14,16 +14,13 @@ class DrawTrianglesShader extends Shader {
 			'attribute vec2 ${Attrib.Position};',
 			'attribute vec2 ${Attrib.TexCoord};',
 			'attribute vec4 ${Attrib.Color};',
-			'uniform vec2 ${Uniform.ProjectionVector};',
-			'uniform vec2 ${Uniform.OffsetVector};',
+			'uniform mat3 ${Uniform.ProjectionMatrix};',
 			
 			'varying vec2 vTexCoord;',
 			'varying vec4 vColor;',
-			
-			'const vec2 center = vec2(-1.0, 1.0);',
 		
 			'void main(void) {',
-			'   gl_Position = vec4( ((${Attrib.Position} + ${Uniform.OffsetVector}) / ${Uniform.ProjectionVector}) + center , 0.0, 1.0);',
+			'   gl_Position = vec4((${Uniform.ProjectionMatrix} * vec3(${Attrib.Position}, 1.0)).xy, 0.0, 1.0);',
 			'   vTexCoord = ${Attrib.TexCoord};',
 			// the passed color is ARGB format
 			'   vColor = ${Attrib.Color}.bgra;',
@@ -73,14 +70,12 @@ class DrawTrianglesShader extends Shader {
 	override function init() {
 		super.init();
 		
-		// TODO Modify graphicsrenderer to draw projection -y
 		getAttribLocation(Attrib.Position);
 		getAttribLocation(Attrib.TexCoord);
 		getAttribLocation(Attrib.Color);
 		
 		getUniformLocation(Uniform.Sampler);
-		getUniformLocation(Uniform.ProjectionVector);
-		getUniformLocation(Uniform.OffsetVector);
+		getUniformLocation(Uniform.ProjectionMatrix);
 		getUniformLocation(Uniform.Color);
 		getUniformLocation(Uniform.Alpha);
 		getUniformLocation(Uniform.UseTexture);
@@ -100,8 +95,7 @@ class DrawTrianglesShader extends Shader {
 @:enum private abstract Uniform(String) from String to String {
 	var UseTexture = "uUseTexture";
 	var Sampler = DefUniform.Sampler;
-	var ProjectionVector = DefUniform.ProjectionVector;
-	var OffsetVector = DefUniform.OffsetVector;
+	var ProjectionMatrix = DefUniform.ProjectionMatrix;
 	var Color = DefUniform.Color;
 	var Alpha = DefUniform.Alpha;
 	var ColorMultiplier = DefUniform.ColorMultiplier;

--- a/openfl/_internal/renderer/opengl/shaders2/FillShader.hx
+++ b/openfl/_internal/renderer/opengl/shaders2/FillShader.hx
@@ -12,8 +12,7 @@ class FillShader extends Shader {
 		vertexSrc = [
 			'attribute vec2 ${Attrib.Position};',
 			'uniform mat3 ${Uniform.TranslationMatrix};',
-			'uniform vec2 ${Uniform.ProjectionVector};',
-			'uniform vec2 ${Uniform.OffsetVector};',
+			'uniform mat3 ${Uniform.ProjectionMatrix};',
 			
 			'uniform vec4 ${Uniform.Color};',
 			'uniform float ${Uniform.Alpha};',
@@ -32,9 +31,7 @@ class FillShader extends Shader {
 			'}',			
 			
 			'void main(void) {',
-			'   vec3 v = ${Uniform.TranslationMatrix} * vec3(${Attrib.Position}, 1.0);',
-			'   v -= ${Uniform.OffsetVector}.xyx;',
-			'   gl_Position = vec4( v.x / ${Uniform.ProjectionVector}.x -1.0, v.y / - ${Uniform.ProjectionVector}.y + 1.0 , 0.0, 1.0);',
+			'   gl_Position = vec4((${Uniform.ProjectionMatrix} * ${Uniform.TranslationMatrix} * vec3(${Attrib.Position}, 1.0)).xy, 0.0, 1.0);',
 			'   vColor = colorTransform(${Uniform.Color}, ${Uniform.Alpha}, ${Uniform.ColorMultiplier}, ${Uniform.ColorOffset});',
 			'}'
 
@@ -60,8 +57,7 @@ class FillShader extends Shader {
 		
 		getAttribLocation(Attrib.Position);
 		getUniformLocation(Uniform.TranslationMatrix);
-		getUniformLocation(Uniform.ProjectionVector);
-		getUniformLocation(Uniform.OffsetVector);
+		getUniformLocation(Uniform.ProjectionMatrix);
 		getUniformLocation(Uniform.Color);
 		getUniformLocation(Uniform.ColorMultiplier);
 		getUniformLocation(Uniform.ColorOffset);
@@ -75,8 +71,7 @@ class FillShader extends Shader {
 
 @:enum private abstract Uniform(String) from String to String {
 	var TranslationMatrix = "uTranslationMatrix";
-	var ProjectionVector = DefUniform.ProjectionVector;
-	var OffsetVector = DefUniform.OffsetVector;
+	var ProjectionMatrix = DefUniform.ProjectionMatrix;
 	var Color = DefUniform.Color;
 	var Alpha = DefUniform.Alpha;
 	var ColorMultiplier = DefUniform.ColorMultiplier;

--- a/openfl/_internal/renderer/opengl/shaders2/PatternFillShader.hx
+++ b/openfl/_internal/renderer/opengl/shaders2/PatternFillShader.hx
@@ -12,16 +12,13 @@ class PatternFillShader extends Shader {
 		vertexSrc = [
 			'attribute vec2 ${Attrib.Position};',
 			'uniform mat3 ${Uniform.TranslationMatrix};',
-			'uniform vec2 ${Uniform.ProjectionVector};',
-			'uniform vec2 ${Uniform.OffsetVector};',
+			'uniform mat3 ${Uniform.ProjectionMatrix};',
 			'uniform mat3 ${Uniform.PatternMatrix};',
 			
 			'varying vec2 vPosition;',
 			
 			'void main(void) {',
-			'   vec3 v = ${Uniform.TranslationMatrix} * vec3(${Attrib.Position} , 1.0);',
-			'   v -= ${Uniform.OffsetVector}.xyx;',
-			'   gl_Position = vec4( v.x / ${Uniform.ProjectionVector}.x -1.0, v.y / - ${Uniform.ProjectionVector}.y + 1.0 , 0.0, 1.0);',
+			'   gl_Position = vec4((${Uniform.ProjectionMatrix} * ${Uniform.TranslationMatrix} * vec3(${Attrib.Position}, 1.0)).xy, 0.0, 1.0);',
 			'   vPosition = (${Uniform.PatternMatrix} * vec3(${Attrib.Position}, 1)).xy;',
 			'}'
 
@@ -70,8 +67,7 @@ class PatternFillShader extends Shader {
 		
 		getUniformLocation(Uniform.TranslationMatrix);
 		getUniformLocation(Uniform.PatternMatrix);
-		getUniformLocation(Uniform.ProjectionVector);
-		getUniformLocation(Uniform.OffsetVector);
+		getUniformLocation(Uniform.ProjectionMatrix);
 		getUniformLocation(Uniform.Sampler);
 		getUniformLocation(Uniform.PatternTL);
 		getUniformLocation(Uniform.PatternBR);
@@ -92,8 +88,7 @@ class PatternFillShader extends Shader {
 	var PatternTL = "uPatternTL";
 	var PatternBR = "uPatternBR";
 	var Sampler = DefUniform.Sampler;
-	var ProjectionVector = DefUniform.ProjectionVector;
-	var OffsetVector = DefUniform.OffsetVector;
+	var ProjectionMatrix = DefUniform.ProjectionMatrix;
 	var Color = DefUniform.Color;
 	var Alpha = DefUniform.Alpha;
 	var ColorMultiplier = DefUniform.ColorMultiplier;

--- a/openfl/_internal/renderer/opengl/shaders2/PrimitiveShader.hx
+++ b/openfl/_internal/renderer/opengl/shaders2/PrimitiveShader.hx
@@ -14,8 +14,7 @@ class PrimitiveShader extends Shader {
 			'attribute vec4 ${Attrib.Color};',
 			
 			'uniform mat3 ${Uniform.TranslationMatrix};',
-			'uniform vec2 ${Uniform.ProjectionVector};',
-			'uniform vec2 ${Uniform.OffsetVector};',
+			'uniform mat3 ${Uniform.ProjectionMatrix};',
 			'uniform vec4 ${Uniform.ColorMultiplier};',
 			'uniform vec4 ${Uniform.ColorOffset};',
 			'uniform float ${Uniform.Alpha};',
@@ -32,9 +31,7 @@ class PrimitiveShader extends Shader {
 			'}',	
 			
 			'void main(void) {',
-			'   vec3 v = ${Uniform.TranslationMatrix} * vec3(${Attrib.Position} , 1.0);',
-			'   v -= ${Uniform.OffsetVector}.xyx;',
-			'   gl_Position = vec4( v.x / ${Uniform.ProjectionVector}.x -1.0, v.y / -${Uniform.ProjectionVector}.y + 1.0 , 0.0, 1.0);',
+			'   gl_Position = vec4((${Uniform.ProjectionMatrix} * ${Uniform.TranslationMatrix} * vec3(${Attrib.Position}, 1.0)).xy, 0.0, 1.0);',
 			'   vColor = colorTransform(${Attrib.Color}, ${Uniform.Alpha}, ${Uniform.ColorMultiplier}, ${Uniform.ColorOffset});',
 			'}'
 		];
@@ -61,8 +58,7 @@ class PrimitiveShader extends Shader {
 		getAttribLocation(Attrib.Position);
 		getAttribLocation(Attrib.Color);
 		getUniformLocation(Uniform.TranslationMatrix);
-		getUniformLocation(Uniform.ProjectionVector);
-		getUniformLocation(Uniform.OffsetVector);
+		getUniformLocation(Uniform.ProjectionMatrix);
 		getUniformLocation(Uniform.Alpha);
 		getUniformLocation(Uniform.ColorMultiplier);
 		getUniformLocation(Uniform.ColorOffset);
@@ -77,8 +73,7 @@ class PrimitiveShader extends Shader {
 
 @:enum private abstract Uniform(String) from String to String {
 	var TranslationMatrix = "uTranslationMatrix";
-	var ProjectionVector = DefUniform.ProjectionVector;
-	var OffsetVector = DefUniform.OffsetVector;
+	var ProjectionMatrix = DefUniform.ProjectionMatrix;
 	var Alpha = DefUniform.Alpha;
 	var ColorMultiplier = DefUniform.ColorMultiplier;
 	var ColorOffset = DefUniform.ColorOffset;

--- a/openfl/_internal/renderer/opengl/utils/FilterManager.hx
+++ b/openfl/_internal/renderer/opengl/utils/FilterManager.hx
@@ -104,10 +104,9 @@ class FilterManager {
 		this.renderSession = renderSession;
 		defaultShader = renderSession.shaderManager.defaultShader;
 		
-		var projection = renderSession.projection;
-		
-		width = Std.int (projection.x * 2);
-		height = Std.int (-projection.y * 2);
+		// TODO
+		width = 0;
+		height = 0;
 		this.buffer = buffer;
 		
 	}

--- a/openfl/_internal/renderer/opengl/utils/GraphicsRenderer.hx
+++ b/openfl/_internal/renderer/opengl/utils/GraphicsRenderer.hx
@@ -859,14 +859,13 @@ class GraphicsRenderer {
 		}
 		*/
 		
-		renderGraphics(object, renderSession, renderSession.projection, false);
+		renderGraphics(object, renderSession, false);
 
 	}
 	
-	public static function renderGraphics (object:DisplayObject, renderSession:RenderSession, projection:Point, ?localCoords:Bool = false):Void {
+	public static function renderGraphics (object:DisplayObject, renderSession:RenderSession, ?localCoords:Bool = false):Void {
 		var graphics = object.__graphics;
 		var gl = renderSession.gl;
-		var offset = renderSession.offset;
 		
 		var glStack = graphics.__glStack[GLRenderer.glContextId];
 		var bucket:GLBucket;
@@ -891,15 +890,15 @@ class GraphicsRenderer {
 					if (batchDrawing && !localCoords) {
 						renderSession.spriteBatch.finish();
 					}
-					renderSession.stencilManager.pushBucket(bucket, renderSession, projection, translationMatrix.toArray(true));
-					var shader = prepareShader(bucket, renderSession, object, projection, translationMatrix.toArray(true));
+					renderSession.stencilManager.pushBucket(bucket, renderSession, translationMatrix.toArray(true));
+					var shader = prepareShader(bucket, renderSession, object, translationMatrix.toArray(true));
 					renderFill(bucket, shader, renderSession);
 					renderSession.stencilManager.popBucket(object, bucket, renderSession);
 				case DrawTriangles:
 					if (batchDrawing && !localCoords) {
 						renderSession.spriteBatch.finish();
 					}
-					var shader = prepareShader(bucket, renderSession, object, projection, null);
+					var shader = prepareShader(bucket, renderSession, object, null);
 					renderDrawTriangles(bucket, shader, renderSession);
 				case DrawTiles:
 					if (!batchDrawing) {
@@ -922,8 +921,7 @@ class GraphicsRenderer {
 					renderSession.shaderManager.setShader (shader);
 					
 					gl.uniformMatrix3fv (shader.getUniformLocation(PrimitiveUniform.TranslationMatrix), false, translationMatrix.toArray(true));
-					gl.uniform2f (shader.getUniformLocation(PrimitiveUniform.ProjectionVector), projection.x, -projection.y);
-					gl.uniform2f (shader.getUniformLocation(PrimitiveUniform.OffsetVector), -offset.x, -offset.y);
+					gl.uniformMatrix3fv (shader.getUniformLocation(PrimitiveUniform.ProjectionMatrix), false, renderSession.projectionMatrix.toArray(true));
 					gl.uniform1f (shader.getUniformLocation(PrimitiveUniform.Alpha), 1);
 					
 					gl.uniform4f (shader.getUniformLocation(FillUniform.ColorMultiplier), ct.redMultiplier, ct.greenMultiplier, ct.blueMultiplier, ct.alphaMultiplier);
@@ -1109,9 +1107,8 @@ class GraphicsRenderer {
 		return bucket;
 	}
 	
-	private static function prepareShader(bucket:GLBucket, renderSession:RenderSession, object:DisplayObject, projection:Point, translationMatrix:Float32Array) {
+	private static function prepareShader(bucket:GLBucket, renderSession:RenderSession, object:DisplayObject, translationMatrix:Float32Array) {
 		var gl = renderSession.gl;
-		var offset = renderSession.offset;
 		var shader:Shader =  null;
 		
 		shader = switch(bucket.mode) {
@@ -1130,8 +1127,8 @@ class GraphicsRenderer {
 		var newShader = renderSession.shaderManager.setShader(shader);
 		
 		// common uniforms
-		gl.uniform2f (shader.getUniformLocation(DefUniform.OffsetVector), -offset.x, -offset.y);
 		gl.uniform1f (shader.getUniformLocation(DefUniform.Alpha), object.__worldAlpha);
+		gl.uniformMatrix3fv(shader.getUniformLocation(DefUniform.ProjectionMatrix), false, @:privateAccess renderSession.projectionMatrix.toArray(true));
 		
 		var ct:ColorTransform = object.__worldColorTransform;
 		gl.uniform4f (shader.getUniformLocation(FillUniform.ColorMultiplier), ct.redMultiplier, ct.greenMultiplier, ct.blueMultiplier, ct.alphaMultiplier);
@@ -1140,17 +1137,14 @@ class GraphicsRenderer {
 		// specific uniforms
 		switch(bucket.mode) {
 			case Fill:
-				gl.uniform2f (shader.getUniformLocation(DefUniform.ProjectionVector), projection.x, -projection.y);
 				gl.uniformMatrix3fv (shader.getUniformLocation(FillUniform.TranslationMatrix), false, translationMatrix);
 				gl.uniform4fv (shader.getUniformLocation(FillUniform.Color), new Float32Array (bucket.color));
 			case PatternFill:
-				gl.uniform2f (shader.getUniformLocation(PatternFillUniform.ProjectionVector), projection.x, -projection.y);
 				gl.uniformMatrix3fv (shader.getUniformLocation(PatternFillUniform.TranslationMatrix), false, translationMatrix);
 				gl.uniform2f(shader.getUniformLocation(PatternFillUniform.PatternTL), bucket.textureTL.x, bucket.textureTL.y);
 				gl.uniform2f(shader.getUniformLocation(PatternFillUniform.PatternBR), bucket.textureBR.x, bucket.textureBR.y);
 				gl.uniformMatrix3fv(shader.getUniformLocation(PatternFillUniform.PatternMatrix), false, bucket.textureMatrix.toArray(false));
 			case DrawTriangles:
-				gl.uniform2f (shader.getUniformLocation(DrawTrianglesUniform.ProjectionVector), projection.x, projection.y);
 				if (bucket.texture != null) {
 					gl.uniform1i(shader.getUniformLocation(DrawTrianglesUniform.UseTexture), 1);
 				} else {

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -8,6 +8,7 @@ import openfl._internal.renderer.opengl.utils.VertexAttribute;
 import openfl._internal.renderer.RenderSession;
 import openfl.display.BitmapData;
 import openfl.display.DisplayObject;
+import openfl.display.PixelSnapping;
 import openfl.display.Tilesheet;
 import openfl.geom.ColorTransform;
 import openfl.geom.Matrix;
@@ -149,7 +150,7 @@ class SpriteBatch {
 		flush();
 	}
 	
-	public function renderBitmapData(bitmapData:BitmapData, smoothing:Bool, matrix:Matrix, ct:ColorTransform, ?alpha:Float = 1, ?blendMode:BlendMode) {
+	public function renderBitmapData(bitmapData:BitmapData, smoothing:Bool, matrix:Matrix, ct:ColorTransform, ?alpha:Float = 1, ?blendMode:BlendMode, ?pixelSnapping:PixelSnapping) {
 		if (bitmapData == null) return;
 		var texture = bitmapData.getTexture(gl);
 		
@@ -166,7 +167,7 @@ class SpriteBatch {
 		enableAttributes(0);
 		
 		var index = batchedSprites * 4 * elementsPerVertex;
-		fillVertices(index, bitmapData.width, bitmapData.height, matrix, uvs, null, color);
+		fillVertices(index, bitmapData.width, bitmapData.height, matrix, uvs, null, color, pixelSnapping);
 		
 		setState(batchedSprites, texture, smoothing, blendMode, ct, true);
 		
@@ -331,7 +332,7 @@ class SpriteBatch {
 				
 				color = ((Std.int(alpha * 255)) & 0xFF) << 24 | (tint & 0xFF) << 16 | ((tint >> 8) & 0xFF) << 8 | ((tint >> 16) & 0xFF);
 				
-				fillVertices(bIndex, rect.width, rect.height, matrix, uvs, null, color);
+				fillVertices(bIndex, rect.width, rect.height, matrix, uvs, null, color, NEVER);
 				
 				setState(batchedSprites, texture, smooth, blendMode, object.__worldColorTransform, false);
 				
@@ -376,7 +377,7 @@ class SpriteBatch {
 	}
 	
 	inline function fillVertices(index:Int, width:Float, height:Float, matrix:Matrix, uvs:TextureUvs, ?pivot:Point,
-		?color:Int = 0xFFFFFFFF) {
+		?color:Int = 0xFFFFFFFF, ?pixelSnapping:PixelSnapping) {
 		
 		var w0:Float, w1:Float, h0:Float, h1:Float;
 		
@@ -391,6 +392,11 @@ class SpriteBatch {
 			h1 = height * -pivot.y; 
 		}
 		
+		if (pixelSnapping == null) {
+			pixelSnapping = PixelSnapping.NEVER;
+		}
+		
+		var snap = pixelSnapping != NEVER;
 		var a = matrix.a;
 		var b = matrix.b;
 		var c = matrix.c;
@@ -398,35 +404,53 @@ class SpriteBatch {
 		var tx = matrix.tx;
 		var ty = matrix.ty;
 		var cOffsetIndex = 0;
-		var off = 0;
 		
-		positions[index++] = (a * w1 + c * h1 + tx) + off;
-		positions[index++] = (d * h1 + b * w1 + ty) + off;
+		if(!snap) {
+			positions[index++] = (a * w1 + c * h1 + tx);
+			positions[index++] = (d * h1 + b * w1 + ty);
+		} else {
+			positions[index++] = Math.fround(a * w1 + c * h1 + tx);
+			positions[index++] = Math.fround(d * h1 + b * w1 + ty);
+		}
 		positions[index++] = uvs.x0;
 		positions[index++] = uvs.y0;
 		if(enableColor) {
 			colors[index++] = color;
 		}
 		
-		positions[index++] = (a * w0 + c * h1 + tx) + off;
-		positions[index++] = (d * h1 + b * w0 + ty) + off;
+		if(!snap) {
+			positions[index++] = (a * w0 + c * h1 + tx);
+			positions[index++] = (d * h1 + b * w0 + ty);
+		} else {
+			positions[index++] = Math.fround(a * w0 + c * h1 + tx);
+			positions[index++] = Math.fround(d * h1 + b * w0 + ty);
+		}
 		positions[index++] = uvs.x1;
 		positions[index++] = uvs.y1;
 		if(enableColor) {
 			colors[index++] = color;
 		}
 		
-		positions[index++] = (a * w0 + c * h0 + tx) + off;
-		positions[index++] = (d * h0 + b * w0 + ty) + off;
+		if(!snap) {
+			positions[index++] = (a * w0 + c * h0 + tx);
+			positions[index++] = (d * h0 + b * w0 + ty);
+		} else {
+			positions[index++] = Math.fround(a * w0 + c * h0 + tx);
+			positions[index++] = Math.fround(d * h0 + b * w0 + ty);
+		}
 		positions[index++] = uvs.x2;
 		positions[index++] = uvs.y2;
 		if(enableColor) {
 			colors[index++] = color;
 		}
 		
-		
-		positions[index++] = (a * w1 + c * h0 + tx) + off;
-		positions[index++] = (d * h0 + b * w1 + ty) + off;
+		if(!snap) {
+			positions[index++] = (a * w1 + c * h0 + tx);
+			positions[index++] = (d * h0 + b * w1 + ty);
+		} else {
+			positions[index++] = Math.fround(a * w1 + c * h0 + tx);
+			positions[index++] = Math.fround(d * h0 + b * w1 + ty);
+		}
 		positions[index++] = uvs.x3;
 		positions[index++] = uvs.y3;
 		if(enableColor) {

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -22,6 +22,7 @@ import lime.utils.*;
 @:access(openfl.display.Graphics)
 @:access(openfl.display.DisplayObject)
 @:access(openfl.display.Tilesheet)
+@:access(openfl.geom.Matrix)
 class SpriteBatch {
 
 	static inline var VERTS_PER_SPRITE:Int = 4;
@@ -379,6 +380,7 @@ class SpriteBatch {
 		
 		var w0:Float, w1:Float, h0:Float, h1:Float;
 		
+		
 		if (pivot == null) {
 			w0 = width; w1 = 0;
 			h0 = height; h1 = 0;
@@ -396,25 +398,26 @@ class SpriteBatch {
 		var tx = matrix.tx;
 		var ty = matrix.ty;
 		var cOffsetIndex = 0;
+		var off = 0;
 		
-		positions[index++] = (a * w1 + c * h1 + tx);
-		positions[index++] = (d * h1 + b * w1 + ty);
+		positions[index++] = (a * w1 + c * h1 + tx) + off;
+		positions[index++] = (d * h1 + b * w1 + ty) + off;
 		positions[index++] = uvs.x0;
 		positions[index++] = uvs.y0;
 		if(enableColor) {
 			colors[index++] = color;
 		}
 		
-		positions[index++] = (a * w0 + c * h1 + tx);
-		positions[index++] = (d * h1 + b * w0 + ty);
+		positions[index++] = (a * w0 + c * h1 + tx) + off;
+		positions[index++] = (d * h1 + b * w0 + ty) + off;
 		positions[index++] = uvs.x1;
 		positions[index++] = uvs.y1;
 		if(enableColor) {
 			colors[index++] = color;
 		}
 		
-		positions[index++] = (a * w0 + c * h0 + tx);
-		positions[index++] = (d * h0 + b * w0 + ty);
+		positions[index++] = (a * w0 + c * h0 + tx) + off;
+		positions[index++] = (d * h0 + b * w0 + ty) + off;
 		positions[index++] = uvs.x2;
 		positions[index++] = uvs.y2;
 		if(enableColor) {
@@ -422,8 +425,8 @@ class SpriteBatch {
 		}
 		
 		
-		positions[index++] = (a * w1 + c * h0 + tx);
-		positions[index++] = (d * h0 + b * w1 + ty);
+		positions[index++] = (a * w1 + c * h0 + tx) + off;
+		positions[index++] = (d * h0 + b * w1 + ty) + off;
 		positions[index++] = uvs.x3;
 		positions[index++] = uvs.y3;
 		if(enableColor) {
@@ -526,8 +529,7 @@ class SpriteBatch {
 		// TODO cache this somehow?, don't do each state change?
 		shader.bindVertexArray(vertexArray);
 		
-		var projection = renderSession.projection;
-		gl.uniform2f(shader.getUniformLocation(DefUniform.ProjectionVector), projection.x, projection.y);
+		gl.uniformMatrix3fv(shader.getUniformLocation(DefUniform.ProjectionMatrix), false, renderSession.projectionMatrix.toArray(true));
 		
 		if (state.colorTransform != null) {
 			var ct = state.colorTransform;
@@ -544,6 +546,7 @@ class SpriteBatch {
 		gl.bindTexture(gl.TEXTURE_2D, state.texture);
 		
 		if (state.textureSmooth) {
+		//if (false) {
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 		} else {
@@ -590,6 +593,7 @@ class SpriteBatch {
 		
 		return r;
 	}
+	
 }
 
 @:access(openfl.geom.ColorTransform)

--- a/openfl/_internal/renderer/opengl/utils/StencilManager.hx
+++ b/openfl/_internal/renderer/opengl/utils/StencilManager.hx
@@ -38,21 +38,19 @@ class StencilManager {
 		
 	}
 	
-	public inline function prepareGraphics(fill:GLBucketData, renderSession:RenderSession, projection:Point, translationMatrix:Float32Array):Void {
-		var offset = renderSession.offset;
+	public inline function prepareGraphics(fill:GLBucketData, renderSession:RenderSession, translationMatrix:Float32Array):Void {
 		var shader = renderSession.shaderManager.fillShader;
 		
 		renderSession.shaderManager.setShader (shader);
 		gl.uniformMatrix3fv (shader.getUniformLocation(FillUniform.TranslationMatrix), false, translationMatrix);
-		gl.uniform2f (shader.getUniformLocation(FillUniform.ProjectionVector), projection.x, -projection.y);
-		gl.uniform2f (shader.getUniformLocation(FillUniform.OffsetVector), -offset.x, -offset.y);
+		gl.uniformMatrix3fv (shader.getUniformLocation(FillUniform.ProjectionMatrix), false, renderSession.projectionMatrix.toArray(true));
 			
 		fill.vertexArray.bind();
 		shader.bindVertexArray(fill.vertexArray);
 		gl.bindBuffer (gl.ELEMENT_ARRAY_BUFFER, fill.indexBuffer);
 	}
 	
-	public function pushBucket (bucket:GLBucket, renderSession:RenderSession, projection:Point, translationMatrix:Float32Array, ?isMask:Bool = false):Void {
+	public function pushBucket (bucket:GLBucket, renderSession:RenderSession, translationMatrix:Float32Array, ?isMask:Bool = false):Void {
 		
 		if(!isMask) {
 			gl.enable(gl.STENCIL_TEST);
@@ -68,7 +66,7 @@ class StencilManager {
 		
 		for (fill in bucket.fills) {
 			if (fill.available) continue;
-			prepareGraphics(fill, renderSession, projection, translationMatrix);
+			prepareGraphics(fill, renderSession, translationMatrix);
 			gl.drawElements (fill.drawMode, fill.glIndices.length, gl.UNSIGNED_SHORT, 0);
 		}
 		
@@ -126,7 +124,7 @@ class StencilManager {
 			
 			switch(bucket.mode) {
 				case Fill, PatternFill:
-					pushBucket(bucket, renderSession, renderSession.projection, translationMatrix.toArray(true), true);
+					pushBucket(bucket, renderSession, translationMatrix.toArray(true), true);
 				case _:
 			}
 		}

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1663,12 +1663,10 @@ class BitmapData implements IBitmapDrawable {
 		if (gl == null) return;
 		
 		var spritebatch = renderSession.spriteBatch;
-		var mainProjection = renderSession.projection;
 		var renderTransparent = renderSession.renderer.transparent;
 
 		var tmpRect = clipRect == null ? new Rectangle(0, 0, width, height) : clipRect.clone();
 		
-		renderSession.projection = new Point((width / 2), -(height / 2));
 		renderSession.renderer.transparent = transparent;
 		
 		if (__framebuffer == null) {
@@ -1678,7 +1676,7 @@ class BitmapData implements IBitmapDrawable {
 		__framebuffer.resize(width, height);
 		gl.bindFramebuffer(gl.FRAMEBUFFER, __framebuffer.frameBuffer);
 		
-		gl.viewport (0, 0, width, height);
+		renderer.setViewport (0, 0, width, height);
 		
 		spritebatch.begin(renderSession, drawSelf ? null : tmpRect);
 		
@@ -1741,9 +1739,8 @@ class BitmapData implements IBitmapDrawable {
 		
 		gl.bindFramebuffer(gl.FRAMEBUFFER, renderSession.defaultFramebuffer);
 		
-		gl.viewport(0, 0, renderSession.renderer.width, renderSession.renderer.height);
+		renderer.setViewport (0, 0, renderSession.renderer.width, renderSession.renderer.height);
 		
-		renderSession.projection = mainProjection;
 		renderSession.renderer.transparent = renderTransparent;
 		
 		gl.colorMask(true, true, true, renderSession.renderer.transparent);

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -895,8 +895,8 @@ class BitmapData implements IBitmapDrawable {
 			gl.bindTexture (gl.TEXTURE_2D, __texture);
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
 			__image.dirty = true;
 			
 		}
@@ -1648,7 +1648,7 @@ class BitmapData implements IBitmapDrawable {
 	
 	@:noCompletion @:dox(hide) public function __renderGL (renderSession:RenderSession):Void {
 		
-		renderSession.spriteBatch.renderBitmapData(this, true, __worldTransform, __worldColorTransform, __worldColorTransform.alphaMultiplier, blendMode);
+		renderSession.spriteBatch.renderBitmapData(this, false, __worldTransform, __worldColorTransform, __worldColorTransform.alphaMultiplier, blendMode);
 		
 	}
 	


### PR DESCRIPTION
Fixes issue #594  (hopefully)

this also comes with:
- Optimized shaders
- Added `Bitmap.pixelSnapping` support (not fully)
- `BitmapData` should default to nearest filtering.
