### PR TITLE
Set precision only on OpenGL ES

### DIFF
--- a/openfl/_internal/aglsl/AGLSLParser.hx
+++ b/openfl/_internal/aglsl/AGLSLParser.hx
@@ -16,13 +16,14 @@ class AGLSLParser {
 	
 	public function parse (desc:Description):String {
 		
-		var header:String = "";
+		var header:String;
 		var body:String = "";
 		var i:Int = 0;
 		
-		#if !desktop
-		header += "precision " + ( desc.header.type == "vertex" ? "highp" : "mediump" ) + " float;\n";
-		#end
+		header = ""
+			+ "#ifdef GL_ES\n"
+			+ "precision " + ( desc.header.type == "vertex" ? "highp" : "mediump" ) + " float;\n"
+			+ "#endif\n";
 		
 		var tag = desc.header.type.charAt (0); //TODO
 		


### PR DESCRIPTION
Currently shader compilation fails on ANGLE, because no precision is set for desktop targets.
Using conditional compilation, you can set precision only on OpenGL ES.