### PR TITLE
CanvasBitmap.render now uses __renderTransform in support of scrollRect.

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasBitmap.hx
+++ b/openfl/_internal/renderer/canvas/CanvasBitmap.hx
@@ -29,7 +29,7 @@ class CanvasBitmap {
 			bitmap.bitmapData.__sync ();
 			
 			context.globalAlpha = bitmap.__worldAlpha;
-			var transform = bitmap.__worldTransform;
+			var transform = bitmap.__renderTransform;
 			var scrollRect = bitmap.scrollRect;
 			
 			if (renderSession.roundPixels) {


### PR DESCRIPTION
Like the GL renderer, CanvasBitmap needs to subtract out __scrollRect.topLeft before rendering if it intends to use scrollRect functionality without offset.  __renderTransform is already set up for this by DIsplayObject; it's copied from worldTransform and offset by -__worldOffset, which in turn includes __offset, which comes from __scrollRect.topLeft.

This was part of an attempt to allow the spritesheet library to do subrect rendering, which succeeded and allowed use of the 9-arg version of CanvasRenderContext2D.drawImage, but requires some changes to Bitmap's get_width and get_height and similar to avoid breaking other assumptions, so the rest of this change probably comes somewhat later; in the interim, this should fix basic scrollRect functionality in CanvasBitmap render.

Note that a similar change may need to be made in the Cairo backend, and possibly others.

Reviewed in house by Jon Meschino; could definitely use some additional external eyes, especially to make sure it doesn't break any invariants or represent a fundamental misunderstanding of the transform/matrix stack.