### PR TITLE
Prevent crash when empty text field is rendered to bitmap data

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -266,6 +266,7 @@ class CanvasTextField {
 				
 				textField.__graphics.__canvas = null;
 				textField.__graphics.__context = null;
+				textField.__graphics.__dirty = false;
 				textField.__dirty = false;
 				
 			} else {


### PR DESCRIPTION
Prevent crash when empty text field is rendered to bitmap data for -Ddom and -Dcanvas modes.

Test case:

```haxe
package org.sample;

import openfl.display.BitmapData;
import openfl.display.Sprite;
import openfl.text.TextField;

class App extends Sprite {
    public function new():Void {
        super();

        var textField = new TextField();
        textField.text = "";

        var bitmapData = new BitmapData(100, 100, true, 0);
        bitmapData.draw(textField);

        trace("Success");
    }
}
```

**Without fix:**
```
TypeError: openfl__$internal_renderer_canvas_CanvasGraphics.fillCommands is null
```
in my other project i got:
```
image is null
```

**With fix:**
```
"App.hx:17: Success"
```