### PR TITLE
Bmpdata frombytes fix

### DIFF
--- a/openfl/display/Bitmap.hx
+++ b/openfl/display/Bitmap.hx
@@ -127,7 +127,7 @@ class Bitmap extends DisplayObject {
 	
 	@:noCompletion private override function __hitTest (x:Float, y:Float, shapeFlag:Bool, stack:Array<DisplayObject>, interactiveOnly:Bool, hitObject:InteractiveObject):Bool {
 		
-		if (hitObject == null || !hitObject.visible || __isMask || bitmapData == null) return false;
+		if (!hitObject.visible || __isMask || bitmapData == null) return false;
 		if (mask != null && !mask.__hitTestMask (x, y)) return false;
 		
 		__getWorldTransform ();

--- a/openfl/display/Bitmap.hx
+++ b/openfl/display/Bitmap.hx
@@ -127,7 +127,7 @@ class Bitmap extends DisplayObject {
 	
 	@:noCompletion private override function __hitTest (x:Float, y:Float, shapeFlag:Bool, stack:Array<DisplayObject>, interactiveOnly:Bool, hitObject:InteractiveObject):Bool {
 		
-		if (!hitObject.visible || __isMask || bitmapData == null) return false;
+		if (hitObject == null || !hitObject.visible || __isMask || bitmapData == null) return false;
 		if (mask != null && !mask.__hitTestMask (x, y)) return false;
 		
 		__getWorldTransform ();

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -2097,10 +2097,11 @@ class BitmapData implements IBitmapDrawable {
 				#end
 				
 				var data = image.buffer.data;
+				var rawAlphaData:ByteArrayData = cast rawAlpha;
 				
 				for (i in 0...rawAlpha.length) {
 					
-					data[i * 4 + 3] = rawAlpha.readUnsignedByte ();
+					data[i * 4 + 3] = rawAlphaData.readUnsignedByte ();
 					
 				}
 				


### PR DESCRIPTION
There's an error in hxcpp that makes flixel fail to compile without this fix to BitmapData.hx. The problem is these two lines in FlxAssets.hx:

```
@:keep @:bitmap("assets/images/ui/button.png")
class GraphicButton extends BitmapData {}
```

We found two fixes -- remove in inline in ByteArray.readUnsignedByte, or pull it out to a local variable and drill out of the abstract. We opted for the latter so we could keep the inline.

Big thanks to @mauvecow for helping on this one.