### PR TITLE
Do not dispatch CONTEXT3D_CREATE right after Stage3D.requestContext3D is called

### DIFF
--- a/openfl/display/Stage3D.hx
+++ b/openfl/display/Stage3D.hx
@@ -1,6 +1,7 @@
 package openfl.display; #if !flash
 
 
+import haxe.Timer;
 import openfl.display.OpenGLView;
 import openfl.display3D.Context3D;
 import openfl.events.ErrorEvent;
@@ -27,12 +28,20 @@ class Stage3D extends EventDispatcher {
 		
 		if (OpenGLView.isSupported) {
 			
-			context3D = new Context3D ();
-			dispatchEvent (new Event (Event.CONTEXT3D_CREATE));
+			Timer.delay(function() {
+				
+				context3D = new Context3D ();
+				dispatchEvent (new Event (Event.CONTEXT3D_CREATE));
+				
+			}, 1);
 			
 		} else {
 			
-			dispatchEvent (new ErrorEvent (ErrorEvent.ERROR));
+			Timer.delay(function() {
+				
+				dispatchEvent (new ErrorEvent (ErrorEvent.ERROR));
+				
+			}, 1);
 			
 		}
 		


### PR DESCRIPTION
I believe that original Stage3D implementation never dispatches CONTEXT3D_CREATE event inside this function.
Since Starling is assuming that you have (at least) one frame before this event is dispatched, current code causes incompatibility between OpenFL and Flash. For example, you have no time to setup listeners for ROOT_CREATED event of Starling.

https://github.com/Gamua/Starling-Framework/blob/v1.7/samples/demo_web/src/Demo_Web.as#L55