### PR TITLE
Added line feeds to TextFields, closes #1120

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -431,6 +431,19 @@ class TextEngine {
 	}
 	
 	
+	public function getBreakIndex (?startIndex:Int):Int {
+		
+		var cr = text.indexOf ("\n", startIndex);
+		var lf = text.indexOf ("\r", startIndex);
+		
+		if (cr == -1) return lf;
+		if (lf == -1) return cr;
+		
+		return cr < lf ? cr : lf;
+		
+	}
+	
+	
 	public function getLine (index:Int):String {
 		
 		if (index < 0 || index > lineBreaks.length + 1) {
@@ -581,7 +594,7 @@ class TextEngine {
 		var spaceWidth = 0.0;
 		var previousSpaceIndex = 0;
 		var spaceIndex = text.indexOf (" ");
-		var breakIndex = text.indexOf ("\n");
+		var breakIndex = getBreakIndex ();
 		
 		var marginRight = 0.0;
 		var offsetX = 2.0;
@@ -778,7 +791,7 @@ class TextEngine {
 				}
 				
 				textIndex = breakIndex + 1;
-				breakIndex = text.indexOf ("\n", textIndex);
+				breakIndex = getBreakIndex (textIndex);
 				lineIndex++;
 				
 				if (formatRange.end == breakIndex) {
@@ -1034,7 +1047,8 @@ class TextEngine {
 								
 								group = layoutGroups[i + lineLength - 1];
 								
-								if (group.endIndex < text.length && text.charAt (group.endIndex) != "\n") {
+								var endChar = text.charAt (group.endIndex);
+								if (group.endIndex < text.length && endChar != "\n" && endChar != "\r") {
 									
 									offsetX = (width - 4 - lineWidths[lineIndex]) / (lineLength - 1);
 									

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -207,7 +207,7 @@ class TextField extends InteractiveObject {
 		
 		if (charIndex < 0 || charIndex > __textEngine.text.length - 1) return 0;
 		
-		var index = __textEngine.text.indexOf ("\n");
+		var index = __textEngine.getBreakIndex ();
 		var startIndex = 0;
 		
 		while (index > -1) {
@@ -222,7 +222,7 @@ class TextField extends InteractiveObject {
 				
 			}
 			
-			index = __textEngine.text.indexOf ("\n", index + 1);
+			index = __textEngine.getBreakIndex (index + 1);
 			
 		}
 		
@@ -391,7 +391,7 @@ class TextField extends InteractiveObject {
 		if (charIndex < 0 || charIndex > __textEngine.text.length - 1) return 0;
 		
 		var startIndex = getFirstCharInParagraph (charIndex);
-		var endIndex = __textEngine.text.indexOf ("\n", charIndex) + 1;
+		var endIndex = __textEngine.getBreakIndex (charIndex) + 1;
 		
 		if (endIndex == 0) endIndex = __textEngine.text.length;
 		return endIndex - startIndex;


### PR DESCRIPTION
#1120 

Needs review, but the string `"test\ntest\rtest\n\rtest\r\ntest"` comes out correctly now.

HTML5:
![image](https://cloud.githubusercontent.com/assets/5033927/15231653/12ec65de-1862-11e6-8e0a-cd2fe62a749f.png)

I'm having trouble exporting to cpp targets if someone can double check that.