### PR TITLE
Drawtiles color offsets 

### DIFF
--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -541,7 +541,8 @@ class SpriteBatch {
 				currentState.texture = nextState.texture;
 				currentState.textureSmooth = nextState.textureSmooth;
 				currentState.blendMode = nextState.blendMode;
-				currentState.colorTransform = nextState.colorTransform;
+				currentState.skipColorTransform = nextState.skipColorTransform;
+				currentState.colorTransform = currentState.skipColorTransform ? null : nextState.colorTransform;
 				
 			}
 			
@@ -617,27 +618,19 @@ class SpriteBatch {
 		state.texture = texture;
 		state.textureSmooth = smooth;
 		state.blendMode = blendMode;
+		
 		// colorTransform is default, skipping it
-		if (colorTransform == null || @:privateAccess colorTransform.__isDefault()) {
-			state.skipColorTransform = true;
-			state.colorTransform.redMultiplier = 1;
-			state.colorTransform.greenMultiplier = 1;
-			state.colorTransform.blueMultiplier= 1;
-			state.colorTransform.alphaMultiplier= 1;
-			state.colorTransform.redOffset = 0;
-			state.colorTransform.greenOffset = 0;
-			state.colorTransform.blueOffset = 0;
-			state.colorTransform.alphaOffset = 0;
-		} else {
-			state.skipColorTransform = false;
-			state.colorTransform.redMultiplier = colorTransform.redMultiplier;
+		state.skipColorTransform = (colorTransform != null && @:privateAccess colorTransform.__isDefault());
+		
+		if (!state.skipColorTransform) {
+			state.colorTransform.redMultiplier   = colorTransform.redMultiplier;
 			state.colorTransform.greenMultiplier = colorTransform.greenMultiplier;
-			state.colorTransform.blueMultiplier = colorTransform.blueMultiplier;
+			state.colorTransform.blueMultiplier  = colorTransform.blueMultiplier;
 			state.colorTransform.alphaMultiplier = colorTransform.alphaMultiplier;
-			state.colorTransform.redOffset = colorTransform.redOffset;
-			state.colorTransform.greenOffset = colorTransform.greenOffset;
-			state.colorTransform.blueOffset = colorTransform.blueOffset;
-			state.colorTransform.alphaOffset = colorTransform.alphaOffset;
+			state.colorTransform.redOffset       = colorTransform.redOffset;
+			state.colorTransform.greenOffset     = colorTransform.greenOffset;
+			state.colorTransform.blueOffset      = colorTransform.blueOffset;
+			state.colorTransform.alphaOffset     = colorTransform.alphaOffset;
 		}
 		
 		state.skipColorTransformAlpha = skipAlpha;
@@ -722,13 +715,9 @@ private class State {
 				texture == other.texture &&
 				textureSmooth == other.textureSmooth &&
 				blendMode == other.blendMode &&
-				skipColorTransform == other.skipColorTransform && 
-				//((colorTransform == null && other.colorTransform == null) || (colorTransform != null && other.colorTransform != null && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha)))
 				// colorTransform.alphaMultiplier == object.__worldAlpha so we can skip it
-				(
-					(colorTransform == null && other.colorTransform == null) ||
-					(colorTransform != null && other.colorTransform != null && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha))
-				)
+				((skipColorTransform && other.skipColorTransform) || (!skipColorTransform && !other.skipColorTransform && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha)))
+				
 		);
 	}
 	

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -334,38 +334,22 @@ class SpriteBatch {
 					tint = Std.int(tileData[iIndex + rgbIndex] * 255) << 16 | Std.int(tileData[iIndex + rgbIndex + 1] * 255) << 8 | Std.int(tileData[iIndex + rgbIndex + 2] * 255);
 				}
 				
