### PR TITLE
Compile Fix

### DIFF
--- a/openfl/utils/ByteArray.hx
+++ b/openfl/utils/ByteArray.hx
@@ -281,7 +281,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData {
 			var windowBits = switch (algorithm) {
 				
 				case DEFLATE: -15;
-				case GZIP: 31;
+				//case GZIP: 31;
 				default: 15;
 				
 			}


### PR DESCRIPTION
The GZIP constant has been removed from CompressionAlgorithm, so it should be commented here too for the meantime.