### PR TITLE
Angle

### DIFF
--- a/openfl/display/Bitmap.hx
+++ b/openfl/display/Bitmap.hx
@@ -127,7 +127,7 @@ class Bitmap extends DisplayObject {
 	
 	@:noCompletion private override function __hitTest (x:Float, y:Float, shapeFlag:Bool, stack:Array<DisplayObject>, interactiveOnly:Bool, hitObject:InteractiveObject):Bool {
 		
-		if (!hitObject.visible || __isMask || bitmapData == null) return false;
+		if (hitObject == null || !hitObject.visible || __isMask || bitmapData == null) return false;
 		if (mask != null && !mask.__hitTestMask (x, y)) return false;
 		
 		__getWorldTransform ();

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1207,6 +1207,12 @@ class BitmapData implements IBitmapDrawable {
 				
 				if (__usingANGLE == null) {
 					__usingANGLE = (GL.getParameter(GL.VERSION).indexOf("ANGLE") != -1);
+					#if windows
+						if (!Lib.application.forceSoftware)
+						{
+						__usingANGLE = true;
+						}
+					#end
 				}
 				if(__usingANGLE == true) {
 					internalFormat = gl.BGRA_EXT;

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -84,9 +84,9 @@ class ApplicationMain {
 		
 		preloader = null;
 		
-		::if (libraries != null)::::foreach libraries::::if (preload)::
-		total++;
-		openfl.Assets.loadLibrary ("::name::").onComplete (library_onLoad);
+		::if (libraries != null)::::foreach libraries::::if (preload)::total++;
+		::end::::end::::end::
+		::if (libraries != null)::::foreach libraries::::if (preload)::openfl.Assets.loadLibrary ("::name::").onComplete (library_onLoad);
 		::end::::end::::end::
 		
 		if (total == 0) {


### PR DESCRIPTION
This causes openfl's Application.hx to call its superclass' processArgs() function and thus process command line arguments for setting configs.

It also fixes BitmapData by selectively choosing the right internal pixel format based on whether the system is using ANGLE or not.