### PR TITLE
I forgot to modify BitmapData.draw() in the last PR

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1684,21 +1684,22 @@ class BitmapData implements IBitmapDrawable {
 		
 		__flipMatrix (m);
 		
-		source.__worldTransform = m;
 		source.__worldColorTransform = colorTransform != null ? colorTransform : new ColorTransform ();
 		source.__blendMode = blendMode;
 		source.__cacheAsBitmap = false;
 		
+		source.__updateMatrices (m);
 		source.__updateChildren (false);
 		
 		source.__renderGL (renderSession);
 		
+		
 		source.__worldColorTransform = ctCache;
-		source.__worldTransform = matrixCache;
 		source.__blendMode = blendModeCache;
 		source.__cacheAsBitmap = cached;
 		
-		source.__updateChildren (true);
+		source.__updateMatrices ();
+		source.__updateChildren (false);
 		
 		spritebatch.finish ();
 		
@@ -1988,6 +1989,17 @@ class BitmapData implements IBitmapDrawable {
 				
 			}
 			
+		}
+		
+	}
+	
+	
+	@:noCompletion @:dox(hide) public function __updateMatrices (?overrideTransform:Matrix = null):Void {
+		
+		if (overrideTransform == null) {
+			__worldTransform.identity();
+		} else {
+			__worldTransform = overrideTransform;
 		}
 		
 	}

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1055,25 +1055,21 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	
 	@:noCompletion private function __getLocalMatrix () {
 		
-		if (__transformDirty) {
+		if (rotation != __rotationCache) {
 			
-			if (rotation != __rotationCache) {
-				
-				__rotationCache = rotation;
-				var radians = rotation * (Math.PI / 180);
-				__rotationSine = Math.sin (radians);
-				__rotationCosine = Math.cos (radians);
-				
-			}
-			
-			__localMatrix.a = __rotationCosine * scaleX;
-			__localMatrix.c = -__rotationSine * scaleY;
-			__localMatrix.b = __rotationSine * scaleX;
-			__localMatrix.d = __rotationCosine * scaleY;
-			__localMatrix.tx = x;
-			__localMatrix.ty = y;
+			__rotationCache = rotation;
+			var radians = rotation * (Math.PI / 180);
+			__rotationSine = Math.sin (radians);
+			__rotationCosine = Math.cos (radians);
 			
 		}
+		
+		__localMatrix.a = __rotationCosine * scaleX;
+		__localMatrix.c = -__rotationSine * scaleY;
+		__localMatrix.b = __rotationSine * scaleX;
+		__localMatrix.d = __rotationCosine * scaleY;
+		__localMatrix.tx = x;
+		__localMatrix.ty = y;
 		
 		return __localMatrix;
 		
@@ -1277,14 +1273,18 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		
 	}
 	
-	
-	@:noCompletion @:dox(hide) public function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null):Void {
+	@:noCompletion @:dox(hide) public function __updateMatrices (?overrideTransform:Matrix = null) {
 		
-		__renderable = (visible && scaleX != 0 && scaleY != 0 && !__isMask);
-		//if (!__renderable && !__isMask) return;
-		
-		__worldTransform.identity();
-		__worldTransform.concat(__getLocalMatrix());
+		if (overrideTransform == null) {
+			
+			__worldTransform.identity ();
+			__worldTransform.concat (__getLocalMatrix());
+			
+		} else {
+			
+			__worldTransform = overrideTransform;
+			
+		}
 		
 		__scrollRectMatrix.identity();
 		if (__scrollRect != null) {
@@ -1304,6 +1304,15 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		}
 		
 		__renderMatrix = __worldTransform.mult(__scrollRectMatrix);
+		
+	}
+	
+	@:noCompletion @:dox(hide) public function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null):Void {
+		
+		__renderable = (visible && scaleX != 0 && scaleY != 0 && !__isMask);
+		//if (!__renderable && !__isMask) return;
+		
+		__updateMatrices();
 		
 		if (updateChildren && __transformDirty) {
 			

--- a/openfl/display/IBitmapDrawable.hx
+++ b/openfl/display/IBitmapDrawable.hx
@@ -20,6 +20,7 @@ interface IBitmapDrawable {
 	function __renderCanvasMask (renderSession:RenderSession):Void;
 	function __renderGL (renderSession:RenderSession):Void;
 	function __updateChildren (transformOnly:Bool):Void;
+	function __updateMatrices (?overrideTransform:Matrix = null):Void;
 	
 	function __updateMask (maskGraphics:Graphics):Void;
 	


### PR DESCRIPTION
:cry: 
It was mostly working but not really. For example, in the RPG Interface from haxeflixel the text was upside down but everything else was correct. Flixel does multiple `draw()` for some effects like text borders and the matrices weren't correct after the first draw.