### PR TITLE
Partial fix for #1123

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -770,6 +770,7 @@ class TextEngine {
 					
 					layoutGroup.offsetY = offsetY;
 					layoutGroup.offsetX = offsetX;
+					layoutGroup.lineIndex++;
 					
 					offsetY += heightValue;
 					lineIndex++;


### PR DESCRIPTION
See #1123 

With this change, every test case I made up in that issue is fixed for `CENTER`, `RIGHT`, and `JUSTIFY` aligns. Could always use more testing, though!

Technically, #1123 also relies on #1094, which isn't complete yet (need to see about multiline input text).