### PR TITLE
Safeguard alpha property to a maximum value of 1.0

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1489,6 +1489,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	
 	@:noCompletion private function set_alpha (value:Float):Float {
 		
+		if (value > 1.0) value = 1.0;
 		if (value != __alpha) __setRenderDirty ();
 		return __alpha = value;
 		


### PR DESCRIPTION
If alpha is set to over 1.0, DisplayObject would disappear.