### PR TITLE
CanvasGraphics null check

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -261,6 +261,12 @@ class CanvasGraphics {
 			
 			var data = new DrawCommandReader (graphics.__commands);
 			
+			// CocoonJS (and maybe some other platforms) does not support isPointInPath or isPointInStroke.
+			// So if we don't have isPointInPath/Stroke, we just assume this was a hit if we made it through Graphics.hitTest()
+			// TODO: safe to call this once and cache result?
+			var hasPointInPath = Reflect.isFunction( context.isPointInPath );
+			var hasPointInStroke = Reflect.isFunction( context.isPointInStroke );
+			
 			for (type in graphics.__commands.types) {
 				
 				switch (type) {
@@ -310,14 +316,14 @@ class CanvasGraphics {
 						endFill ();
 						endStroke ();
 						
-						if (hasFill && context.isPointInPath (x, y)) {
+						if (hasFill && (!hasPointInPath || context.isPointInPath (x, y))) {
 							
 							data.destroy ();
 							return true;
 							
 						}
 						
-						if (hasStroke && (context:Dynamic).isPointInStroke (x, y)) {
+						if (hasStroke && (!hasPointInStroke || context.isPointInStroke (x, y))) {
 							
 							data.destroy ();
 							return true;
@@ -332,14 +338,14 @@ class CanvasGraphics {
 						endFill ();
 						endStroke ();
 						
-						if (hasFill && context.isPointInPath (x, y)) {
+						if (hasFill && (!hasPointInPath || context.isPointInPath (x, y))) {
 							
 							data.destroy ();
 							return true;
 							
 						}
 						
-						if (hasStroke && (context:Dynamic).isPointInStroke (x, y)) {
+						if (hasStroke && (!hasPointInStroke || context.isPointInStroke (x, y))) {
 							
 							data.destroy ();
 							return true;
@@ -412,13 +418,13 @@ class CanvasGraphics {
 			
 			data.destroy ();
 			
-			if (hasFill && context.isPointInPath (x, y)) {
+			if (hasFill && (!hasPointInPath || context.isPointInPath (x, y))) {
 				
 				return true;
 				
 			}
 			
-			if (hasStroke && (context:Dynamic).isPointInStroke (x, y)) {
+			if (hasStroke && (!hasPointInStroke || context.isPointInStroke (x, y))) {
 				
 				return true;
 				

--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -200,7 +200,7 @@ class Sound extends EventDispatcher {
 		
 		if (untyped window.createjs != null) {
 			
-			SoundJS.alternateExtensions = [ "ogg", "mp3", "wav" ];
+			SoundJS.alternateExtensions = [ "ogg", "m4a", "mp3", "wav" ];
 			
 		}
 		


### PR DESCRIPTION
CanvasGraphics.hx
Hoping this commit can spawn a discussion around this area of code. But it seems there may be some platforms (CocoonJS being one) that do not support or intend to support isPointInPath and isPointInStroke. So for this change, I just added a safety check to ensure the functions exist before trying to use them. If they don't exist, we assume the hit was good (something better to do here?). This change will prevent some uncommon edge cases from crashing regarding platform specifics.

The other thing to consider is optimizing this hitTest function. Seems there may be some early checks we can do to return early, and I believe the code redraws the entire canvas each time that might be able to be optimized.

Sound.hx
Regarding the second file (accidentally lumped into this pull, sorry!), I wanted to add m4a fallback support. If this warrants a discussion we can have that on a separate thread.
