### PR TITLE
Cast URL method to string before setting curl opt

### DIFF
--- a/openfl/net/URLLoader.hx
+++ b/openfl/net/URLLoader.hx
@@ -363,7 +363,7 @@ class URLLoader extends EventDispatcher {
 		
 		CURLEasy.reset (__curl);
 		CURLEasy.setopt (__curl, URL, url);
-		
+
 		switch (method) {
 			
 			case HEAD:
@@ -394,8 +394,9 @@ class URLLoader extends EventDispatcher {
 				CURLEasy.setopt(__curl, INFILESIZE, uri.length);
 			
 			case _:
+				var reqMethod:String = method;
 				
-				CURLEasy.setopt(__curl, CUSTOMREQUEST, cast method);
+				CURLEasy.setopt(__curl, CUSTOMREQUEST, reqMethod);
 				CURLEasy.setopt(__curl, READFUNCTION, readFunction.bind(_, uri));
 				CURLEasy.setopt(__curl, INFILESIZE, uri.length);
 			


### PR DESCRIPTION
@jgranick any method that fell into this catch all case was being sent as its int representation from the enum instead of its representation as a string. We noticed this when delete requests were being sent as "0" instead of "DELETE".

Do you think it would be a better change to make the `URLRequestMethod` a string enum instead of an int enum? Or are there other reasons for using an int there?