### PR TITLE
Fire/broadcast FOCUS_IN, FOCUS_OUT and TEXT_INPUT events

### DIFF
--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -29,6 +29,7 @@ import openfl.events.EventPhase;
 import openfl.events.FocusEvent;
 import openfl.events.KeyboardEvent;
 import openfl.events.MouseEvent;
+import openfl.events.TextEvent;
 import openfl.events.TouchEvent;
 import openfl.geom.Matrix;
 import openfl.geom.Point;
@@ -790,7 +791,27 @@ class Stage extends DisplayObjectContainer implements IModule {
 	
 	public function onTextInput (text:String):Void {
 		
+		var stack = new Array <DisplayObject> ();
 		
+		if (__focus == null) {
+			
+			__getInteractive (stack);
+			
+		} else {
+			
+			__focus.__getInteractive (stack);
+			
+		}
+		
+		var event = new TextEvent (TextEvent.TEXT_INPUT, true, false, text);
+		if (stack.length > 0) {
+			
+			stack.reverse ();
+			__fireEvent (event, stack);
+		} else {
+			
+			__broadcast (event, true);
+		}
 		
 	}
 	

--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -848,14 +848,16 @@ class Stage extends DisplayObjectContainer implements IModule {
 	
 	public function onWindowFocusIn ():Void {
 		
-		
+		var event = new FocusEvent (FocusEvent.FOCUS_IN, true, false, null, false, 0);
+		__broadcast (event, true);
 		
 	}
 	
 	
 	public function onWindowFocusOut ():Void {
 		
-		
+		var event = new FocusEvent (FocusEvent.FOCUS_OUT, true, false, null, false, 0);
+		__broadcast (event, true);
 		
 	}
 	


### PR DESCRIPTION
Focus events are just broadcasted forward, text input events follow the same pattern as key up and down events.

After this I found out that Text input is still pretty useless on cpp target as there are no event handlers bound, https://github.com/openfl/openfl/blob/master/openfl/text/TextField.hx#L1660-L1862 Or I'm missing something :)