### PR TITLE
Enable m4a support for HTML5

### DIFF
--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -200,7 +200,7 @@ class Sound extends EventDispatcher {
 		
 		if (untyped window.createjs != null) {
 			
-			SoundJS.alternateExtensions = [ "ogg", "mp3", "wav" ];
+			SoundJS.alternateExtensions = [ "ogg", "m4a", "mp3", "wav" ];
 			
 		}
 		


### PR DESCRIPTION
Adds m4a to the SoundJS alternateExtensions array, enabling AAC audio in HTML5. Gives us another option than mp3 for Internet Explorer and Safari, which don't support ogg.