### PR TITLE
Speedup (dramatically) canvas BitmapData rendering in DOM

### DIFF
--- a/openfl/_internal/renderer/dom/DOMBitmap.hx
+++ b/openfl/_internal/renderer/dom/DOMBitmap.hx
@@ -81,18 +81,24 @@ class DOMBitmap {
 			}
 			
 			DOMRenderer.initializeElement (bitmap, bitmap.__canvas, renderSession);
+			bitmap.__changeId = bitmap.bitmapData.__changeId - 1;
 			
 		}
 		
-		bitmap.bitmapData.__sync ();
+		if (bitmap.__changeId != bitmap.bitmapData.__changeId) {
+			
+			bitmap.__changeId = bitmap.bitmapData.__changeId;
+			bitmap.bitmapData.__sync ();
+			
+			bitmap.__canvas.width = bitmap.bitmapData.width;
+			bitmap.__canvas.height = bitmap.bitmapData.height;
+			
+			// [alpha in style will be used instead] bitmap.__context.globalAlpha = bitmap.__worldAlpha;
+			bitmap.__context.drawImage (bitmap.bitmapData.image.buffer.__srcCanvas, 0, 0);
+			
+		}
 		
-		bitmap.__canvas.width = bitmap.bitmapData.width;
-		bitmap.__canvas.height = bitmap.bitmapData.height;
-		
-		bitmap.__context.globalAlpha = bitmap.__worldAlpha;
-		bitmap.__context.drawImage (bitmap.bitmapData.image.buffer.__srcCanvas, 0, 0);
-		
-		DOMRenderer.applyStyle (bitmap, renderSession, true, false, true);
+		DOMRenderer.applyStyle (bitmap, renderSession, true, true, true);
 		#end
 		
 	}

--- a/openfl/display/Bitmap.hx
+++ b/openfl/display/Bitmap.hx
@@ -11,6 +11,7 @@ import openfl.geom.Point;
 import openfl.geom.Rectangle;
 
 #if (js && html5)
+import haxe.Int32;
 import js.html.ImageElement;
 #end
 
