### PR TITLE
SystemPath inWhich return correction

### DIFF
--- a/openfl/_legacy/utils/SystemPath.hx
+++ b/openfl/_legacy/utils/SystemPath.hx
@@ -77,7 +77,7 @@ class SystemPath {
 			
 		}
 		
-		return jni_filesystem_get_special_dir (which);
+		return jni_filesystem_get_special_dir (inWhich);
 		
 		#end
 		


### PR DESCRIPTION
function lime_filesystem_get_special_dir returned wrong value. Thx to Alex Kolpakov for the contribution.