### PR TITLE
Fixing another case where rendering will go wrong if a shader was set

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1716,7 +1716,10 @@ class BitmapData implements IBitmapDrawable {
 		// enable writing to all the colors and alpha
 		gl.colorMask(true, true, true, true);
 		renderSession.blendModeManager.setBlendMode(BlendMode.NORMAL);
-		
+
+		// set default shader
+		renderSession.shaderManager.setShader(renderSession.shaderManager.defaultShader, true);
+
 		if (clearBuffer || drawSelf) {
 			__framebuffer.clear();
 		}


### PR DESCRIPTION
This fixes where a shader was set between the time you're rendering to a bitmapData and the last frame.