### PR TITLE
Fix build failure with -Dtelemetry and -Dlegacy

### DIFF
--- a/openfl/profiler/Telemetry.hx
+++ b/openfl/profiler/Telemetry.hx
@@ -71,7 +71,9 @@ class Telemetry {
 		var config = new hxtelemetry.Config ();
 		config.allocations = true;
 		config.host = "localhost";
+		#if (!openfl_legacy)
 		config.app_name = Lib.application.config.title;
+		#end
 		config.activity_descriptors = [ { name: TelemetryCommandName.EVENT, description: "Event Handler", color: 0x2288cc }, { name: TelemetryCommandName.RENDER, description: "Rendering", color:0x66aa66 } ];
 		telemetry = new HxTelemetry (config);
 		#end


### PR DESCRIPTION
The Telemetry.hx file has a compile failure with -Dlegacy and -Dtelemetry -- `Lib.application.config.title` apparently isn't available in Legacy. @singmajesty - does legacy have access to the app title somewhere? If not, this leaves the default.