### PR TITLE
If the image is transparent, we should premultipy it.

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -995,7 +995,7 @@ class BitmapData implements IBitmapDrawable {
 				
 			}
 			
-			if (!textureImage.premultiplied && !textureImage.transparent) {
+			if (!textureImage.premultiplied && textureImage.transparent) {
 				
 				textureImage = textureImage.clone ();
 				textureImage.premultiplied = true;


### PR DESCRIPTION
This probably fixes this issue http://community.openfl.org/t/update-effected-images/1563