### PR TITLE
TextField: more accurate getCharBoundaries() function

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -965,6 +965,45 @@ class TextEngine {
 			}
 			
 		}
+	}
+	
+	
+	private function getFormattedTextWidth (text:String, format:TextFormat):Float {
+		
+		#if (js && html5)
+		
+		return __context.measureText (text).width;
+		
+		#else
+		
+		if (__textLayout == null) {
+			
+			__textLayout = new TextLayout ();
+			
+		}
+		
+		var width = 0.0;
+		
+		__textLayout.text = null;
+		__textLayout.font = findFont(format.font);
+		
+		if (format.size != null) {
+			
+			__textLayout.size = format.size;
+			
+		}
+		
+		__textLayout.text = text;
+		
+		for (position in __textLayout.positions) {
+			
+			width += position.advance.x;
+			
+		}
+		
+		return width;
+		
+		#end
 		
 	}
 	

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -126,7 +126,7 @@ class TextField extends InteractiveObject {
 		
 	}
 	
-	
+	@:access(openfl._internal.text.TextEngine)
 	public function getCharBoundaries (charIndex:Int):Rectangle {
 		
 		if (charIndex < 0 || charIndex > __textEngine.text.length - 1) return null;
@@ -137,15 +137,10 @@ class TextField extends InteractiveObject {
 			
 			if (charIndex >= group.startIndex && charIndex <= group.endIndex) {
 				
-				var x = group.offsetX;
+				var x = group.offsetX + __textEngine.getFormattedTextWidth(text.substr(group.startIndex, (charIndex-group.startIndex)), group.format);
+				var width = __textEngine.getFormattedTextWidth(text.charAt(charIndex), group.format);
 				
-				for (i in 0...(charIndex - group.startIndex)) {
-					
-					x += group.advances[i];
-					
-				}
-				
-				return new Rectangle (x, group.offsetY, group.advances[charIndex - group.startIndex], group.ascent + group.descent);
+				return new Rectangle (x, group.offsetY, width, group.ascent + group.descent);
 				
 			}
 			


### PR DESCRIPTION
This results in 100% accuracy in Defender's Quest, before, getCharBoundaries() was apparently ignoring spaces.

Context: I use this function in order to selectively recolor letters (directly on the cached bitmap representation) of multi-line text fields with lots of spaces and punctuation. Doing that precisely requires 100% accurate getCharBoundaries().

I have not tested this outside of DQ, but I'm pretty confident in the results (and they were definitely inaccurate before).