-				if (useRGBOffset) {
-					/*
-					colorTransform.redMultiplier   = 1;
-					colorTransform.greenMultiplier = 1;
-					colorTransform.blueMultiplier  = 1;
-					colorTransform.alphaMultiplier = 1;
-					colorTransform.redOffset       = 255;
-					colorTransform.greenOffset     = 0;
-					colorTransform.blueOffset      = 0;
-					colorTransform.alphaOffset     = 0;
-					*/
-					colorTransform.redMultiplier   = 1;
-					colorTransform.greenMultiplier = 1;
-					colorTransform.blueMultiplier  = 1;
-					colorTransform.alphaMultiplier = 1;
-					colorTransform.redOffset       = tileData[iIndex + rgbOffsetIndex + 4];
-					colorTransform.greenOffset     = tileData[iIndex + rgbOffsetIndex + 5];
-					colorTransform.blueOffset      = tileData[iIndex + rgbOffsetIndex + 6];
-					colorTransform.alphaOffset     = tileData[iIndex + rgbOffsetIndex + 7];
-				} else {
-					var wct = object.__worldColorTransform;
-					colorTransform.redMultiplier   = wct.redMultiplier;
-					colorTransform.greenMultiplier = wct.greenMultiplier;
-					colorTransform.blueMultiplier  = wct.blueMultiplier;
-					colorTransform.alphaMultiplier = wct.alphaMultiplier;
-					colorTransform.redOffset       = wct.redOffset;
-					colorTransform.greenOffset     = wct.greenOffset;
-					colorTransform.blueOffset      = wct.blueOffset;
-					colorTransform.alphaOffset     = wct.alphaOffset;
-					//colorTransform = object.__worldColorTransform;
-				}
+				var wct = object.__worldColorTransform;
+				colorTransform.redMultiplier   = wct.redMultiplier;
+				colorTransform.greenMultiplier = wct.greenMultiplier;
+				colorTransform.blueMultiplier  = wct.blueMultiplier;
+				colorTransform.alphaMultiplier = wct.alphaMultiplier;
+				colorTransform.redOffset       = wct.redOffset;
+				colorTransform.greenOffset     = wct.greenOffset;
+				colorTransform.blueOffset      = wct.blueOffset;
+				colorTransform.alphaOffset     = wct.alphaOffset;
 				
