### PR TITLE
add "fullscreenHotkey" to project.xml window config

### DIFF
--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -868,33 +868,39 @@ class Stage extends DisplayObjectContainer implements IModule {
 			stack.reverse ();
 			__fireEvent (event, stack);
 			
-			#if (windows || linux)
+			if(window.config.fullscreenHotkey) {
 			
-			if (keyCode == KeyCode.RETURN && modifier.altKey && type == KeyboardEvent.KEY_DOWN && !modifier.ctrlKey && !modifier.shiftKey && !modifier.metaKey && !event.isDefaultPrevented ()) {
+				#if (windows || linux)
 				
-				switch (displayState) {
+				if (keyCode == KeyCode.RETURN && modifier.altKey && type == KeyboardEvent.KEY_DOWN && !modifier.ctrlKey && !modifier.shiftKey && !modifier.metaKey && !event.isDefaultPrevented ()) {
 					
-					case NORMAL: displayState = FULL_SCREEN;
-					default: displayState = NORMAL;
-					
-				}
-				
-			}
-			
-			#elseif mac
-			
-			if (keyCode == KeyCode.F && modifier.ctrlKey && modifier.metaKey && type == KeyboardEvent.KEY_DOWN && !modifier.altKey && !modifier.shiftKey && !event.isDefaultPrevented ()) {
-				
-				switch (displayState) {
-					
-					case NORMAL: displayState = FULL_SCREEN;
-					default: displayState = NORMAL;
+					switch (displayState) {
+						
+						case NORMAL: displayState = FULL_SCREEN;
+						default: displayState = NORMAL;
+						
+					}
 					
 				}
 				
+				#elseif mac
+				
+				if (keyCode == KeyCode.F && modifier.ctrlKey && modifier.metaKey && type == KeyboardEvent.KEY_DOWN && !modifier.altKey && !modifier.shiftKey && !event.isDefaultPrevented ()) {
+					
+					switch (displayState) {
+						
+						case NORMAL: displayState = FULL_SCREEN;
+						default: displayState = NORMAL;
+						
+					}
+					
+				}
+				
+				#end
+				
 			}
 			
-			#elseif android
+			#if android
 			
 			if (keyCode == KeyCode.APP_CONTROL_BACK && modifier == 0 && type == KeyboardEvent.KEY_UP && !event.isDefaultPrevented ()) {
 				

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -119,6 +119,7 @@ class ApplicationMain {
 					depthBuffer: ::depthBuffer::,
 					display: ::display::,
 					fullscreen: ::fullscreen::,
+					fullscreenHotkey: ::fullscreenHotkey::,
 					hardware: ::hardware::,
 					height: ::height::,
 					parameters: "::parameters::",


### PR DESCRIPTION
default value is true, if true, alt+enter for windows/linux (and ctrl+meta+F for mac) will fullscreen the app. If false, it will not when such keystrokes are pressed.

the config value is "fullscreenHotkey", and the value in xml is "fullscreen-hotkey"

I'm not particularly attached to the names/style, just the functionality.