### PR TITLE
Fix MIPNONE to use nearest when filter is NEAREST

### DIFF
--- a/openfl/display3D/Context3D.hx
+++ b/openfl/display3D/Context3D.hx
@@ -850,7 +850,7 @@ class Context3D {
 				
 				case Context3DMipFilter.MIPNONE:
 					
-					GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
+					GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, filter == Context3DTextureFilter.NEAREST ? GL.NEAREST : GL.LINEAR);
 				
 			} 
 			
@@ -899,7 +899,7 @@ class Context3D {
 				
 			}
 			
-			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
+			GL.texParameteri (GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, filter == Context3DTextureFilter.NEAREST ? GL.NEAREST : GL.LINEAR);
 			
 		} else if (Std.is (texture, CubeTexture)) {
 			
@@ -969,7 +969,7 @@ class Context3D {
 				
 				case Context3DMipFilter.MIPNONE:
 					
-					GL.texParameteri (GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
+					GL.texParameteri (GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, filter == Context3DTextureFilter.NEAREST ? GL.NEAREST : GL.LINEAR);
 				
 			}
 			


### PR DESCRIPTION
Always using LINEAR for MIPNONE is wrong. That will prevent us from using NEAREST texture filter.