### PR TITLE
uploadFromFloat32Array() should be available everywhere.

### DIFF
--- a/openfl/display3D/VertexBuffer3D.hx
+++ b/openfl/display3D/VertexBuffer3D.hx
@@ -62,14 +62,12 @@ class VertexBuffer3D {
 	}
 	
 	
-	#if js
 	public function uploadFromFloat32Array (data:Float32Array, startVertex:Int, numVertices:Int):Void {
 		
 		GL.bindBuffer (GL.ARRAY_BUFFER, glBuffer);
 		GL.bufferData (GL.ARRAY_BUFFER, data, GL.STATIC_DRAW);
 		
 	}
-	#end
 	
 	
 	public function uploadFromVector (data:Vector<Float>, startVertex:Int, numVertices:Int):Void {


### PR DESCRIPTION
Uploading a Float32Array is the clear winner in terms of performance, and I've confirmed that this implementation works on Windows, Mac, Neko for Windows, Android, and iOS.