### PR TITLE
Allow user to set parameters of HXTelemetry config

### DIFF
--- a/openfl/profiler/Telemetry.hx
+++ b/openfl/profiler/Telemetry.hx
@@ -3,6 +3,7 @@ package openfl.profiler; #if !flash
 
 #if (cpp && hxtelemetry)
 import hxtelemetry.HxTelemetry;
+import hxtelemetry.HxTelemetry.Config;
 #end
 
 @:allow(openfl.display.Stage)
@@ -65,15 +66,25 @@ class Telemetry {
 	}
 	
 	
+	#if (cpp && hxtelemetry)
+	private static var hxtConfig:Config = new Config();
+	public static var config(get, null):Config;
+	public static function get_config():Config
+	{
+		if (telemetry!=null) throw "Must setup Telemetry.config before Telemetry is initialized!";
+		return hxtConfig;
+	}
+	#else
+	public static var config(get, null):Dynamic;
+	public static function get_config():Dynamic return {};
+	#end
+
 	private static inline function __initialize ():Void {
 		
 		#if (cpp && hxtelemetry)
-		var config = new HxTelemetry.Config ();
-		config.allocations = true;
-		config.host = "localhost";
-		config.app_name = Lib.application.config.title;
-		config.activity_descriptors = [ { name: TelemetryCommandName.EVENT, description: "Event Handler", color: 0x2288cc }, { name: TelemetryCommandName.RENDER, description: "Rendering", color:0x66aa66 } ];
-		telemetry = new HxTelemetry (config);
+		hxtConfig.app_name = Lib.application.config.title;
+		hxtConfig.activity_descriptors = [ { name: TelemetryCommandName.EVENT, description: "Event Handler", color: 0x2288cc }, { name: TelemetryCommandName.RENDER, description: "Rendering", color:0x66aa66 } ];
+		telemetry = new HxTelemetry (hxtConfig);
 		#end
 		
 	}


### PR DESCRIPTION
Allow the user to set parameters of the Telemetry config via a public static config accessor. Features of this implementation include:
- app title still set from Telemetry.hx, telemetry still instantiated from early in framework (Stage)
- error message if set too late (must be a static function initializer, before stage is constructed)

I guess the static initializer is questionable -- perhaps there is another way? How is app title parsed? I don't love the idea of cross-platform locating and parsing a .telemetry.cfg config file (like Flash -- this is one of the most irritating components of telemetry, imo, plus options may be different), or using compiler defines (might cause full recompile when not necessary.) But I'm happy to discuss.