### PR TITLE
Textfield Fix, BGRA internalFormat and Flip source data

### DIFF
--- a/openfl/_internal/aglsl/AGLSLParser.hx
+++ b/openfl/_internal/aglsl/AGLSLParser.hx
@@ -107,6 +107,10 @@ class AGLSLParser {
 			
 		}
 		
+		#if js
+		if (desc.header.type == "fragment")
+			header += "vec4 texture2DYFlip(in sampler2D s, in vec2 coord) {return texture2D(s, vec2(coord.x, 1.0 - coord.y));}\n";
+		#end
 		// extra gl fluff: setup position and depth adjust temps
 		if (desc.header.type == "vertex") {
 			

--- a/openfl/_internal/aglsl/Mapping.hx
+++ b/openfl/_internal/aglsl/Mapping.hx
@@ -59,7 +59,11 @@ class Mapping {
 				//         s 															flags  	dest    a     b 	    mw 	  mh    ndwm  scale dm	  lod 
 				new OpLUT ("%dest = %cast(texture%texdimLod(%b,%texsize(%a)).%dm);\n", null, true, true, true, null, null, null, null, true, null),
 				new OpLUT ("if ( float(%a)<0.0 ) discard;\n", null, false, true, false, null, null, null, true, null, null),
-				new OpLUT ("%dest = %cast(texture%texdim(%b,%texsize(%a)%lod).%dm);\n", null, true, true, true, null, null, true, null, true, true),
+                #if js
+					new OpLUT ("%dest = %cast(texture%texdimYFlip(%b,%texsize(%a)%lod).%dm);\n", null, true, true, true, null, null, true, null, true, true),
+				#else
+					new OpLUT ("%dest = %cast(texture%texdim(%b,%texsize(%a)%lod).%dm);\n", null, true, true, true, null, null, true, null, true, true),
+				#end
 				new OpLUT ("%dest = %cast(greaterThanEqual(%a,%b).%dm);\n", 0, true, true, true, null, null, true, null, true, null),
 				new OpLUT ("%dest = %cast(lessThan(%a,%b).%dm);\n", 0, true, true, true, null, null, true, null, true, null),
 				new OpLUT ("%dest = %cast(sign(%a));\n", 0, true, true, false, null, null, null, null, null, null),

--- a/openfl/display/OpenGLView.hx
+++ b/openfl/display/OpenGLView.hx
@@ -9,6 +9,8 @@ import openfl.display.Stage;
 import openfl.geom.Rectangle;
 import openfl.gl.GL;
 import openfl.Lib;
+import lime.app.Application;
+import lime.ui.Window;
 
 #if (js && html5)
 import js.html.CanvasElement;

--- a/openfl/display/OpenGLView.hx
+++ b/openfl/display/OpenGLView.hx
@@ -42,7 +42,14 @@ class OpenGLView extends DirectRenderer {
 			__canvas.width = Lib.current.stage.stageWidth;
 			__canvas.height = Lib.current.stage.stageHeight;
 			
-			__context = cast __canvas.getContext ("webgl");
+			var window:Window = Application.current.window;
+			__context = cast __canvas.getContext("webgl", {
+				alpha:false, 
+				premultipliedAlpha: false, 
+				antialias:false, 
+				depth:window.config.depthBuffer, 
+				stencil:window.config.stencilBuffer
+			});
 			
 			if (__context == null) {
 				

--- a/openfl/display3D/Context3D.hx
+++ b/openfl/display3D/Context3D.hx
@@ -91,6 +91,9 @@ import openfl.Lib;
 		
 		stage.addChildAt(ogl, 0);
 		
+		#if js
+		GL.pixelStorei (GL.UNPACK_FLIP_Y_WEBGL, 1);
+		#end
 	}
 	
 	

--- a/openfl/display3D/Context3D.hx
+++ b/openfl/display3D/Context3D.hx
@@ -93,6 +93,7 @@ import openfl.Lib;
 		
 		#if js
 		GL.pixelStorei (GL.UNPACK_FLIP_Y_WEBGL, 1);
+		GL.pixelStorei (GL.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
 		#end
 	}
 	

--- a/openfl/display3D/textures/Texture.hx
+++ b/openfl/display3D/textures/Texture.hx
@@ -28,7 +28,7 @@ using openfl.display.BitmapData;
 		mipmapsGenerated = false;
 		
 		if (internalFormat == -1){
-			#if cpp
+			#if (cpp && !openfl_legacy)
 			internalFormat = GL.BGRA_EXT;
 			#else
 			internalFormat = GL.RGBA;


### PR DESCRIPTION
Flip source data along its vertical axis when starling filters are being used.
This is required to get Starling filters to behave currently in html5.