### PR TITLE
Reduce "flickering" with SimpleButton that only has an upState.

### DIFF
--- a/openfl/display/SimpleButton.hx
+++ b/openfl/display/SimpleButton.hx
@@ -131,9 +131,10 @@ class SimpleButton extends DisplayObjectContainer {
 		mouseChildren = false;
 		
 		this.upState = (upState != null) ? upState : __generateDefaultState ();
-		this.overState = (overState != null) ? overState : __generateDefaultState ();
-		this.downState = (downState != null) ? downState : __generateDefaultState ();
-		this.hitTestState = (hitTestState != null) ? hitTestState : __generateDefaultState ();
+		// NOTE (tienery): Over and down states can be null, check them in event handling later
+		this.overState = overState;
+		this.downState = downState;
+		this.hitTestState = (hitTestState != null) ? hitTestState : generateDefaultState ();
 		
 		__currentState = this.upState;
 		
@@ -276,7 +277,8 @@ class SimpleButton extends DisplayObjectContainer {
 	
 	@:noCompletion private function __this_onMouseDown (event:MouseEvent):Void {
 		
-		__currentState = downState;
+		if (downState != null)
+			__currentState = downState;
 		
 	}
 	
@@ -294,7 +296,7 @@ class SimpleButton extends DisplayObjectContainer {
 	
 	@:noCompletion private function __this_onMouseOver (event:MouseEvent):Void {
 		
-		if (overState != __currentState) {
+		if (overState != __currentState && overState != null) {
 			
 			__currentState = overState;
 			
@@ -304,8 +306,11 @@ class SimpleButton extends DisplayObjectContainer {
 	
 	
 	@:noCompletion private function __this_onMouseUp (event:MouseEvent):Void {
-		
-		__currentState = overState;
+	
+		if (overState != null)
+			__currentState = overState;
+		else
+			__currentState = upState;
 		
 	}
 	

--- a/openfl/display/SimpleButton.hx
+++ b/openfl/display/SimpleButton.hx
@@ -134,7 +134,7 @@ class SimpleButton extends DisplayObjectContainer {
 		// NOTE (tienery): Over and down states can be null, check them in event handling later
 		this.overState = overState;
 		this.downState = downState;
-		this.hitTestState = (hitTestState != null) ? hitTestState : generateDefaultState ();
+		this.hitTestState = (hitTestState != null) ? hitTestState : __generateDefaultState ();
 		
 		__currentState = this.upState;
 		


### PR DESCRIPTION
The use of the `SimpleButton` class should also be used with an upState, and over and down states should be assumed null if only that parameter is given. This should reduce flickering whenever hovering over/pressing down on the button.