### PR TITLE
Return true for MultiTouch.supportsTouchEvents

### DIFF
--- a/openfl/ui/Multitouch.hx
+++ b/openfl/ui/Multitouch.hx
@@ -155,6 +155,8 @@ class Multitouch {
 			return true;
 			
 		}
+		#elseif (cpp)
+		return true;
 		#end
 		
 		return false;


### PR DESCRIPTION
Not sure how to really detect this, but I think it might be fine to always return true for cpp targets which include:
- Windows + touchscreen
- Linux + touchscreen
- Android / mobile ?

(note: touch doesn't seem to work yet on Android, so might want to wait for this)