### PR TITLE
Add WebGL context init config

### DIFF
--- a/openfl/display/OpenGLView.hx
+++ b/openfl/display/OpenGLView.hx
@@ -9,6 +9,8 @@ import openfl.display.Stage;
 import openfl.geom.Rectangle;
 import openfl.gl.GL;
 import openfl.Lib;
+import lime.app.Application;
+import lime.ui.Window;
 
 #if (js && html5)
 import js.html.CanvasElement;

--- a/openfl/display/OpenGLView.hx
+++ b/openfl/display/OpenGLView.hx
@@ -42,7 +42,14 @@ class OpenGLView extends DirectRenderer {
 			__canvas.width = Lib.current.stage.stageWidth;
 			__canvas.height = Lib.current.stage.stageHeight;
 			
-			__context = cast __canvas.getContext ("webgl");
+			var window:Window = Application.current.window;
+			__context = cast __canvas.getContext("webgl", {
+				alpha:false, 
+				premultipliedAlpha: false, 
+				antialias:false, 
+				depth:window.config.depthBuffer, 
+				stencil:window.config.stencilBuffer
+			});
 			
 			if (__context == null) {
 				


### PR DESCRIPTION
adds the ability to configure the init of the WebGL context with the window node in the openFL profile file.
Eg: `<window width="320" height="480" depth-buffer="false" stencil-buffer="true" />`