### PR TITLE
ScrollRects, bounds and more

### DIFF
--- a/openfl/_internal/renderer/AbstractMaskManager.hx
+++ b/openfl/_internal/renderer/AbstractMaskManager.hx
@@ -42,4 +42,25 @@ class AbstractMaskManager {
 	}
 	
 	
+	public function popRect ():Void {
+		
+		
+		
+	}
+	
+	
+	public function saveState ():Void {
+		
+		
+		
+	}
+	
+	
+	public function restoreState ():Void {
+		
+		
+		
+	}
+	
+	
 }

--- a/openfl/_internal/renderer/AbstractRenderer.hx
+++ b/openfl/_internal/renderer/AbstractRenderer.hx
@@ -3,6 +3,7 @@ package openfl._internal.renderer;
 
 import openfl.display.Shape;
 import openfl.display.Stage;
+import openfl.geom.Rectangle;
 
 
 class AbstractRenderer {
@@ -11,6 +12,7 @@ class AbstractRenderer {
 	public var height:Int;
 	public var width:Int;
 	public var transparent:Bool;
+	public var viewPort:Rectangle;
 	
 	private var renderSession:RenderSession;
 	

--- a/openfl/_internal/renderer/cairo/CairoMaskManager.hx
+++ b/openfl/_internal/renderer/cairo/CairoMaskManager.hx
@@ -62,4 +62,11 @@ class CairoMaskManager extends AbstractMaskManager {
 	}
 	
 	
+	public override function popRect ():Void {
+		
+		renderSession.cairo.restore ();
+		
+	}
+	
+	
 }

--- a/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
+++ b/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
@@ -60,5 +60,11 @@ class CanvasMaskManager extends AbstractMaskManager {
 		
 	}
 	
+	public override function popRect ():Void {
+		
+		renderSession.context.restore ();
+		
+	}
+	
 	
 }

--- a/openfl/_internal/renderer/opengl/GLBitmap.hx
+++ b/openfl/_internal/renderer/opengl/GLBitmap.hx
@@ -3,6 +3,7 @@ package openfl._internal.renderer.opengl;
 
 import openfl._internal.renderer.RenderSession;
 import openfl.display.Bitmap;
+import openfl.geom.Matrix;
 
 @:access(openfl.display.Bitmap)
 @:access(openfl.display.BitmapData)
@@ -15,8 +16,21 @@ class GLBitmap {
 		
 		if (!bitmap.__renderable || bitmap.__worldAlpha <= 0 || bitmap.bitmapData == null || !bitmap.bitmapData.__isValid) return;
 		
-		renderSession.spriteBatch.renderBitmapData(bitmap.bitmapData, bitmap.smoothing, bitmap.__worldTransform, bitmap.__worldColorTransform, bitmap.__worldAlpha, bitmap.__blendMode, bitmap.pixelSnapping);
+		renderSession.spriteBatch.renderBitmapData(bitmap.bitmapData, bitmap.smoothing, bitmap.__renderTransform, bitmap.__worldColorTransform, bitmap.__worldAlpha, bitmap.__blendMode, bitmap.pixelSnapping);
 	}
 	
+	private static inline function flipMatrix (m:Matrix, height:Float):Void {
+		
+		var tx = m.tx;
+		var ty = m.ty;
+		m.tx = 0;
+		m.ty = 0;
+		m.scale (1, -1);
+		m.translate (0, height);
+		m.tx += tx;
+		m.ty -= ty;
+		
+		
+	}
 	
 }

--- a/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -7,7 +7,6 @@ import lime.graphics.ImageChannel;
 import lime.graphics.opengl.GL;
 import lime.graphics.opengl.GLFramebuffer;
 import lime.graphics.GLRenderContext;
-import lime.math.Rectangle;
 import lime.math.Vector2;
 import lime.utils.ByteArray;
 import openfl._internal.renderer.AbstractRenderer;
@@ -25,6 +24,7 @@ import openfl.display.Stage;
 import openfl.errors.Error;
 import openfl.geom.Matrix;
 import openfl.geom.Point;
+import openfl.geom.Rectangle;
 import openfl.text.TextField;
 
 #if (js && html5)
