### PR TITLE
Improved preloader creation/extension

### DIFF
--- a/openfl/display/Preloader.hx
+++ b/openfl/display/Preloader.hx
@@ -168,15 +168,10 @@ class Preloader extends LimePreloader {
 }
 
 
-#if tools
-typedef OpenFLPreloader = NMEPreloader
-#else
-private class OpenFLPreloader extends Sprite {
+class OpenFLPreloader extends Sprite {
 	
-	public function new () { super (); }
 	public function onInit ():Void {};
 	public function onUpdate (loaded:Int, total:Int):Void {};
 	public function onLoaded ():Void {};
 	
 }
-#end

--- a/templates/haxe/NMEPreloader.hx
+++ b/templates/haxe/NMEPreloader.hx
@@ -1,11 +1,12 @@
 package;
 
 
+import openfl.display.Preloader.OpenFLPreloader;
 import openfl.display.Sprite;
 import openfl.events.Event;
 
 
-class NMEPreloader extends Sprite {
+class NMEPreloader extends OpenFLPreloader {
 	
 	
 	private var outline:Sprite;
@@ -95,21 +96,21 @@ class NMEPreloader extends Sprite {
 	}
 	
 	
-	public function onInit () {
+	override public function onInit () {
 		
 		
 		
 	}
 	
 	
-	public function onLoaded () {
+	override public function onLoaded () {
 		
 		dispatchEvent (new Event (Event.COMPLETE));
 		
 	}
 	
 	
-	public function onUpdate (bytesLoaded:Int, bytesTotal:Int):Void {
+	override public function onUpdate (bytesLoaded:Int, bytesTotal:Int):Void {
 		
 		var percentLoaded = bytesLoaded / bytesTotal;
 		


### PR DESCRIPTION
The current preloader requires the user to extend `NMEPreloader` and override its methods, but the `NMEPreloader` have it's own, hard-coded, behavior.

This pull request changes `NMEPreloader` to extend `OpenFLPreloader`, which is a empty class (almost an interface that extends `Sprite`).
The only requirement to create a preloader now is 1) extend `OpenFLPreloader` and dispatch an `Event.COMPLETE` when you are done with the preloader.