### PR TITLE
EventDispatcher: refactor against nested event bugs.

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -225,7 +225,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if !disa
 	
 	private function __broadcast (event:Event, notifyChilden:Bool):Bool {
 		
-		if (__eventMap != null && hasEventListener (event.type)) {
+		if (hasEventListener (event.type)) {
 			
 			var result = super.__dispatchEvent (event);
 			

--- a/tests/unit/test/openfl/events/EventDispatcherTest.hx
+++ b/tests/unit/test/openfl/events/EventDispatcherTest.hx
@@ -242,6 +242,73 @@ class EventDispatcherTest {
 		
 		
 	}
-	
-	
+
+	var test01aCallCount = 0;
+	var o:EventDispatcher = null;
+	var test02aCallCount = 0;
+	var test02Sequence:String = "";
+
+	private function test01a (e:Event):Void {
+		++test01aCallCount;
+		if ( test01aCallCount == 1 ) { // avoid infinite recursion, but we still should get a second call
+			o.dispatchEvent( new Event("Test01Event") );
+		}
+	}
+
+	@Test
+	public function testDispatch1()
+	{
+		test01aCallCount = 0;
+		o = new EventDispatcher();
+
+		o.addEventListener( "Test01Event", test01a );
+		o.dispatchEvent( new Event( "Test01Event" ) );
+
+		Assert.areEqual(2, test01aCallCount);
+	}
+
+	public function test02a (e:Event):Void {
+		test02Sequence += "a";
+		++test02aCallCount;
+		if ( test02aCallCount == 1 ) {
+			test02Sequence += "(";
+			o.dispatchEvent( new Event( "Test02Event" ) );
+			test02Sequence += ")";
+
+			// dispatching should still be true here, so this shouldn't modify the list we're traversing over
+			// ...but it does...
+			o.removeEventListener( "Test02Event", test02a );
+			o.removeEventListener( "Test02Event", test02b );
+			o.addEventListener( "Test02Event", test02a, false, 4 );
+			o.addEventListener( "Test02Event", test02b, false, 5 );
+		}
+	}
+	private function test02b (e:Event):Void {
+		test02Sequence += "b";
+	}
+	private function test02c (e:Event):Void {
+		test02Sequence += "c";
+	}
+
+	@Test
+	public function testDispatch2()
+	{
+		test02aCallCount = 0;
+		test02Sequence = "";
+
+		o = new EventDispatcher();
+		// Test 02: Dispatching goes false too soon.
+		// The reset of dispatching at the tail of __dispatchEvent,
+		// namely the __dispatching.set (event.type, false); line,
+		// is unconditional. Clearly we want to keep dispatching true
+		// if we're nested, so we should only unset that if we're the
+		// "outermost" dispatcher.
+		o.addEventListener( "Test02Event", test02a, false, 3 );
+		o.addEventListener( "Test02Event", test02b, false, 2 );
+		o.addEventListener( "Test02Event", test02c, false, 1 );
+		o.dispatchEvent( new Event( "Test02Event" ) );
+
+		Assert.areEqual("a(abc)bc", test02Sequence);
+	}
+
 }


### PR DESCRIPTION
Also add comments, dedupe some logic, avoid unnecessary copies, avoid
redundant lookups, and name and grouping changes to be slightly easier to
reason about.

Stepped through all the branches in getList, addEventListener,
removeEventListener, and __dispatchEvent in the Chrome Canary debugger.

This is intended to be posted in #1100 ; see comments in #1101 .

Specifically:

* Merge all the __eventMap, __newEventMap, and __dispatching maps together
  into one map of a new support struct-style class "EventTypeInfo" --
  saves lookups by key and makes the lifetime of the three members
  relative to one another more obvious.

* There should be no risk of losing listeners by discarding __newEventMap
  (one key/value pair or entirely) too early in removeEventListener,
  before merging it back into __eventMap.

* Toss out listener lists and the entire map when appropriate.

* Versus pull #1101 above, don't *always* copy the list from eventMap to
  newEventMap during __dispatchEvent; if we haven't seen any
  modifications, there's no reason to do this.  eventMap will never change
  out from under us while we're dispatching -- if something comes along
  and asks to mutate the list (Add or Remove mode), *then* we'll copy and
  return the newEventMap (now newListeners) list.

Other notes:

* We now return false from __dispatchEvent on all types of empty list, not
  just null __eventMap.  Before this would have returned true on some and
  false on others, depending on whether the list was nulled after it was
  emptied or not.  Seems like the increased consistency here would be a
  good thing.

* We are taking an extra "new" / indirection in lookups -- we now have
  three levels of null where we'd have two potentially before: __typeInfos
  itself, __typeInfo.get(type), and __typeInfo.get(type).listeners or
  .newListeners.  This only adds a smallish block to getList versus the
  old two-level way, and because we're saving so much on lookups the extra
  indirection should not be costly.  This makes lifetime easier to
  reason about.

Summarizing the getList modes:

* Add will never return null.  Others may (for any of the three levels).
  It may return an empty list (new or existing).

* ReadCopy will never directly return a list that may be mutated; that is,
  it may return "listeners" by ref, which is never mutated while
  dispatching, or it may return a copy of newListeners.

I'd like to add a number of asserts (per the invariants mentioned above
and in GetListMode enum docs), but not sure the best way to do this.

Also, I'm not sure the explicit sets in EventTypeInfo's new method are necessary.

Reviewed locally (first pass) by Danielle Cerniglia and Josh Elliott.
Posting before extensive review for comment.  Any errors are of course my
own.

Please feel free to point out any style or submission problems; I'm still new to contributing to openfl!