### PR TITLE
Add uploadFromInt16Array to IndexBuffer3D and fix Context3D constructor

### DIFF
--- a/openfl/display3D/Context3D.hx
+++ b/openfl/display3D/Context3D.hx
@@ -49,7 +49,7 @@ import openfl.Lib;
 	private var samplerParameters:Array<SamplerState>; //TODO : use Tupple3
 	private var scrollRect:Rectangle;
 	private var stencilbuffer:GLRenderbuffer;
-	private var stencilCompareMode:Int;
+	private var stencilCompareMode:Context3DCompareMode;
 	private var stencilRef:Int;
 	private var stencilReadMask:Int;
 	private var texturesCreated:Array<TextureBase>; // to keep track of stuff to dispose when calling dispose
@@ -60,8 +60,12 @@ import openfl.Lib;
 		
 		disposed = false;
 		
+		stencilCompareMode = Context3DCompareMode.ALWAYS;
+		stencilRef = 0;
+		stencilReadMask = 0xFF;
+		
 		_yFlip = 1;
-
+		
 		vertexBuffersCreated = new Array ();
 		indexBuffersCreated = new Array ();
 		programsCreated = new Array ();

--- a/openfl/display3D/IndexBuffer3D.hx
+++ b/openfl/display3D/IndexBuffer3D.hx
@@ -85,6 +85,14 @@ import openfl.Vector;
 	}
 	
 	
+	public function uploadFromInt16Array (data:Int16Array, startOffset:Int, count:Int):Void {
+		
+		GL.bindBuffer (GL.ELEMENT_ARRAY_BUFFER, glBuffer);
+		GL.bufferData (GL.ELEMENT_ARRAY_BUFFER, data.subarray (startOffset, startOffset + count), bufferUsage);
+		
+	}
+	
+	
 }
 
 


### PR DESCRIPTION
 - Adds an function that uploads indices from Int16Array to IndexBuffer3D
 - Initialize some int values in Context3D constructor, so that stencil buffer works properly on html5