### PR TITLE
Graphics.copyFrom() wasn't working if the other Graphics didn't have any bounds

### DIFF
--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -159,7 +159,7 @@ import js.html.CanvasRenderingContext2D;
 	
 	public function copyFrom (sourceGraphics:Graphics):Void {
 		
-		__bounds = sourceGraphics.__bounds.clone ();
+		__bounds = sourceGraphics.__bounds != null ? sourceGraphics.__bounds.clone () : null;
 		__commands = sourceGraphics.__commands.copy ();
 		__dirty = true;
 		__strokePadding = sourceGraphics.__strokePadding;

--- a/tests/test/openfl/display/GraphicsTest.hx
+++ b/tests/test/openfl/display/GraphicsTest.hx
@@ -282,6 +282,16 @@ class GraphicsTest {
 		
 	}
 	
+
+	@Test public function copyFrom () {
+
+		// copyFrom of a Graphics with empty bounds shouldn't
+		// cause an error
+
+		var emptyGraphics = new Shape().graphics;
+		new Shape().graphics.copyFrom(emptyGraphics);
+
+	}
 	
 	/*private function hex (value:Int):String {
 		


### PR DESCRIPTION
Should check if bounds are null before trying to clone it.