### PR TITLE
readFunction bug,read max bytes every time.

### DIFF
--- a/openfl/net/URLLoader.hx
+++ b/openfl/net/URLLoader.hx
@@ -508,7 +508,12 @@ class URLLoader extends EventDispatcher {
 	
 	private function readFunction (max:Int, input:ByteArray):Bytes {
 		
-		return input;
+		var len:Int = max > input.bytesAvailable?input.bytesAvailable:max;
+		var bytes:Bytes = Bytes.alloc(len);
+		for (i in 0...len) {
+			bytes.set(i,input.readByte());
+		}
+		return bytes;
 		
 	}
 	


### PR DESCRIPTION
when the data is big than max bytes,the position do not move in the old code,it will make mistake.