+				if (useRGBOffset) {
+					colorTransform.redOffset   += tileData[iIndex + rgbOffsetIndex + 0];
+					colorTransform.greenOffset += tileData[iIndex + rgbOffsetIndex + 1];
+					colorTransform.blueOffset  += tileData[iIndex + rgbOffsetIndex + 2];
+					colorTransform.alphaOffset += tileData[iIndex + rgbOffsetIndex + 3];
+				}
 				
 				if (useScale) {
 					scale = tileData[iIndex + scaleIndex];

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -197,7 +197,7 @@ class SpriteBatch {
 		var useAlpha = (flags & Tilesheet.TILE_ALPHA) > 0;
 		var useRect = (flags & Tilesheet.TILE_RECT) > 0;
 		var useOrigin = (flags & Tilesheet.TILE_ORIGIN) > 0;
-		var useColorTransform = ((flags & Tilesheet.TILE_TRANS_COLOR) > 0);
+		var useRGBOffset = ((flags & Tilesheet.TILE_TRANS_COLOR) > 0);
 		
 		var blendMode:BlendMode = switch(flags & 0xF0000) {
 			case Tilesheet.TILE_BLEND_ADD:                ADD;
@@ -222,7 +222,7 @@ class SpriteBatch {
 		var scaleIndex = 0;
 		var rotationIndex = 0;
 		var rgbIndex = 0;
-		var colorTransformIndex = 0;
+		var rgbOffsetIndex = 0;
 		var alphaIndex = 0;
 		var transformIndex = 0;
 		
@@ -234,7 +234,7 @@ class SpriteBatch {
 		if (useTransform) { transformIndex = numValues; numValues += 4; }
 		if (useRGB) { rgbIndex = numValues; numValues += 3; }
 		if (useAlpha) { alphaIndex = numValues; numValues ++; }
-		if (useColorTransform) { colorTransformIndex = numValues; numValues += 8; }
+		if (useRGBOffset) { rgbOffsetIndex = numValues; numValues += 4; }
 		
 		var totalCount = tileData.length;
 		if (count >= 0 && totalCount > count) totalCount = count;
@@ -334,7 +334,7 @@ class SpriteBatch {
 					tint = Std.int(tileData[iIndex + rgbIndex] * 255) << 16 | Std.int(tileData[iIndex + rgbIndex + 1] * 255) << 8 | Std.int(tileData[iIndex + rgbIndex + 2] * 255);
 				}
 				
-				if (useColorTransform) {
+				if (useRGBOffset) {
 					/*
 					colorTransform.redMultiplier   = 1;
 					colorTransform.greenMultiplier = 1;
@@ -345,14 +345,14 @@ class SpriteBatch {
 					colorTransform.blueOffset      = 0;
 					colorTransform.alphaOffset     = 0;
 					*/
-					colorTransform.redMultiplier   = tileData[iIndex + colorTransformIndex];
-					colorTransform.greenMultiplier = tileData[iIndex + colorTransformIndex + 1];
-					colorTransform.blueMultiplier  = tileData[iIndex + colorTransformIndex + 2];
-					colorTransform.alphaMultiplier = tileData[iIndex + colorTransformIndex + 3];
-					colorTransform.redOffset       = tileData[iIndex + colorTransformIndex + 4];
-					colorTransform.greenOffset     = tileData[iIndex + colorTransformIndex + 5];
-					colorTransform.blueOffset      = tileData[iIndex + colorTransformIndex + 6];
-					colorTransform.alphaOffset     = tileData[iIndex + colorTransformIndex + 7];
+					colorTransform.redMultiplier   = 1;
+					colorTransform.greenMultiplier = 1;
+					colorTransform.blueMultiplier  = 1;
+					colorTransform.alphaMultiplier = 1;
+					colorTransform.redOffset       = tileData[iIndex + rgbOffsetIndex + 4];
+					colorTransform.greenOffset     = tileData[iIndex + rgbOffsetIndex + 5];
+					colorTransform.blueOffset      = tileData[iIndex + rgbOffsetIndex + 6];
+					colorTransform.alphaOffset     = tileData[iIndex + rgbOffsetIndex + 7];
 				} else {
 					var wct = object.__worldColorTransform;
 					colorTransform.redMultiplier   = wct.redMultiplier;
@@ -739,10 +739,11 @@ private class State {
 				textureSmooth == other.textureSmooth &&
 				blendMode == other.blendMode &&
 				skipColorTransform == other.skipColorTransform && 
+				//((colorTransform == null && other.colorTransform == null) || (colorTransform != null && other.colorTransform != null && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha)))
 				// colorTransform.alphaMultiplier == object.__worldAlpha so we can skip it
 				(
-					(colorTransform == null && other.colorTransform == null) || 
-					(colorTransform != null && other.colorTransform != null && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha)) ||
+					(colorTransform == null && other.colorTransform == null) ||
+					(colorTransform != null && other.colorTransform != null && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha))
 				)
 		);
 	}

--- a/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
+++ b/openfl/_internal/renderer/opengl/utils/SpriteBatch.hx
@@ -68,7 +68,7 @@ class SpriteBatch {
 	
 	var matrix:Matrix = new Matrix();
 	var uvs:TextureUvs = new TextureUvs();
-	
+	var colorTransform:ColorTransform = new ColorTransform();
 	
 	public function new(gl:GLRenderContext, maxSprites:Int = 2000) {
 		this.maxSprites = maxSprites;
@@ -127,6 +127,8 @@ class SpriteBatch {
 			state.destroy();
 		}
 		
+		colorTransform = null;
+		
 		gl = null;
 	}
 	
@@ -183,7 +185,7 @@ class SpriteBatch {
 		batchedSprites++;
 	}
 	
-	public function renderTiles(object:DisplayObject, sheet:Tilesheet, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, ?flashShader:FlashShader, count:Int = -1) {		
+	public function renderTiles(object:DisplayObject, sheet:Tilesheet, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, ?flashShader:FlashShader, count:Int = -1) {
 		
 		var texture = sheet.__bitmap.getTexture(gl);
 		if (texture == null) return;
@@ -195,6 +197,7 @@ class SpriteBatch {
 		var useAlpha = (flags & Tilesheet.TILE_ALPHA) > 0;
 		var useRect = (flags & Tilesheet.TILE_RECT) > 0;
 		var useOrigin = (flags & Tilesheet.TILE_ORIGIN) > 0;
+		var useColorTransform = ((flags & Tilesheet.TILE_TRANS_COLOR) > 0);
 		
 		var blendMode:BlendMode = switch(flags & 0xF0000) {
 			case Tilesheet.TILE_BLEND_ADD:                ADD;
@@ -219,6 +222,7 @@ class SpriteBatch {
 		var scaleIndex = 0;
 		var rotationIndex = 0;
 		var rgbIndex = 0;
+		var colorTransformIndex = 0;
 		var alphaIndex = 0;
 		var transformIndex = 0;
 		
@@ -230,6 +234,7 @@ class SpriteBatch {
 		if (useTransform) { transformIndex = numValues; numValues += 4; }
 		if (useRGB) { rgbIndex = numValues; numValues += 3; }
 		if (useAlpha) { alphaIndex = numValues; numValues ++; }
+		if (useColorTransform) { colorTransformIndex = numValues; numValues += 8; }
 		
 		var totalCount = tileData.length;
 		if (count >= 0 && totalCount > count) totalCount = count;
@@ -329,6 +334,39 @@ class SpriteBatch {
 					tint = Std.int(tileData[iIndex + rgbIndex] * 255) << 16 | Std.int(tileData[iIndex + rgbIndex + 1] * 255) << 8 | Std.int(tileData[iIndex + rgbIndex + 2] * 255);
 				}
 				
+				if (useColorTransform) {
+					/*
+					colorTransform.redMultiplier   = 1;
+					colorTransform.greenMultiplier = 1;
+					colorTransform.blueMultiplier  = 1;
+					colorTransform.alphaMultiplier = 1;
+					colorTransform.redOffset       = 255;
+					colorTransform.greenOffset     = 0;
+					colorTransform.blueOffset      = 0;
+					colorTransform.alphaOffset     = 0;
+					*/
+					colorTransform.redMultiplier   = tileData[iIndex + colorTransformIndex];
+					colorTransform.greenMultiplier = tileData[iIndex + colorTransformIndex + 1];
+					colorTransform.blueMultiplier  = tileData[iIndex + colorTransformIndex + 2];
+					colorTransform.alphaMultiplier = tileData[iIndex + colorTransformIndex + 3];
+					colorTransform.redOffset       = tileData[iIndex + colorTransformIndex + 4];
+					colorTransform.greenOffset     = tileData[iIndex + colorTransformIndex + 5];
+					colorTransform.blueOffset      = tileData[iIndex + colorTransformIndex + 6];
+					colorTransform.alphaOffset     = tileData[iIndex + colorTransformIndex + 7];
+				} else {
+					var wct = object.__worldColorTransform;
+					colorTransform.redMultiplier   = wct.redMultiplier;
+					colorTransform.greenMultiplier = wct.greenMultiplier;
+					colorTransform.blueMultiplier  = wct.blueMultiplier;
+					colorTransform.alphaMultiplier = wct.alphaMultiplier;
+					colorTransform.redOffset       = wct.redOffset;
+					colorTransform.greenOffset     = wct.greenOffset;
+					colorTransform.blueOffset      = wct.blueOffset;
+					colorTransform.alphaOffset     = wct.alphaOffset;
+					//colorTransform = object.__worldColorTransform;
+				}
+				
+				
 				if (useScale) {
 					scale = tileData[iIndex + scaleIndex];
 				}
@@ -390,7 +428,7 @@ class SpriteBatch {
 				
 				writtenVertexBytes = bIndex + 20;
 				
-				setState(batchedSprites, texture, smooth, blendMode, object.__worldColorTransform, flashShader, false);
+				setState(batchedSprites, texture, smooth, blendMode, colorTransform, flashShader, false);
 				
 				batchedSprites++;
 			}
@@ -587,6 +625,7 @@ class SpriteBatch {
 	}
 	
 	inline function setState(index:Int, texture:GLTexture, ?smooth:Bool = false, ?blendMode:BlendMode, ?colorTransform:ColorTransform, ?shader:FlashShader, ?skipAlpha:Bool = false) {
+		
 		var state:State = states[index];
 		if (state == null) {
 			state = states[index] = new State();
@@ -595,7 +634,28 @@ class SpriteBatch {
 		state.textureSmooth = smooth;
 		state.blendMode = blendMode;
 		// colorTransform is default, skipping it
-		state.colorTransform = (colorTransform != null && @:privateAccess colorTransform.__isDefault()) ? null : colorTransform;
+		if (colorTransform == null || @:privateAccess colorTransform.__isDefault()) {
+			state.skipColorTransform = true;
+			state.colorTransform.redMultiplier = 1;
+			state.colorTransform.greenMultiplier = 1;
+			state.colorTransform.blueMultiplier= 1;
+			state.colorTransform.alphaMultiplier= 1;
+			state.colorTransform.redOffset = 0;
+			state.colorTransform.greenOffset = 0;
+			state.colorTransform.blueOffset = 0;
+			state.colorTransform.alphaOffset = 0;
+		} else {
+			state.skipColorTransform = false;
+			state.colorTransform.redMultiplier = colorTransform.redMultiplier;
+			state.colorTransform.greenMultiplier = colorTransform.greenMultiplier;
+			state.colorTransform.blueMultiplier = colorTransform.blueMultiplier;
+			state.colorTransform.alphaMultiplier = colorTransform.alphaMultiplier;
+			state.colorTransform.redOffset = colorTransform.redOffset;
+			state.colorTransform.greenOffset = colorTransform.greenOffset;
+			state.colorTransform.blueOffset = colorTransform.blueOffset;
+			state.colorTransform.alphaOffset = colorTransform.alphaOffset;
+		}
+		
 		state.skipColorTransformAlpha = skipAlpha;
 		if (shader == null) {
 			state.shader = null;
@@ -663,7 +723,8 @@ private class State {
 	public var texture:GLTexture;
 	public var textureSmooth:Bool = true;
 	public var blendMode:BlendMode;
-	public var colorTransform:ColorTransform;
+	public var colorTransform:ColorTransform = new ColorTransform();
+	public var skipColorTransform:Bool = false;
 	public var skipColorTransformAlpha:Bool = false;
 	public var shader:Shader;
 	public var shaderData:GLShaderData;
@@ -677,8 +738,12 @@ private class State {
 				texture == other.texture &&
 				textureSmooth == other.textureSmooth &&
 				blendMode == other.blendMode &&
+				skipColorTransform == other.skipColorTransform && 
 				// colorTransform.alphaMultiplier == object.__worldAlpha so we can skip it
-				((colorTransform == null && other.colorTransform == null) || (colorTransform != null && other.colorTransform != null && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha)))
+				(
+					(colorTransform == null && other.colorTransform == null) || 
+					(colorTransform != null && other.colorTransform != null && colorTransform.__equals(other.colorTransform, skipColorTransformAlpha)) ||
+				)
 		);
 	}
 	

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -477,6 +477,7 @@ import js.html.CanvasRenderingContext2D;
 		var useRGB = (flags & Tilesheet.TILE_RGB) > 0;
 		var useAlpha = (flags & Tilesheet.TILE_ALPHA) > 0;
 		var useTransform = (flags & Tilesheet.TILE_TRANS_2x2) > 0;
+		var useColorTransform = (flags & Tilesheet.TILE_TRANS_COLOR) > 0;
 		var useRect = (flags & Tilesheet.TILE_RECT) > 0;
 		var useOrigin = (flags & Tilesheet.TILE_ORIGIN) > 0;
 		
@@ -492,7 +493,7 @@ import js.html.CanvasRenderingContext2D;
 			
 		}
 		
-		if (useTransform || useScale || useRotation || useRGB || useAlpha) {
+		if (useTransform || useScale || useRotation || useRGB || useAlpha || useColorTransform) {
 			
 			var scaleIndex = 0;
 			var rotationIndex = 0;
@@ -504,6 +505,7 @@ import js.html.CanvasRenderingContext2D;
 			if (useTransform) { transformIndex = numValues; numValues += 4; }
 			if (useRGB) { numValues += 3; }
 			if (useAlpha) { numValues++; }
+			if (useColorTransform) { numValues += 4; }
 			
 			var itemCount = Std.int (totalCount / numValues);
 			var index = 0;

--- a/openfl/display/Tilesheet.hx
+++ b/openfl/display/Tilesheet.hx
@@ -190,11 +190,10 @@ class Tilesheet {
 	 * @param	smooth whether to smooth the tile or not
 	 * @param	flags
 	 * @param	count
-	 * @param	colorTransform
 	 */
-	public function drawTiles (graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1, colorTransform:ColorTransform = null):Void {
+	public function drawTiles (graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1):Void {
 		
-		graphics.drawTiles (this, tileData, smooth, flags, count, colorTransform);
+		graphics.drawTiles (this, tileData, smooth, flags, count);
 		
 	}
 	

--- a/openfl/display/Tilesheet.hx
+++ b/openfl/display/Tilesheet.hx
@@ -1,7 +1,6 @@
 package openfl.display; #if !openfl_legacy
 
 
-import flash.geom.ColorTransform;
 import openfl.display.BitmapData;
 import openfl.display.Graphics;
 import openfl.geom.Point;

--- a/openfl/display/Tilesheet.hx
+++ b/openfl/display/Tilesheet.hx
@@ -1,6 +1,7 @@
 package openfl.display; #if !openfl_legacy
 
 
+import flash.geom.ColorTransform;
 import openfl.display.BitmapData;
 import openfl.display.Graphics;
 import openfl.geom.Point;
@@ -20,6 +21,7 @@ class Tilesheet {
 	public static inline var TILE_TRANS_2x2 = 0x0010;
 	public static inline var TILE_RECT = 0x0020;
 	public static inline var TILE_ORIGIN = 0x0040;
+	public static inline var TILE_TRANS_COLOR = 0x0080;
 	
 	public static inline var TILE_BLEND_NORMAL = 0x00000000;
 	public static inline var TILE_BLEND_ADD = 0x00010000;
@@ -188,10 +190,11 @@ class Tilesheet {
 	 * @param	smooth whether to smooth the tile or not
 	 * @param	flags
 	 * @param	count
+	 * @param	colorTransform
 	 */
-	public function drawTiles (graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1):Void {
+	public function drawTiles (graphics:Graphics, tileData:Array<Float>, smooth:Bool = false, flags:Int = 0, count:Int = -1, colorTransform:ColorTransform = null):Void {
 		
-		graphics.drawTiles (this, tileData, smooth, flags, count);
+		graphics.drawTiles (this, tileData, smooth, flags, count, colorTransform);
 		
 	}
 	

--- a/openfl/utils/CompressionAlgorithm.hx
+++ b/openfl/utils/CompressionAlgorithm.hx
@@ -1,38 +1,12 @@
 package openfl.utils; #if !openfl_legacy
 
 
-@:enum abstract CompressionAlgorithm(Null<Int>) {
+@:enum abstract CompressionAlgorithm(String) from String to String {
 	
-	public var DEFLATE = 0;
-	//GZIP;
-	public var LZMA = 1;
-	public var ZLIB = 2;
-	
-	@:from private static function fromString (value:String):CompressionAlgorithm {
-		
-		return switch (value) {
-			
-			case "deflate": DEFLATE;
-			case "lzma": LZMA;
-			case "zlib": ZLIB;
-			default: null;
-			
-		}
-		
-	}
-	
-	@:to private static function toString (value:Int):String {
-		
-		return switch (value) {
-			
-			case CompressionAlgorithm.DEFLATE: "deflate";
-			case CompressionAlgorithm.LZMA: "lzma";
-			case CompressionAlgorithm.ZLIB: "zlib";
-			default: null;
-			
-		}
-		
-	}
+	public var DEFLATE = "deflate";
+	public var GZIP = "gzip";
+	public var LZMA = "lzma";
+	public var ZLIB = "zlib";
 	
 }
 

--- a/openfl/utils/CompressionAlgorithm.hx
+++ b/openfl/utils/CompressionAlgorithm.hx
@@ -1,12 +1,38 @@
 package openfl.utils; #if !openfl_legacy
 
 
-@:enum abstract CompressionAlgorithm(String) from String to String {
+@:enum abstract CompressionAlgorithm(Null<Int>) {
 	
-	public var DEFLATE = "deflate";
-	public var GZIP = "gzip";
-	public var LZMA = "lzma";
-	public var ZLIB = "zlib";
+	public var DEFLATE = 0;
+	//GZIP;
+	public var LZMA = 1;
+	public var ZLIB = 2;
+	
+	@:from private static function fromString (value:String):CompressionAlgorithm {
+		
+		return switch (value) {
+			
+			case "deflate": DEFLATE;
+			case "lzma": LZMA;
+			case "zlib": ZLIB;
+			default: null;
+			
+		}
+		
+	}
+	
+	@:to private static function toString (value:Int):String {
+		
+		return switch (value) {
+			
+			case CompressionAlgorithm.DEFLATE: "deflate";
+			case CompressionAlgorithm.LZMA: "lzma";
+			case CompressionAlgorithm.ZLIB: "zlib";
+			default: null;
+			
+		}
+		
+	}
 	
 }
 


### PR DESCRIPTION
Rebased version of this: https://github.com/openfl/openfl/pull/992

--------------

Adds the ability to specify color offsets (not just color tint) in drawtiles API. I added the extra parameters to the end so that it's just purely extra optional information to add, otherwise the new code should have no effect on existing drawtiles commands.

--------------

Quick overview of how this works:

    Add 4 color offset floats to the end of the drawtiles data.
    Add the TileSheet.TILE_TRANS_COLOR flag.

Each State now always has its own colorTransform that is only ever modified to match what's passed in, rather than passing either null or a pointer to the world transform. This colorTransform is never null, and a new skipColorTransform property covers that "null" case.

This is important because the State object needs to retain the color offset information until rendering, and passing in a global colorTransform object or setting it to null destroys that connection.

SpriteBatch also has its own colorTransform instance that is only ever modified, not replaced. This way it's easier to keep track of where colorTransform objects are winding up. They are never passed around, only used to copy information from one another.

The actual rendering looks at the state and sees if skipColorTransform is true, if so, it passes a null to the currentState pointer, otherwise it passes the actual colorTransform.
