### PR TITLE
skip duplicate point in lineTo.

### DIFF
--- a/openfl/_internal/renderer/opengl/utils/DrawPath.hx
+++ b/openfl/_internal/renderer/opengl/utils/DrawPath.hx
@@ -84,8 +84,7 @@ class PathBuiler {
 			var ey = __currentPath.points[l - 1];
 			
 			if (!(sx == ex && sy == ey)) {
-				__currentPath.points.push (sx);
-				__currentPath.points.push (sy);
+				lineTo(sx, sy);
 			}
 		}
 	}
@@ -111,8 +110,22 @@ class PathBuiler {
 	}
 	
 	private static inline function lineTo (x:Float, y:Float) {
-		__currentPath.points.push (x);
-		__currentPath.points.push (y);
+		var points = __currentPath.points;
+		var push_point:Bool = true;
+
+		// Skip duplicate point.
+		if (points.length > 1) {
+			var lastX = points[points.length-2];
+			var lastY = points[points.length-1];
+			if (lastX == x && lastY == y) {
+				push_point = false;
+			}
+		}
+
+		if (push_point == true) {
+			__currentPath.points.push (x);
+			__currentPath.points.push (y);
+		}
 	}
 	
 	private static inline function curveTo (cx:Float, cy:Float, x:Float, y:Float) {


### PR DESCRIPTION
Codes for test issue
         var path:Graphics = this.graphics;
         path.lineStyle(5, 0xff0000);
         path.moveTo(0, 0);
         path.lineTo(100, 0);
         path.lineTo(100, 0);                                           
         path.lineTo(100, 100);

Issue result.
![screenshot from 2015-05-25 11 43 13](https://cloud.githubusercontent.com/assets/2268115/7791463/5a6a2cca-02d3-11e5-8892-26cde6d9ff2e.png)

Correct result.
![screenshot from 2015-05-25 11 43 30](https://cloud.githubusercontent.com/assets/2268115/7791465/678c5374-02d3-11e5-8334-f1549377348e.png)

yodesoft.com
openfl.cn