@@ -29,6 +30,7 @@ class Bitmap extends DisplayObject {
 	
 	#if (js && html5)
 	private var __image:ImageElement;
+	private var __changeId:Int32 = 0;
 	#end
 	
 	
@@ -191,6 +193,16 @@ class Bitmap extends DisplayObject {
 	
 	
 	private function set_bitmapData (value:BitmapData):BitmapData {
+
+		#if (js && html5)
+
+		if (value != null) {
+
+			__changeId = value.__changeId - 1;
+
+		}
+
+		#end
 
 		bitmapData = value;
 

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -39,6 +39,7 @@ import openfl.utils.ByteArray;
 import openfl.Vector;
 
 #if (js && html5)
+import haxe.Int32;
 import js.html.CanvasElement;
 import js.html.CanvasRenderingContext2D;
 import js.html.ImageData;
@@ -85,6 +86,10 @@ class BitmapData implements IBitmapDrawable {
 	private var __pingPongTexture:PingPongTexture;
 	private var __usingPingPongTexture:Bool = false;
 	private var __uvData:TextureUvs;
+
+	#if (js && html5)
+	private var __changeId:Int32 = -1;
+	#end
 	
 	
 	public function new (width:Int, height:Int, transparent:Bool = true, fillColor:UInt = 0xFFFFFFFF) {
@@ -167,6 +172,10 @@ class BitmapData implements IBitmapDrawable {
 		
 		image.dirty = true;
 		
+		#if (js && html5)
+		__changeId++;
+		#end
+		
 	}
 	
 	
@@ -191,6 +200,10 @@ class BitmapData implements IBitmapDrawable {
 		
 		image.colorTransform (rect.__toLimeRectangle (), colorTransform.__toLimeColorMatrix ());
 		__usingPingPongTexture = false;
+		
+		#if (js && html5)
+		__changeId++;
+		#end
 		
 	}
 	
@@ -348,6 +361,10 @@ class BitmapData implements IBitmapDrawable {
 		image.copyChannel (sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), sourceChannel, destChannel);
 		__usingPingPongTexture = false;
 		
+		#if (js && html5)
+		__changeId++;
+		#end
+		
 	}
 	
 	
@@ -357,6 +374,10 @@ class BitmapData implements IBitmapDrawable {
 		
 		image.copyPixels (sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), alphaBitmapData != null ? alphaBitmapData.image : null, alphaPoint != null ? alphaPoint.__toLimeVector2 () : null, mergeAlpha);
 		__usingPingPongTexture = false;
+		
+		#if (js && html5)
+		__changeId++;
+		#end
 		
 	}
 	
@@ -369,6 +390,10 @@ class BitmapData implements IBitmapDrawable {
 		height = 0;
 		rect = null;
 		__isValid = false;
+		
+		#if (js && html5)
+		__changeId++;
+		#end
 		
 		if (__texture != null) {
 			
@@ -466,6 +491,8 @@ class BitmapData implements IBitmapDrawable {
 		buffer.__srcImageData = null;
 		buffer.data = null;
 		
+		__changeId++;
+		
 		#else
 		
 		if (colorTransform != null) {
@@ -558,6 +585,10 @@ class BitmapData implements IBitmapDrawable {
 		image.fillRect (rect.__toLimeRectangle (), color, ARGB32);
 		__usingPingPongTexture = false;
 		
+		#if (js && html5)
+		__changeId++;
+		#end
+		
 	}
 	
 	
@@ -566,6 +597,10 @@ class BitmapData implements IBitmapDrawable {
 		if (!__isValid) return;
 		image.floodFill (x, y, color, ARGB32);
 		__usingPingPongTexture = false;
+		
+		#if (js && html5)
+		__changeId++;
+		#end
 		
 	}
 	
@@ -959,6 +994,10 @@ class BitmapData implements IBitmapDrawable {
 		image.merge (sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), redMultiplier, greenMultiplier, blueMultiplier, alphaMultiplier);
 		__usingPingPongTexture = false;
 		
+		#if (js && html5)
+		__changeId++;
+		#end
+		
 	}
 	
 	
@@ -1016,6 +1055,11 @@ class BitmapData implements IBitmapDrawable {
 				setPixel32(x, y, rgb);
 			}
 		}		
+		
+		#if (js && html5)
+		__changeId++;
+		#end
+		
 	}
 	
 	
@@ -1059,7 +1103,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		pixels.position = 0;
 		var destRect = new Rectangle (destPoint.x, destPoint.y, sw, sh);
-		setPixels (destRect, pixels);
+		setPixels (destRect, pixels); // __changeId will be changed in setPixels()
 		
 	}
 	
@@ -1067,6 +1111,7 @@ class BitmapData implements IBitmapDrawable {
 	public function perlinNoise (baseX:Float, baseY:Float, numOctaves:UInt, randomSeed:Int, stitch:Bool, fractalNoise:Bool, channelOptions:UInt = 7, grayScale:Bool = false, offsets:Array<Point> = null):Void {
 		
 		openfl.Lib.notImplemented ("BitmapData.perlinNoise");
+		// #if (js && html5) __changeId++; #end
 		
 	}
 	
@@ -1077,6 +1122,10 @@ class BitmapData implements IBitmapDrawable {
 		image.scroll (x, y);
 		__usingPingPongTexture = false;
 		
+		#if (js && html5)
+		__changeId++;
+		#end
+		
 	}
 	
 	
@@ -1085,6 +1134,10 @@ class BitmapData implements IBitmapDrawable {
 		if (!__isValid) return;
 		image.setPixel (x, y, color, ARGB32);
 		__usingPingPongTexture = false;
+		
+		#if (js && html5)
+		__changeId++;
+		#end
 		
 	}
 	
@@ -1095,6 +1148,10 @@ class BitmapData implements IBitmapDrawable {
 		image.setPixel32 (x, y, color, ARGB32);
 		__usingPingPongTexture = false;
 		
+		#if (js && html5)
+		__changeId++;
+		#end
+		
 	}
 	
 	
@@ -1103,6 +1160,10 @@ class BitmapData implements IBitmapDrawable {
 		if (!__isValid || rect == null) return;
 		image.setPixels (rect.__toLimeRectangle (), byteArray, ARGB32);
 		__usingPingPongTexture = false;
+		
+		#if (js && html5)
+		__changeId++;
+		#end
 		
 	}
 	
@@ -1119,7 +1180,7 @@ class BitmapData implements IBitmapDrawable {
 		}
 		
 		byteArray.position = 0;
-		setPixels (rect, byteArray);
+		setPixels (rect, byteArray); // __changeId will be changed in setPixels()
 		
 	}
 	
@@ -1127,6 +1188,10 @@ class BitmapData implements IBitmapDrawable {
 	public function threshold (sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point, operation:String, threshold:Int, color:Int = 0x00000000, mask:Int = 0xFFFFFFFF, copySource:Bool = false):Int {
 		
 		if (sourceBitmapData == null || sourceRect == null || destPoint == null || sourceRect.x > sourceBitmapData.width || sourceRect.y > sourceBitmapData.height || destPoint.x > width || destPoint.y > height) return 0;
+		
+		#if (js && html5)
+		__changeId++;
+		#end
 		
 		return image.threshold (sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), operation, threshold, color, mask, copySource, ARGB32);
 		
@@ -1184,7 +1249,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		Image.fromBase64 (base64, type, function (image) {
 			
-			__fromImage (image);
+			__fromImage (image); // __changeId will be changed inside __fromImage()
 			
 			if (onload != null) {
 				
@@ -1201,7 +1266,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		Image.fromBytes (bytes, function (image) {
 			
-			__fromImage (image);
+			__fromImage (image); // __changeId will be changed inside __fromImage()
 			
 			if (rawAlpha != null) {
 				
@@ -1220,6 +1285,10 @@ class BitmapData implements IBitmapDrawable {
 				
 				image.dirty = true;
 				
+				#if (js && html5)
+				__changeId++;
+				#end
+				
 			}
 			
 			if (onload != null) {
@@ -1237,7 +1306,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		Image.fromFile (path, function (image) {
 			
-			__fromImage (image);
+			__fromImage (image); // __changeId will be changed inside __fromImage()
 			
 			if (onload != null) {
 				
@@ -1266,6 +1335,10 @@ class BitmapData implements IBitmapDrawable {
 			#end
 			
 			__isValid = true;
+			
+			#if (js && html5)
+			__changeId++;
+			#end
 			
 		}
 		


### PR DESCRIPTION
Speedup (dramatically) non-image BitmapData (when __canvas is used) rendering in DOM mode.

**Issue is still reproducible on OpenFL 4.**

Without fix: http://pub.zame-dev.org/openfl-bitmap-data-slowness/dom/index.html - 2 FPS
Canvas renderer (to compare): http://pub.zame-dev.org/openfl-bitmap-data-slowness/canvas/index.html - 60 FPS

Sample project: http://pub.zame-dev.org/openfl-bitmap-data-slowness/project.zip

Sample project code:

``` haxe
class App extends Sprite {
    public function new() {
        super();

        var spritesheetBitmapData = Assets.getBitmapData("drawable/spritesheet.png");

        var defaultBitmapData = new BitmapData(58, 51, true, 0);
        defaultBitmapData.copyPixels(spritesheetBitmapData, new Rectangle(66, 0, 58, 81), new Point(0, 0), null, null, true);

        var lockedBitmapData = new BitmapData(66, 72, true, 0);
        lockedBitmapData.copyPixels(spritesheetBitmapData, new Rectangle(0, 0, 66, 72), new Point(0, 0), null, null, true);

        for (row in 0 ... 7) {
            for (col in 0 ... 60) {
                var bitmap = new Bitmap(defaultBitmapData, PixelSnapping.AUTO, true);
                bitmap.x = 20 * col + 4;
                bitmap.y = 90 * row + 35;
                addChild(bitmap);
            }
        }

        for (row in 0 ... 7) {
            for (col in 0 ... 60) {
                var bitmap = new Bitmap(lockedBitmapData, PixelSnapping.AUTO, true);
                bitmap.x = 20 * col;
                bitmap.y = 90 * row;
                bitmap.alpha = 0.75;
                addChild(bitmap);
            }
        }

        addChild(new FPS(16, 16, 0xff0000));
    }
}
```

Sample project just created two BitmapDatas from one spritesheet, than use them to place 840 Bitmaps on the screen.
Bitmaps are static, they not moved, not changed, etc.

This fix will work well with multiple Bitmaps sharing a single BitmapData.

Why `image.dirty` from lime is not used? At first attempt I try to use "dirty" from lime, but it turned out that it is not suitable (I don't remember exact reason). That's why I added "__changeId".

**Pictures:**

Dom (notice - **2** FPS)

![screen shot 2016-11-27 at 14 57 11](https://cloud.githubusercontent.com/assets/85473/20648319/70e2b154-b4b4-11e6-9ad0-6f318616c714.png)

Canvas (notice - 61 FPS)

![screen shot 2016-11-27 at 14 57 45](https://cloud.githubusercontent.com/assets/85473/20648322/81a697ee-b4b4-11e6-9210-4f37f635a320.png)
