### PR TITLE
Legacy TextFormatAlign: make the values inline

### DIFF
--- a/openfl/_legacy/text/TextFormatAlign.hx
+++ b/openfl/_legacy/text/TextFormatAlign.hx
@@ -3,10 +3,10 @@ package openfl._legacy.text; #if openfl_legacy
 
 class TextFormatAlign 
 {
-	public static var LEFT = "left";
-	public static var RIGHT = "right";
-	public static var CENTER = "center";
-	public static var JUSTIFY = "justify";
+	public static inline var LEFT = "left";
+	public static inline var RIGHT = "right";
+	public static inline var CENTER = "center";
+	public static inline var JUSTIFY = "justify";
 }
 
 


### PR DESCRIPTION
This fixes `Constant expression expected` errors with the dev branch of Haxe when trying to `switch-case` over these values, see HaxeFoundation/haxe@04899ffdc5a2ff727150c8e86287f274d13bf938.