### PR TITLE
Compile Fix

### DIFF
--- a/openfl/utils/CompressionAlgorithm.hx
+++ b/openfl/utils/CompressionAlgorithm.hx
@@ -4,7 +4,7 @@ package openfl.utils; #if !openfl_legacy
 @:enum abstract CompressionAlgorithm(String) from String to String {
 	
 	public var DEFLATE = "deflate";
-	//GZIP;
+	public var GZIP = "gzip";
 	public var LZMA = "lzma";
 	public var ZLIB = "zlib";
 	


### PR DESCRIPTION
ByteArray.hx requires GZIP to be defined.