### PR TITLE
Fixes FileReference to work with new ByteArray

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"tags": [],
 	"description": "The \"Open Flash Library\" for fast 2D development",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"releasenote": "Consistency fixes",
 	"contributors": [ "singmajesty" ]
 }

--- a/openfl/net/FileReference.hx
+++ b/openfl/net/FileReference.hx
@@ -4,6 +4,7 @@ package openfl.net; #if (!display && !flash) #if !openfl_legacy
 import haxe.io.Path;
 import lime.system.System;
 import lime.ui.FileDialog;
+import lime.utils.Bytes;
 import openfl.events.Event;
 import openfl.events.EventDispatcher;
 import openfl.events.IOErrorEvent;
@@ -112,7 +113,7 @@ class FileReference extends EventDispatcher {
 		
 		if (__path != null) {
 			
-			data = ByteArray.readFile (__path);
+			data = ByteArrayData.fromBytes(Bytes.readFile(__path));
 			
 		}
 		
@@ -130,7 +131,7 @@ class FileReference extends EventDispatcher {
 		
 		#if desktop
 		
-		if (Std.is (data, ByteArray)) {
+		if (Std.is (data, ByteArrayData)) {
 			
 			__data = data;
 			
@@ -227,7 +228,7 @@ class FileReference extends EventDispatcher {
 		
 		#if desktop
 		
-		if (Std.is (__urlLoader.data, ByteArray)) {
+		if (Std.is (__urlLoader.data, ByteArrayData)) {
 			
 			__data = __urlLoader.data;
 			


### PR DESCRIPTION
This won't compile with ByteArray as an abstract, so I changed as littlle as I could to get it working again