### PR TITLE
Allow unresizable HTML5 apps

### DIFF
--- a/templates/html5/template/index.html
+++ b/templates/html5/template/index.html
@@ -24,7 +24,8 @@
 	
 	<style>
 		html,body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
-		#openfl-content { background: #000000; width: 100%; height: 100%; }
+		#openfl-content { background: #000000; ::if resizable::width: 100%; height: 100%;::else::width: ::WIN_WIDTH::px; height: ::WIN_HEIGHT::px; ::end::}
+		
 		::foreach assets::::if (type == "font")::
 		@font-face {
 			font-family: '::fontName::';


### PR DESCRIPTION
If the user sets the window config "resizable" to false in an html5 app, then it forces the window to always be a certain fixed size.

I just add some macro logic to the template. If resizable is true, width/height are "100%" (the current behavior). If resizable is false, width/height are the exact values specified by the user in project.xml