### PR TITLE
Remove created OpenGL resources from list to avoid memory leak

### DIFF
--- a/openfl/display3D/Context3D.hx
+++ b/openfl/display3D/Context3D.hx
@@ -133,7 +133,7 @@ import openfl.Lib;
 	
 	public function createCubeTexture (size:Int, format:Context3DTextureFormat, optimizeForRenderToTexture:Bool, streamingLevels:Int = 0):CubeTexture {
 		
-		var texture = new CubeTexture (GL.createTexture (), size); // TODO use format, optimizeForRenderToTexture and streamingLevels?
+		var texture = new CubeTexture (this, GL.createTexture (), size); // TODO use format, optimizeForRenderToTexture and streamingLevels?
 		texturesCreated.push (texture);
 		return texture;
 		
@@ -142,7 +142,7 @@ import openfl.Lib;
 	
 	public function createIndexBuffer (numIndices:Int):IndexBuffer3D {
 		
-		var indexBuffer = new IndexBuffer3D (GL.createBuffer (), numIndices);
+		var indexBuffer = new IndexBuffer3D (this, GL.createBuffer (), numIndices);
 		indexBuffersCreated.push (indexBuffer);
 		return indexBuffer;
 		
@@ -151,7 +151,7 @@ import openfl.Lib;
 	
 	public function createProgram ():Program3D {
 		
-		var program = new Program3D (GL.createProgram ());
+		var program = new Program3D (this, GL.createProgram ());
 		programsCreated.push (program);
 		return program;
 		
@@ -160,7 +160,7 @@ import openfl.Lib;
 	
 	public function createRectangleTexture (width:Int, height:Int, format:Context3DTextureFormat, optimizeForRenderToTexture:Bool):RectangleTexture {
 		
-		var texture = new RectangleTexture (GL.createTexture (), optimizeForRenderToTexture, width, height); // TODO use format, optimizeForRenderToTexture and streamingLevels?
+		var texture = new RectangleTexture (this, GL.createTexture (), optimizeForRenderToTexture, width, height); // TODO use format, optimizeForRenderToTexture and streamingLevels?
 		texturesCreated.push (texture);
 		return texture;
 		
@@ -169,7 +169,7 @@ import openfl.Lib;
 	
 	public function createTexture (width:Int, height:Int, format:Context3DTextureFormat, optimizeForRenderToTexture:Bool, streamingLevels:Int = 0):Texture {
 		
-		var texture = new Texture (GL.createTexture (), optimizeForRenderToTexture, width, height); // TODO use format, optimizeForRenderToTexture and streamingLevels?
+		var texture = new Texture (this, GL.createTexture (), optimizeForRenderToTexture, width, height); // TODO use format, optimizeForRenderToTexture and streamingLevels?
 		texturesCreated.push (texture);
 		return texture;
 		
@@ -178,9 +178,57 @@ import openfl.Lib;
 	
 	public function createVertexBuffer (numVertices:Int, data32PerVertex:Int):VertexBuffer3D {
 		
-		var vertexBuffer = new VertexBuffer3D (GL.createBuffer (), numVertices, data32PerVertex);
+		var vertexBuffer = new VertexBuffer3D (this, GL.createBuffer (), numVertices, data32PerVertex);
 		vertexBuffersCreated.push (vertexBuffer);
 		return vertexBuffer;
+		
+	}
+	
+	
+	@:noCompletion public function __deleteTexture (texture:TextureBase):Void
+	{
+		
+		if (texture.glTexture == null)
+			return;
+		texturesCreated.remove (texture);
+		GL.deleteTexture (texture.glTexture);
+		texture.glTexture = null;
+		
+	}
+	
+	
+	@:noCompletion public function __deleteVertexBuffer (buffer:VertexBuffer3D):Void
+	{
+		
+		if (buffer.glBuffer == null)
+			return;
+		vertexBuffersCreated.remove (buffer);
+		GL.deleteBuffer (buffer.glBuffer);
+		buffer.glBuffer = null;
+		
+	}
+	
+	
+	@:noCompletion public function __deleteIndexBuffer (buffer:IndexBuffer3D):Void
+	{
+		
+		if (buffer.glBuffer == null)
+			return;
+		indexBuffersCreated.remove (buffer);
+		GL.deleteBuffer (buffer.glBuffer);
+		buffer.glBuffer = null;
+		
+	}
+	
+	
+	@:noCompletion public function __deleteProgram (program:Program3D):Void
+	{
+		
+		if (program.glProgram == null)
+			return;
+		programsCreated.remove (program);
+		GL.deleteProgram (program.glProgram);
+		program.glProgram = null;
 		
 	}
 	

--- a/openfl/display3D/IndexBuffer3D.hx
+++ b/openfl/display3D/IndexBuffer3D.hx
@@ -10,13 +10,14 @@ import openfl.Vector;
 
 @:final class IndexBuffer3D {
 	
-	
+	public var context:Context3D;
 	public var glBuffer:GLBuffer;
 	public var numIndices:Int;
 	
 	
-	public function new (glBuffer:GLBuffer, numIndices:Int) {
+	public function new (context:Context3D, glBuffer:GLBuffer, numIndices:Int) {
 		
+		this.context = context;
 		this.glBuffer = glBuffer;
 		this.numIndices = numIndices;
 		
@@ -25,7 +26,7 @@ import openfl.Vector;
 	
 	public function dispose ():Void {
 		
-		GL.deleteBuffer (glBuffer);
+		context.__deleteIndexBuffer (this);
 		
 	}
 	

--- a/openfl/display3D/Program3D.hx
+++ b/openfl/display3D/Program3D.hx
@@ -8,12 +8,13 @@ import openfl.gl.GLShader;
 
 @:final class Program3D {
 	
-	
+	public var context:Context3D;
 	public var glProgram:GLProgram;
 	
 	
-	public function new (program:GLProgram) {
+	public function new (context:Context3D, program:GLProgram) {
 		
+		this.context = context;
 		this.glProgram = program;
 		
 	}
@@ -21,7 +22,7 @@ import openfl.gl.GLShader;
 	
 	public function dispose ():Void {
 		
-		GL.deleteProgram (glProgram);
+		context.__deleteProgram (this);
 		
 	}
 	

--- a/openfl/display3D/VertexBuffer3D.hx
+++ b/openfl/display3D/VertexBuffer3D.hx
@@ -9,14 +9,15 @@ import openfl.Vector;
 
 class VertexBuffer3D {
 	
-	
+	public var context:Context3D;
 	public var data32PerVertex:Int;
 	public var glBuffer:GLBuffer;
 	public var numVertices:Int;
 	
 	
-	public function new (glBuffer:GLBuffer, numVertices:Int, data32PerVertex:Int) {
+	public function new (context:Context3D, glBuffer:GLBuffer, numVertices:Int, data32PerVertex:Int) {
 		
+		this.context = context;
 		this.glBuffer = glBuffer;
 		this.numVertices = numVertices;
 		this.data32PerVertex = data32PerVertex;
@@ -26,7 +27,7 @@ class VertexBuffer3D {
 	
 	public function dispose ():Void {
 		
-		GL.deleteBuffer (glBuffer);
+		context.__deleteVertexBuffer (this);
 		
 	}
 	

--- a/openfl/display3D/textures/CubeTexture.hx
+++ b/openfl/display3D/textures/CubeTexture.hx
@@ -1,6 +1,7 @@
 package openfl.display3D.textures; #if !flash
 
 
+import openfl.display3D.Context3D;
 import openfl.gl.GL;
 import openfl.gl.GLTexture;
 import openfl.geom.Rectangle;
@@ -18,9 +19,9 @@ using openfl.display.BitmapData;
 	public var mipmapsGenerated:Bool;
 	
 	
-	public function new (glTexture:GLTexture, size:Int) {
+	public function new (context:Context3D, glTexture:GLTexture, size:Int) {
 		
-		super (glTexture, size, size);
+		super (context, glTexture, size, size);
 		this.size = size;
 		this.mipmapsGenerated = false;
 		

--- a/openfl/display3D/textures/RectangleTexture.hx
+++ b/openfl/display3D/textures/RectangleTexture.hx
@@ -2,6 +2,7 @@ package openfl.display3D.textures; #if !flash
 
 
 import openfl.display.BitmapData;
+import openfl.display3D.Context3D;
 import openfl.gl.GL;
 import openfl.gl.GLTexture;
 import openfl.geom.Rectangle;
@@ -15,7 +16,7 @@ import openfl.utils.UInt8Array;
 	public var optimizeForRenderToTexture:Bool;
 	
 	
-	public function new (glTexture:GLTexture, optimize:Bool, width:Int, height:Int) {
+	public function new (context:Context3D, glTexture:GLTexture, optimize:Bool, width:Int, height:Int) {
 		
 		optimizeForRenderToTexture = optimize;
 		
@@ -23,7 +24,7 @@ import openfl.utils.UInt8Array;
 		if (optimizeForRenderToTexture == null) optimizeForRenderToTexture = false;
 		#end
 		
-		super (glTexture, width, height);
+		super (context, glTexture, width, height);
 		
 		#if (cpp || neko || nodejs)
 		if (optimizeForRenderToTexture)

--- a/openfl/display3D/textures/Texture.hx
+++ b/openfl/display3D/textures/Texture.hx
@@ -1,6 +1,7 @@
 package openfl.display3D.textures; #if !flash
 
 
+import openfl.display3D.Context3D;
 import openfl.gl.GL;
 import openfl.gl.GLTexture;
 import openfl.gl.GLFramebuffer;
@@ -19,7 +20,7 @@ using openfl.display.BitmapData;
 	
 	public var mipmapsGenerated:Bool;
 	
-	public function new (glTexture:GLTexture, optimize:Bool, width:Int, height:Int) {
+	public function new (context:Context3D, glTexture:GLTexture, optimize:Bool, width:Int, height:Int) {
 		
 		optimizeForRenderToTexture = optimize;
 
@@ -29,7 +30,7 @@ using openfl.display.BitmapData;
 		if (optimizeForRenderToTexture == null) optimizeForRenderToTexture = false;
 		#end
 		
-		super (glTexture, width, height);
+		super (context, glTexture, width, height);
 		
 		#if (cpp || neko || nodejs)
 		if (optimizeForRenderToTexture) { 

--- a/openfl/display3D/textures/TextureBase.hx
+++ b/openfl/display3D/textures/TextureBase.hx
@@ -9,17 +9,18 @@ import openfl.events.EventDispatcher;
 
 class TextureBase extends EventDispatcher {
 	
-	
+	public var context:Context3D;
 	public var height:Int;
 	public var frameBuffer:GLFramebuffer;
 	public var glTexture:GLTexture;
 	public var width:Int;
 	
 	
-	public function new (glTexture:GLTexture, width:Int = 0, height:Int = 0) {
+	public function new (context:Context3D, glTexture:GLTexture, width:Int = 0, height:Int = 0) {
 		
 		super ();
 		
+		this.context = context;
 		this.width = width;
 		this.height = height;
 		this.glTexture = glTexture;
@@ -29,7 +30,7 @@ class TextureBase extends EventDispatcher {
 	
 	public function dispose ():Void {
 		
-		GL.deleteTexture (glTexture);
+		context.__deleteTexture (this);
 		
 	}
 	


### PR DESCRIPTION
Currently, textures, vertex/index buffers, shader programs created by Context3D is not removed from list when they get disposed. This will slowly lead to memory leak if you create/dispose textures or buffers many times.

Using Array's remove method is not best for performance as it does linear search and creates new array, but I left it untouched for now.