### PR TITLE
Fixed Tilesheet bounds calc when TILE_TRANS_2x2 is used.

### DIFF
--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -867,8 +867,8 @@ import js.html.CanvasRenderingContext2D;
 						rect.setTo (0, 0, tile.width, tile.height);
 						matrix.setTo (tileData[index + transformIndex], tileData[index + transformIndex + 1], tileData[index + transformIndex + 2], tileData[index + transformIndex + 3], 0, 0);
 						
-						originX = tilePoint.x * tile.width;
-						originY = tilePoint.y * tile.height;
+						originX = tilePoint.x * scale;
+						originY = tilePoint.y * scale;
 						
 						matrix.translate (x - matrix.__transformX (originX, originY), y - matrix.__transformY (originX, originY));
 						


### PR DESCRIPTION
Origin was being calculated incorrectly when Tilesheet.TILE_TRANS_2X2 was used, which caused the bounds to inflate all over the place. In the worst case this would crash in software or when mouse hit detection occured.
