### PR TITLE
Fix hitArea when a complex object is used

### DIFF
--- a/openfl/display/Sprite.hx
+++ b/openfl/display/Sprite.hx
@@ -67,12 +67,18 @@ class Sprite extends DisplayObjectContainer {
 	private override function __hitTest (x:Float, y:Float, shapeFlag:Bool, stack:Array<DisplayObject>, interactiveOnly:Bool, hitObject:DisplayObject):Bool {
 		
 		if (hitArea != null) {
-			
-			if (!hitArea.mouseEnabled && hitArea.__hitTest (x, y, shapeFlag, stack, interactiveOnly, hitObject)) {
-				
-				stack[stack.length - 1] = hitObject;
-				return true;
-				
+
+			if (!hitArea.mouseEnabled)
+			{
+				hitArea.mouseEnabled = true;
+				var hitTest = hitArea.__hitTest (x, y, shapeFlag, null, true, hitObject);
+				hitArea.mouseEnabled = false;
+
+				if( hitTest ){
+					stack[stack.length] = hitObject;
+				}
+
+				return hitTest;
 			}
 			
 		} else {


### PR DESCRIPTION
When a movieclip was used as a hitArea, it would always return false on _hitTest.

As it needed mouseEnabled=false, the return stack would be filled, but the boolean would always be false