@@ -79,6 +79,7 @@ class GLRenderer extends AbstractRenderer {
 		this.preserveDrawingBuffer = preserveDrawingBuffer;
 		this.width = width;
 		this.height = height;
+		this.viewPort = new Rectangle();
 		
 		this.options = {
 			alpha: transparent,
@@ -177,6 +178,8 @@ class GLRenderer extends AbstractRenderer {
 			vpHeight = height;
 			gl.viewport(x, y, width, height);
 			setOrtho(x, y, width, height);
+			
+			viewPort.setTo(x, y, width, height);
 		}
 	}
 	

--- a/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -121,7 +121,6 @@ class GLRenderer extends AbstractRenderer {
 		renderSession.gl = this.gl;
 		renderSession.drawCount = 0;
 		renderSession.shaderManager = this.shaderManager;
-		renderSession.maskManager = this.maskManager;
 		renderSession.filterManager = this.filterManager;
 		renderSession.blendModeManager = this.blendModeManager;
 		renderSession.spriteBatch = this.spriteBatch;

--- a/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -322,7 +322,7 @@ class GLRenderer extends AbstractRenderer {
 		var bitmap = shape.__graphics.__bitmap;
 		
 		matrix.translate (shape.__graphics.__bounds.x, shape.__graphics.__bounds.y);
-		matrix.concat (shape.__worldTransform);
+		matrix.concat (shape.__renderTransform);
 		
 		renderSession.spriteBatch.renderBitmapData (bitmap, smooth, matrix, shape.__worldColorTransform, shape.__worldAlpha, shape.__blendMode, ALWAYS);
 		

--- a/openfl/_internal/renderer/opengl/utils/GLMaskManager.hx
+++ b/openfl/_internal/renderer/opengl/utils/GLMaskManager.hx
@@ -45,13 +45,13 @@ class GLMaskManager extends AbstractMaskManager {
 		// correct coords from top-left (OpenFL) to bottom-left (GL)
 		@:privateAccess GLBitmap.flipMatrix(m, renderSession.renderer.viewPort.height);
 		var clip = rect.clone();
-		@:privateAccess rect.__transform(rect, m);
+		@:privateAccess clip.__transform(clip, m);
 		
-		if (currentClip != null && currentClip.intersects(clip)) {
+		if (currentClip != null /*&& currentClip.intersects(clip)*/) {
 			clip = currentClip.intersection(clip);
 		}
 		
-		var restartBatch = currentClip == null || currentClip.containsRect(clip);
+		var restartBatch = currentClip == null || clip.isEmpty() || currentClip.containsRect(clip);
 		
 		clips.push(clip);
 		currentClip = clip;			
@@ -89,7 +89,7 @@ class GLMaskManager extends AbstractMaskManager {
 		renderSession.spriteBatch.stop ();
 		
 		clips.pop ();
-		currentClip = clips.pop ();
+		currentClip = clips[clips.length - 1];
 		
 		renderSession.spriteBatch.start (currentClip);
 		

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -140,7 +140,7 @@ class SpriteBatch {
 	
 	public function start(?clipRect:Rectangle = null) {
 		if (!drawing) {
-			throw "Call Spritebatch.begin() before start()";
+			stop();
 		}
 		dirty = true;
 		this.clipRect = clipRect;

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -489,10 +489,10 @@ class SpriteBatch {
 		
 		if (clipRect != null) {
 			gl.enable(gl.SCISSOR_TEST);
-			gl.scissor(Math.floor(clipRect.x), 
-						Math.floor(clipRect.y),
-						Math.floor(clipRect.width),
-						Math.floor(clipRect.height)
+			gl.scissor(Math.ceil(clipRect.x), 
+						Math.ceil(clipRect.y),
+						Math.ceil(clipRect.width),
+						Math.ceil(clipRect.height)
 					);
 		}
 		

--- a/openfl/display/Bitmap.hx
+++ b/openfl/display/Bitmap.hx
@@ -55,7 +55,7 @@ import js.html.ImageElement;
 @:access(openfl.geom.Rectangle)
 
 
-class Bitmap extends DisplayObjectContainer {
+class Bitmap extends DisplayObject {
 	
 	
 	/**
@@ -209,7 +209,9 @@ class Bitmap extends DisplayObjectContainer {
 	
 	@:noCompletion @:dox(hide) public override function __renderGL (renderSession:RenderSession):Void {
 		
+		__preRenderGL(renderSession);
 		GLBitmap.render (this, renderSession);
+		__postRenderGL(renderSession);
 		
 	}
 	

--- a/openfl/display/Bitmap.hx
+++ b/openfl/display/Bitmap.hx
@@ -55,7 +55,7 @@ import js.html.ImageElement;
 @:access(openfl.geom.Rectangle)
 
 
-class Bitmap extends DisplayObject {
+class Bitmap extends DisplayObjectContainer {
 	
 	
 	/**
@@ -208,21 +208,8 @@ class Bitmap extends DisplayObject {
 	
 	
 	@:noCompletion @:dox(hide) public override function __renderGL (renderSession:RenderSession):Void {
-		if (scrollRect != null) {
-			renderSession.spriteBatch.stop();
-			var m = __worldTransform.clone();
-			var clip = Rectangle.__temp;
-			scrollRect.__transform(clip, m);
-			clip.y = renderSession.renderer.height - clip.y - clip.height;
-			renderSession.spriteBatch.start(clip);
-		}
 		
 		GLBitmap.render (this, renderSession);
-		
-		if (scrollRect != null) {
-			renderSession.spriteBatch.stop();
-			renderSession.spriteBatch.start();
-		}
 		
 	}
 	
@@ -269,7 +256,13 @@ class Bitmap extends DisplayObject {
 		
 		if (bitmapData != null) {
 			
-			scaleY = value / bitmapData.height;
+			if (value != bitmapData.height) {
+				
+				__setTransformDirty ();
+				scaleY = value / bitmapData.height;
+				
+			}
+			
 			return value;
 			
 		}
@@ -296,7 +289,13 @@ class Bitmap extends DisplayObject {
 		
 		if (bitmapData != null) {
 			
-			scaleX = value / bitmapData.width;
+			if (value != bitmapData.width) {
+				
+				__setTransformDirty ();
+				scaleX = value / bitmapData.width;
+				
+			}
+			
 			return value;
 			
 		}

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -812,13 +812,18 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	 */
 	public function getBounds (targetCoordinateSpace:DisplayObject):Rectangle {
 		
-		var matrix = Matrix.__temp;
-		matrix.identity();
+		
+		var matrix:Matrix;
 		
 		if (targetCoordinateSpace != null) {
 			
-			matrix = matrix.clone ();
-			matrix.concat (targetCoordinateSpace.__worldTransform.clone ().invert ());
+			matrix = __getTransform().clone();
+			matrix.concat (targetCoordinateSpace.__getTransform().clone().invert());
+			
+		} else {
+			
+			matrix = Matrix.__temp;
+			matrix.identity();
 			
 		}
 		

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1220,6 +1220,14 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		
 		if (!__renderable || __worldAlpha <= 0) return;
 		
+		__preRenderGL(renderSession);
+		__drawGraphicsGL(renderSession);
+		__postRenderGL(renderSession);
+		
+	}
+	
+	@:noCompletion @:dox(hide) public inline function __drawGraphicsGL (renderSession:RenderSession):Void {
+		
 		if (__graphics != null) {
 			
 			if (#if !disable_cairo_graphics __graphics.__hardware #else true #end) {
@@ -1237,6 +1245,39 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 				GLRenderer.renderBitmap (this, renderSession);
 				
 			}
+			
+		}
+		
+	}
+	
+	@:noCompletion @:dox(hide) public inline function __preRenderGL (renderSession:RenderSession):Void {
+		
+		if (__scrollRect != null) {
+			
+			renderSession.maskManager.pushRect (__scrollRect, __renderTransform);
+			
+		}
+
+		if (__mask != null && __maskGraphics != null && __maskGraphics.__commands.length > 0) {
+			
+			renderSession.maskManager.pushMask (this);
+			
+		}
+		
+	}
+	
+	
+	@:noCompletion @:dox(hide) public inline function __postRenderGL (renderSession:RenderSession):Void {
+		
+		if (__mask != null && __maskGraphics != null && __maskGraphics.__commands.length > 0) {
+			
+			renderSession.maskManager.popMask ();
+			
+		}
+		
+		if (__scrollRect != null) {
+			
+			renderSession.maskManager.popRect ();
 			
 		}
 		

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1050,10 +1050,17 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	}
 	
 	
-	@:noCompletion private inline function __getLocalBounds (rect:Rectangle):Void {
+	@:noCompletion private inline function __getLocalBounds (rect:Rectangle, ?withLocalTransform:Bool = true):Void {
 		
-		var m = __localTransform.clone();
-		m.__translateTransformed ( -m.tx, -m.ty);
+		var m:Matrix;
+		if (withLocalTransform) {
+			m = __localTransform.clone();
+			m.__translateTransformed ( -m.tx, -m.ty);
+		} else { 
+			m = Matrix.__temp;
+			m.identity();
+		}
+		
 		__getBounds (rect, m);
 		
 	}
@@ -1579,7 +1586,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	@:noCompletion private function set_height (value:Float):Float {
 		
 		var bounds = new Rectangle ();
-		__getLocalBounds (bounds);
+		__getLocalBounds (bounds, false);
 		
 		if (value != bounds.height) {
 			
@@ -1882,7 +1889,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	@:noCompletion private function set_width (value:Float):Float {
 		
 		var bounds = new Rectangle ();
-		__getLocalBounds (bounds);
+		__getLocalBounds (bounds, false);
 		
 		if (value != bounds.width) {
 			

--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -1000,40 +1000,17 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (!__renderable || __worldAlpha <= 0) return;
 		
-		if (scrollRect != null) {
-			
-			renderSession.maskManager.pushRect (scrollRect, __renderTransform);
-			
-		}
+		__preRenderGL(renderSession);
 		
-		
-		var masked = __mask != null && __maskGraphics != null && __maskGraphics.__commands.length > 0;
-		
-		if (masked) {
-			
-			renderSession.maskManager.pushMask (this);
-			
-		}
-		
-		super.__renderGL (renderSession);
+		__drawGraphicsGL(renderSession);
 		
 		for (child in __children) {
 			
 			child.__renderGL (renderSession);
 			
 		}
-		
-		if (masked) {
-			
-			renderSession.maskManager.popMask ();
-			
-		}
-		
-		if (scrollRect != null) {
-			
-			renderSession.maskManager.popRect ();
-			
-		}
+
+		__postRenderGL(renderSession);
 		
 		if (__removedChildren.length > 0) {
 			

--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -167,6 +167,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			var event = new Event (Event.ADDED, true);
 			event.target = child;
 			child.__dispatchEvent (event);
+			__setRenderDirty();
 			
 		}
 		
@@ -238,6 +239,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			var event = new Event (Event.ADDED, true);
 			event.target = child;
 			child.__dispatchEvent (event);
+			__setRenderDirty();
 			
 		}
 		
@@ -444,6 +446,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			child.__setTransformDirty ();
 			child.__setRenderDirty ();
 			child.__dispatchEvent (new Event (Event.REMOVED, true));
+			__setRenderDirty();
 			
 		}
 		
@@ -681,8 +684,10 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (matrix != null) {
 			
-			matrixCache = __worldTransform;
-			__worldTransform = matrix;
+			matrix = matrix.clone();
+			//matrixCache = __worldTransform;
+			//__worldTransform = matrix;
+			__updateTransforms (matrix);
 			__updateChildren (true);
 			
 		}
@@ -696,7 +701,8 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (matrix != null) {
 			
-			__worldTransform = matrixCache;
+			//__worldTransform = matrixCache;
+			__updateTransforms();
 			__updateChildren (true);
 			
 		}
@@ -841,7 +847,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (scrollRect != null) {
 			
-			renderSession.maskManager.popMask ();
+			renderSession.maskManager.popRect ();
 			
 		}
 		
@@ -910,7 +916,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (scrollRect != null) {
 			
-			renderSession.maskManager.popMask ();
+			renderSession.maskManager.popRect ();
 			
 		}
 		
@@ -995,13 +1001,9 @@ class DisplayObjectContainer extends InteractiveObject {
 		if (!__renderable || __worldAlpha <= 0) return;
 		
 		if (scrollRect != null) {
-			renderSession.spriteBatch.stop();
-			var m = __worldTransform.clone();
-			var clip = Rectangle.__temp;
-			scrollRect.__transform(clip, m);
-			clip.y = renderSession.renderer.height - clip.y - clip.height;
 			
-			renderSession.spriteBatch.start(clip);
+			renderSession.maskManager.pushRect (scrollRect, __renderTransform);
+			
 		}
 		
 		
@@ -1009,9 +1011,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (masked) {
 			
-			renderSession.spriteBatch.stop ();
 			renderSession.maskManager.pushMask (this);
-			renderSession.spriteBatch.start ();
 			
 		}
 		
@@ -1025,16 +1025,14 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (masked) {
 			
-			renderSession.spriteBatch.stop ();
-			//renderSession.maskManager.popMask (this);
 			renderSession.maskManager.popMask ();
-			renderSession.spriteBatch.start ();
 			
 		}
 		
 		if (scrollRect != null) {
-			renderSession.spriteBatch.stop();
-			renderSession.spriteBatch.start();
+			
+			renderSession.maskManager.popRect ();
+			
 		}
 		
 		if (__removedChildren.length > 0) {

--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -1039,6 +1039,8 @@ class Stage extends DisplayObjectContainer implements IModule {
 		
 		var event = new Event (Event.RESIZE);
 		__broadcast (event, false);
+		// Flash dispatchs the resize event at every little change, with a minumum of 2 events when maximizing. So let's dispatch the event again.
+		__broadcast (event, false);
 		
 	}
 	

--- a/openfl/geom/Transform.hx
+++ b/openfl/geom/Transform.hx
@@ -188,7 +188,7 @@ class Transform {
 		
 		if (__hasMatrix) {
 			
-			return __displayObject.__transform.clone ();
+			return __displayObject.__localTransform.clone ();
 			
 		}
 		
@@ -222,7 +222,7 @@ class Transform {
 				
 			}
 			
-			__displayObject.__transform.copyFrom (value);
+			__displayObject.__localTransform.copyFrom (value);
 			__displayObject.__setTransformDirty ();
 			
 		}
@@ -236,7 +236,7 @@ class Transform {
 		
 		if (__hasMatrix3D) {
 			
-			var matrix = __displayObject.__transform;
+			var matrix = __displayObject.__localTransform;
 			return new Matrix3D ([ matrix.a, matrix.b, 0.0, 0.0, matrix.c, matrix.d, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, matrix.tx, matrix.ty, 0.0, 1.0 ]);
 			
 		}
@@ -271,12 +271,12 @@ class Transform {
 				
 			}
 			
-			__displayObject.__transform.a = value.rawData[0];
-			__displayObject.__transform.b = value.rawData[1];
-			__displayObject.__transform.c = value.rawData[5];
-			__displayObject.__transform.d = value.rawData[6];
-			__displayObject.__transform.tx = value.rawData[12];
-			__displayObject.__transform.ty = value.rawData[13];
+			__displayObject.__localTransform.a = value.rawData[0];
+			__displayObject.__localTransform.b = value.rawData[1];
+			__displayObject.__localTransform.c = value.rawData[5];
+			__displayObject.__localTransform.d = value.rawData[6];
+			__displayObject.__localTransform.tx = value.rawData[12];
+			__displayObject.__localTransform.ty = value.rawData[13];
 			
 			__displayObject.__setTransformDirty ();
 			

--- a/openfl/geom/Transform.hx
+++ b/openfl/geom/Transform.hx
@@ -94,7 +94,7 @@ class Transform {
 	 * window coordinates, which may not be the same coordinate space as that of
 	 * the Stage.
 	 */
-	public var concatenatedMatrix:Matrix;
+	public var concatenatedMatrix(get, never):Matrix;
 	
 	/**
 	 * A Matrix object containing values that alter the scaling, rotation, and
@@ -140,7 +140,6 @@ class Transform {
 		
 		__colorTransform = new ColorTransform ();
 		concatenatedColorTransform = new ColorTransform ();
-		concatenatedMatrix = new Matrix ();
 		pixelBounds = new Rectangle ();
 		
 		__displayObject = displayObject;
@@ -189,6 +188,19 @@ class Transform {
 		if (__hasMatrix) {
 			
 			return __displayObject.__localTransform.clone ();
+			
+		}
+		
+		return null;
+		
+	}
+	
+
+	@:noCompletion private function get_concatenatedMatrix ():Matrix {
+		
+		if (__hasMatrix) {
+			
+			return __displayObject.__getTransform().clone();
 			
 		}
 		

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -1353,6 +1353,8 @@ class TextField extends InteractiveObject {
 	
 	@:noCompletion @:dox(hide) public override function __renderGL (renderSession:RenderSession):Void {
 		
+		__preRenderGL(renderSession);
+		
 		#if !disable_cairo_graphics
 		
 		#if lime_cairo
@@ -1368,6 +1370,8 @@ class TextField extends InteractiveObject {
 		//GLTextField.render (this, renderSession);
 		
 		#end
+		
+		__postRenderGL(renderSession);
 		
 	}
 	

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -187,7 +187,8 @@ class ApplicationMain {
 			
 		}
 		
-		openfl.Lib.current.stage.dispatchEvent (new openfl.events.Event (openfl.events.Event.RESIZE, false, false));
+		// TODO Why is this here?
+		//openfl.Lib.current.stage.dispatchEvent (new openfl.events.Event (openfl.events.Event.RESIZE, false, false));
 		
 	}
 	


### PR DESCRIPTION
Here we go again. This PR brings back:
- Correct bounds calculations with `width` and `height`, mostly... If you check the test you will see that some `getBounds()` calls give different results, I'm not sure why :confused: More tests in the old PR https://github.com/openfl/openfl/pull/736 . 
- Removed ApplicationMain.hx RESIZE event. I'm not sure why there is a RESIZE event there, it shouldn't be.
- `stage.onWindowResized()` fires two `RESIZE` events. Flash fires multiple `RESIZE` events while resizing the window but OpenFL does not. Same when maximizing the window, if Flash it fires two events while OpenFL only fires one. These two events are needed, check `test2()`
- `ScrollRect` support for OpenGL / webGL. It still suffers the same problem described here https://github.com/openfl/openfl/pull/736#issuecomment-119740030 I haven't touched canvas or anything else... I will leave it to someone else.
- Added `Transform.concatenatedMatrix`

As always, this changes a lot of stuff and it's really hard for me to be testing every little thing Flash has. Expect some bugs and errors.

Tests:
```haxe
package tests;
import openfl.Assets;
import openfl.display.Bitmap;
import openfl.display.Shape;
import openfl.display.Sprite;
import openfl.events.Event;
import openfl.geom.ColorTransform;
import openfl.geom.Rectangle;
import openfl.text.TextField;
import openfl.text.TextFormat;

/**
 * ...
 * @author MrCdK
 */
class SRTest extends Sprite
{

	public function new() 
	{
		super();
		addEventListener(Event.ADDED_TO_STAGE, test1);
	}
	
    function test1(_) {
        var bd1 = Assets.getBitmapData("assets/openfl.png", false);
        var bd2 = Assets.getBitmapData("assets/openfl.png", false);
        bd2.colorTransform(bd2.rect, new ColorTransform(1, 1, 0.5));

        var parent = new Sprite();
        var child = new Sprite();

        this.addChild(parent);
        parent.addChild(new Bitmap(bd1));
        parent.addChild(child);

        child.addChild(new Bitmap(bd2));
        parent.rotation = 10;
        parent.scaleX   = 1.2;
        child.scaleX    = 0.5;  

        trace("Before moving child");
        trace("\tParent data: (w, h, bounds)", parent.width, parent.height, parent.getBounds(null));
        trace("\tChild  data: (w, h, bounds)", child.width,  child.height,  child.getBounds(null) );
        child.x = parent.width - 100;
        child.y = parent.height - 100;
        trace("After moving child");
        trace("\tParent data: (w, h, bounds)", parent.width, parent.height, parent.getBounds(null));
        trace("\tChild  data: (w, h, bounds)", child.width,  child.height,  child.getBounds(null) );
		
		trace("MORE BOUNDS");
		trace("parent.getBounds(child): " + parent.getBounds(child));
		trace("child.getBounds(parent): " + child.getBounds(parent));
		trace("parent.getBounds(this): " + parent.getBounds(this));
		trace("child.getBounds(this): " + child.getBounds(this));
		trace("this.getBounds(parent): " + this.getBounds(parent));
		trace("this.getBounds(child): " + this.getBounds(child));
		
		var this_world = this.transform.concatenatedMatrix;
		var parent_world = parent.transform.concatenatedMatrix;
		var child_world = child.transform.concatenatedMatrix;
		var this_world_i = this_world.clone();
		var parent_world_i = parent_world.clone();
		var child_world_i = child_world.clone();
		
		this_world_i.invert();
		parent_world_i.invert();
		child_world_i.invert();
		
		trace("This world: " + this_world, this_world_i);
		trace("Parent world: " + parent_world, parent_world_i);
		trace("Child world: " + child_world, child_world_i);
		
		/*		
		
		There are differences in "parent.getBounds(this)" and "this.getBounds(***)" I can't really explain.
		
		FLASH:
			SRTest.hx:40: Before moving child
			SRTest.hx:41: 	Parent data: (w, h, bounds),693.95,610.9,(x=0, y=0, w=512, h=512)
			SRTest.hx:42: 	Child  data: (w, h, bounds),256,512,(x=0, y=0, w=512, h=512)
			SRTest.hx:45: After moving child
			SRTest.hx:46: 	Parent data: (w, h, bounds),992.4,1253.8,(x=0, y=0, w=849.95, h=1093.3)
			SRTest.hx:47: 	Child  data: (w, h, bounds),256,512,(x=0, y=0, w=512, h=512)
			SRTest.hx:49: MORE BOUNDS
			SRTest.hx:50: parent.getBounds(child): (x=-1187.9, y=-581.3, w=1699.9, h=1093.3)
			SRTest.hx:51: child.getBounds(parent): (x=593.95, y=581.3, w=256, h=512)
			SRTest.hx:52: parent.getBounds(this): (x=-189.85, y=0, w=1194.3, h=1253.8)
			SRTest.hx:53: child.getBounds(this): (x=512.05, y=696.25, w=391.45000000000005, h=557.55)
			SRTest.hx:54: this.getBounds(parent): (x=-72.95, y=-156.9, w=995.85, h=1407.1000000000001)
			SRTest.hx:55: this.getBounds(child): (x=-1333.8, y=-738.2, w=1991.75, h=1407.1)
			SRTest.hx:68: This world: (a=1, b=0, c=0, d=1, tx=0, ty=0),(a=1, b=0, c=0, d=1, tx=0, ty=0)
			SRTest.hx:69: Parent world: (a=1.1817626953125, b=0.2083740234375, c=-0.17364501953125, d=0.98480224609375, tx=0, ty=0),(a=0.8206783400032348, b=-0.17364709344722923, c=0.14470591120602436, d=0.9848140080038817, tx=0, ty=0)
			SRTest.hx:70: Child world: (a=0.59088134765625, b=0.10418701171875, c=-0.17364501953125, d=0.98480224609375, tx=601, ty=696.25),(a=1.6413566800064696, b=-0.17364709344722923, c=0.2894118224120487, d=0.9848140080038817, tx=-1187.958346038277, ty=-581.3148499109179)
		NEKO:
			SRTest.hx:40: Before moving child
			SRTest.hx:41: 	Parent data: (w, h, bounds),693.973750416169,610.911009900812,(x=0, y=0, width=512, height=512)
			SRTest.hx:42: 	Child  data: (w, h, bounds),256,512,(x=0, y=0, width=512, height=512)
			SRTest.hx:45: After moving child
			SRTest.hx:46: 	Parent data: (w, h, bounds),992.432601587815,1253.84266291585,(x=0, y=0, width=849.973750416169, height=1093.33724093164)
			SRTest.hx:47: 	Child  data: (w, h, bounds),256,512,(x=0, y=0, width=512, height=512)
			SRTest.hx:49: MORE BOUNDS
			SRTest.hx:50: parent.getBounds(child): (x=-1187.94750083234, y=-581.337240931643, width=1699.94750083234, height=1093.33724093164)
			SRTest.hx:51: child.getBounds(parent): (x=593.973750416169, y=581.337240931643, width=256, height=512)
			SRTest.hx:52: parent.getBounds(this): (x=-88.9078669654683, y=0, width=992.432601587815, height=1253.84266291585)
			SRTest.hx:53: child.getBounds(this): (x=512.083925931528, y=696.27637319432, width=391.440808690819, height=557.566289721531)
			SRTest.hx:54: this.getBounds(parent): (x=-1.4210854715202e-014, y=0, width=849.973750416169, height=1093.33724093164)
			SRTest.hx:55: this.getBounds(child): (x=-1187.94750083234, y=-581.337240931643, width=1699.94750083234, height=1093.33724093164)
			SRTest.hx:68: This world: matrix(1, 0, 0, 1, 0, 0),matrix(1, -0, -0, 1, 0, 0)
			SRTest.hx:69: Parent world: matrix(1.18176930361465, 0.208377813200316, -0.17364817766693, 0.984807753012208, 0, 0),matrix(0.820673127510174, -0.17364817766693, 0.144706814722442, 0.984807753012208, -0, 0)
			SRTest.hx:70: Child world: matrix(0.590884651807325, 0.104188906600158, -0.17364817766693, 0.984807753012208, 600.991792896996, 696.27637319432),matrix(1.64134625502035, -0.17364817766693, 0.289413629444884, 0.984807753012208, -1187.94750083234, -581.337240931643)

		
		*/
    }
	
	function test2(_) {
		var bd1 = Assets.getBitmapData("assets/openfl.png", false);
		
		var bitmap1 = new Bitmap(bd1);
		bitmap1.x = 100;
		bitmap1.y = 100;
		addChild(bitmap1);
		
		var resize_calls = 0;
		function resize(_) {
			
			trace('RESIZE CALL ${resize_calls++}');
			trace('- BEFORE:\n\tscale x, y : $scaleX, $scaleY\n\twidth, height : $width, $height\n\tStage width, height : ${stage.stageWidth}, ${stage.stageHeight}');
			this.scaleX = stage.stageWidth / this.width;
			this.scaleY = stage.stageHeight / this.height;
			trace('- AFTER:\n\tscale x, y : $scaleX, $scaleY\n\twidth, height : $width, $height\n\tStage width, height : ${stage.stageWidth}, ${stage.stageHeight}');
			
		}
		stage.addEventListener(Event.RESIZE, resize);
		/*
		Values when maximizing the window.
		The scaleY/height differences are caused by the menu bar of the flash player
		
		FLASH:
			SRTest.hx:123: RESIZE CALL 0
			SRTest.hx:124: - BEFORE:
				scale x, y : 1, 1
				width, height : 512, 512
				Stage width, height : 1920, 1008
			SRTest.hx:127: - AFTER:
				scale x, y : 3.75, 1.96875
				width, height : 1920, 1008
				Stage width, height : 1920, 1008
			SRTest.hx:123: RESIZE CALL 1
			SRTest.hx:124: - BEFORE:
				scale x, y : 3.75, 1.96875
				width, height : 1920, 1008
				Stage width, height : 1920, 1008
			SRTest.hx:127: - AFTER:
				scale x, y : 1, 1
				width, height : 512, 512
				Stage width, height : 1920, 1008
				
		NEKO:
			SRTest.hx:123: RESIZE CALL 0
			SRTest.hx:124: - BEFORE:
				scale x, y : 1, 1
				width, height : 512, 512
				Stage width, height : 1920, 1028
			SRTest.hx:127: - AFTER:
				scale x, y : 3.75, 2.0078125
				width, height : 1920, 1028
				Stage width, height : 1920, 1028
			SRTest.hx:123: RESIZE CALL 1
			SRTest.hx:124: - BEFORE:
				scale x, y : 3.75, 2.0078125
				width, height : 1920, 1028
				Stage width, height : 1920, 1028
			SRTest.hx:127: - AFTER:
				scale x, y : 1, 1
				width, height : 512, 512
				Stage width, height : 1920, 1028
		
		*/
	}

	function test3(_) {
		var container:Sprite = new Sprite();
		container.x = 100;
		container.y = 100;
		this.addChild(container);
		var contents = new Bitmap(Assets.getBitmapData("assets/openfl.png", false));
		container.addChild(contents);
		// (x=0, y=0, w=512, h=512)
		trace(contents.getBounds(container));
		// (x=100, y=100, w=512, h=512)
		trace(contents.getBounds(this));
		
	}
	
	function test4(_) {
		var container:Sprite = new Sprite();
		container.x = 100;
		container.y = 100;
		this.addChild(container);
		var contents:Shape = new Shape();
		contents.graphics.drawCircle(0,0,100);
		container.addChild(contents);
		// (x=-100, y=-100, w=200, h=200)
		trace(contents.getBounds(container));
		// (x=0, y=0, w=200, h=200)
		trace(contents.getBounds(this));
	}

	function test5(_) {
		var bd1 = Assets.getBitmapData("assets/openfl.png", false);
		
		var bitmap1 = new Bitmap(bd1);
		bitmap1.x = 100;
		bitmap1.y = 100;
		addChild(bitmap1);
		bitmap1.scrollRect = new Rectangle(100, -100, 300, 300);
	}
	
	function test6(_) {
		var bd1 = Assets.getBitmapData("assets/openfl.png", false);
		var bd2 = Assets.getBitmapData("assets/openfl.png", false);
		var bd3 = Assets.getBitmapData("assets/openfl.png", false);
		bd2.colorTransform(bd2.rect, new ColorTransform(1, 1, 0.5));
		bd3.colorTransform(bd2.rect, new ColorTransform(1, 0.5, 1));
		
		var bitmap1 = new Bitmap(bd1);
		var bitmap2 = new Bitmap(bd2);
		var bitmap3 = new Bitmap(bd3);
		var parent = new Sprite();
		var child1 = new Sprite();
		var child2 = new Sprite();
		var shape = new Shape();
		var text = new TextField();
		
		addChild(parent);
		parent.addChild(bitmap1);
		parent.addChild(child1);
		parent.addChild(child2);
		parent.addChild(shape);
		parent.addChild(text);
		child1.addChild(bitmap2);
		child2.addChild(bitmap3);
		
		
		parent.x = 100;
		parent.scrollRect = new Rectangle(0, -512, 400, 512);
		
		child1.y = 10;
		child1.x = 10;
		child1.scrollRect = new Rectangle(100, 100, 380, 200);
		
		child2.y = 220;
		child2.x = 10;
		child2.scrollRect = new Rectangle(120, 120, 380, 200);
		
		shape.y = 110;
		shape.graphics.beginFill(0);
		shape.graphics.drawCircle(100, 100, 100);
		shape.scrollRect = new Rectangle(0, 50, 200, 100);
		
		var format = new TextFormat();
		format.size = 20;
		text.x = 10;
		text.y = 40;
		text.defaultTextFormat = format;
		text.text = "Hello World";
		text.scrollRect = new Rectangle(10, 10, 200, 200);
		
		stage.addEventListener(Event.ENTER_FRAME, function(_) {
			var sr = parent.scrollRect;
			if (sr.y >= 0) return;
			sr.offset(0, 1);
			parent.scrollRect = sr; 
		});
		
	}
	
}
```