### PR TITLE
Implement BitmapData.compare() function

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -297,7 +297,7 @@ class BitmapData implements IBitmapDrawable {
 	 * @return If the two BitmapData objects have the same dimensions (width and height), the method returns a new BitmapData object that has the difference between the two objects (see the main discussion).If the BitmapData objects are equivalent, the method returns the number 0. If no argument is passed or if the argument is not a BitmapData object, the method returns -1. If either BitmapData object has been disposed of, the method returns -2. If the widths of the BitmapData objects are not equal, the method returns the number -3. If the heights of the BitmapData objects are not equal, the method returns the number -4.
 	 */
 	
-	@:access(BitmapData)
+	@:access(lime.graphics.Image)
 	public function compare (otherBitmapData:BitmapData):Dynamic {
 		
 		if (otherBitmapData == null) 
@@ -313,7 +313,7 @@ class BitmapData implements IBitmapDrawable {
 			return -4;
 		
 		//Fast-fail check: are they 100% equivalent at the byte level
-		if (this.image.format == otherBitmapData.image.format) {
+		if (this.image != null && otherBitmapData.image != null && this.image.format == otherBitmapData.image.format) {
 			
 			var bytes1 = this.image.data;
 			var bytes2 = otherBitmapData.image.data;

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -313,10 +313,10 @@ class BitmapData implements IBitmapDrawable {
 			return -4;
 		
 		//Fast-fail check: are they 100% equivalent at the byte level
-		if (this.__image.format == otherBitmapData.__image.format) {
+		if (this.image.format == otherBitmapData.image.format) {
 			
-			var bytes1 = this.__image.data;
-			var bytes2 = otherBitmapData.__image.data;
+			var bytes1 = this.image.data;
+			var bytes2 = otherBitmapData.image.data;
 			
 			var allEqual:Bool = false;
 			for (i in 0...bytes1.length)


### PR DESCRIPTION
This implements the BitmapData.compare() function, and as far as I can tell matches the results called for in the [Flash API documentation](http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/BitmapData.html#compare())

Do note that Flash apparently didn't follow the documentation and the flash player's results are buggy:

- If a null BitmapData is supplied, the API says it should return -1, but Flash throws a TypeError instead.
- If a disposed BitmapData is supplied, the API says it should return -2, but Flash throws an Error instead.
- Flash does correctly return -3 or -4 if width or height does not match.
- Flash returns wildly inconsistent results. In the test case I created, returning a false positive for every single non-error case.

This is still an extremely useful function to have. Not sure if you want to "match" flash's results by purposefully sabotaging the function or not. 

```
¯\_(ツ)_/¯
```

HTML5:
![html5](https://cloud.githubusercontent.com/assets/739064/9446311/8de277d6-4a56-11e5-853e-65b864f7c1b1.png)

Neko:
![neko](https://cloud.githubusercontent.com/assets/739064/9446596/1edd1290-4a58-11e5-9a61-2e2d7fba59f8.png)

Flash:
![flash](https://cloud.githubusercontent.com/assets/739064/9446310/8dda4930-4a56-11e5-9a08-edef9fbcfd40.png)

My test case is here:
https://github.com/openfl/openfl-samples/pull/32