### PR TITLE
Use the full request url in case it includes url variables.

### DIFF
--- a/openfl/display/Loader.hx
+++ b/openfl/display/Loader.hx
@@ -429,16 +429,7 @@ class Loader extends Sprite {
 		
 		worker.doWork.add (function (_) {
 			
-			var path = request.url;
-			var index = path.indexOf ("?");
-			
-			if (index > -1) {
-				
-				path = path.substring (0, index);
-				
-			}
-			
-			BitmapData.fromFile (path, function (bitmapData) worker.sendComplete (bitmapData), function () worker.sendError (IOErrorEvent.IO_ERROR));
+			BitmapData.fromFile (request.url, function (bitmapData) worker.sendComplete (bitmapData), function () worker.sendError (IOErrorEvent.IO_ERROR));
 			
 		});
 		


### PR DESCRIPTION
Test case: https://gist.github.com/bmfs/ba27868115055c3c093e

In Flash it works properly
In HTML5, the Loader class strips the request url from any URL variables.

(In the native target, the test case won't work. However that is due to the curl request no having the followlocation flag set to true)