### PR TITLE
Fix bounds in drawTiles

### DIFF
--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -582,16 +582,16 @@ import js.html.CanvasRenderingContext2D;
 						tileWidth = tile.width * scale;
 						tileHeight = tile.height * scale;
 						
-						x -= tilePoint.x * tileWidth;
-						y -= tilePoint.y * tileHeight;
+						x -= tilePoint.x * scale;
+						y -= tilePoint.y * scale;
 						
 						if (rotation != 0) {
 							
 							rect.setTo (0, 0, tileWidth, tileHeight);
 							
 							matrix.identity ();
-							matrix.rotate (rotation);
 							matrix.translate (x, y);
+							matrix.rotate (rotation);
 							
 							rect.__transform (rect, matrix);
 							
@@ -659,8 +659,8 @@ import js.html.CanvasRenderingContext2D;
 					if (tile != null) {
 						
 						centerPoint = sheet.__centerPoints[id];
-						originX = centerPoint.x * tile.width;
-						originY = centerPoint.y * tile.height;
+						originX = centerPoint.x;
+						originY = centerPoint.y;
 						
 						__inflateBounds (x - originX, y - originY);
 						__inflateBounds (x - originX + tile.width, y - originY + tile.height);

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -582,16 +582,14 @@ import js.html.CanvasRenderingContext2D;
 						tileWidth = tile.width * scale;
 						tileHeight = tile.height * scale;
 						
-						x -= tilePoint.x * scale;
-						y -= tilePoint.y * scale;
-						
 						if (rotation != 0) {
 							
 							rect.setTo (0, 0, tileWidth, tileHeight);
 							
 							matrix.identity ();
-							matrix.translate (x, y);
+							matrix.translate (- tilePoint.x * scale, - tilePoint.y * scale);
 							matrix.rotate (rotation);
+							matrix.translate (x, y);
 							
 							rect.__transform (rect, matrix);
 							
@@ -599,6 +597,9 @@ import js.html.CanvasRenderingContext2D;
 							__inflateBounds (rect.right, rect.bottom);
 							
 						} else {
+							
+							x -= tilePoint.x * scale;
+							y -= tilePoint.y * scale;
 							
 							__inflateBounds (x, y);
 							__inflateBounds (x + tileWidth, y + tileHeight);


### PR DESCRIPTION
Based on https://github.com/openfl/openfl/pull/1091 + correctly handle scale and rotation.

Without fix: http://pub.zame-dev.org/openfl-drawtiles-bug/develop/index.html - tiles with centerPoint not rendered at all
With fix: http://pub.zame-dev.org/openfl-drawtiles-bug/drawtiles-transform-fix-dev/index.html - everything rendered correctly

Sample project: http://pub.zame-dev.org/openfl-drawtiles-bug/project.zip

Sample project code:

```haxe
class TilesheetTester extends Sprite {
    public function new(x : Float, y : Float, useFlags : Bool, useCenterPoint : Bool) {
        super();

        this.x = x;
        this.y = y;

        var tilesheet = new Tilesheet(Assets.getBitmapData("drawable/frosty-blood.png"));
        tilesheet.addTileRect(new Rectangle(0, 0, 58, 58), (useCenterPoint ? new Point(29, 29) : null));

        var tileData : Array<Float> = [
            0.0, // x
            0.0, // y
            0.0, // tileId
        ];

        if (useFlags) {
            tileData[3] = 1.5; // scale
            tileData[4] = 45.0 * Math.PI / 180.0; // rotation
            tileData[5] = 1.0; // rgb
            tileData[6] = 1.0; // rgb
            tileData[7] = 1.0; // rgb
            tileData[8] = 0.75; // a
        }

        tilesheet.drawTiles(
            graphics,
            tileData,
            true,
            (useFlags ? Tilesheet.TILE_SCALE | Tilesheet.TILE_ROTATION | Tilesheet.TILE_RGB | Tilesheet.TILE_ALPHA : 0),
            (useFlags ? 9 : 3)
        );
    }
}

class App extends Sprite {
    public function new() {
        super();

        addChild(new TilesheetTester(50, 50, false, false));
        addChild(new TilesheetTester(150, 50, true, false));
        addChild(new TilesheetTester(300, 100, false, true));
        addChild(new TilesheetTester(400, 100, true, true));
    }
}
```
