### PR TITLE
Fix event contructor, enable for other platforms

### DIFF
--- a/openfl/events/TouchEvent.hx
+++ b/openfl/events/TouchEvent.hx
@@ -269,17 +269,12 @@ class TouchEvent extends Event {
 	
 	@:noCompletion public static function __create (type:String, /*event:lime.ui.TouchEvent,*/ touch:Dynamic /*js.html.Touch*/, stageX:Float, stageY:Float, local:Point, target:InteractiveObject):TouchEvent {
 		
-		#if (js && html5)
-		var evt = new TouchEvent (type, true, false, local.x, local.y, null, false, false, false/*event.ctrlKey, event.altKey, event.shiftKey*/, false /* note: buttonDown not supported on w3c spec */, 0, 0);
-		
+		var evt = new TouchEvent (type, true, false, local.x, local.y, 1, 1, null, false, false, false/*event.ctrlKey, event.altKey, event.shiftKey*/, false /* note: buttonDown not supported on w3c spec */, 0, false, 0);
 		evt.stageX = stageX;
 		evt.stageY = stageY;
 		evt.target = target;
 		
 		return evt;
-		#else
-		return null;
-		#end
 		
 	}
 	


### PR DESCRIPTION
Fixed TouchEvent constructor arguments to match expected ones.
Remove limitation to JS and HTML5 for touch events as we'll probably want this for mobile and desktop touchscreens.

Required by https://github.com/openfl/lime/pull/470.
Without this fix it would just return null and crash.

@jgranick please review
