### PR TITLE
Fix issue #867

### DIFF
--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -403,7 +403,6 @@ class DisplayObjectContainer extends InteractiveObject {
 	 */
 	public function getObjectsUnderPoint (point:Point):Array<DisplayObject> {
 		
-		point = localToGlobal (point);
 		var stack = new Array<DisplayObject> ();
 		__hitTest (point.x, point.y, false, stack, false);
 		stack.reverse ();


### PR DESCRIPTION
The documentation for `getObjectsUnderPoint()` states that the `point` parameter is in Stage coordinates, so the call to `localToGlobal()` is incorrect.