### PR TITLE
autosize bug fix

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -869,7 +869,7 @@ class TextField extends InteractiveObject {
 						}
 						
 						__textEngine.height = __textEngine.textHeight + 4;
-					
+						__textEngine.update ();
 					default:
 						
 					


### PR DESCRIPTION
when __textEngine.height is change,the __textEngine.bottomScrollV need to update  the right value.
otherwise ,the text will display wrong.
