### PR TITLE
Show mouse cursor of pressed object when present. (Flash behavior)

### DIFF
--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -1102,14 +1102,23 @@ class Stage extends DisplayObjectContainer implements IModule {
 		
 		var cursor = null;
 		
-		for (target in stack) {
+		// If any object is pressed, we use it's cursor at all times until released.
+		if (__mouseDownLeft != null) {
 			
-			cursor = target.__getCursor ();
+			cursor = __mouseDownLeft.__getCursor();
 			
-			if (cursor != null) {
+		} else {
+			
+			for (target in stack) {
 				
-				Mouse.cursor = cursor;
-				break;
+				cursor = target.__getCursor ();
+				
+				if (cursor != null) {
+					
+					Mouse.cursor = cursor;
+					break;
+					
+				}
 				
 			}
 			


### PR DESCRIPTION
In flash, when you press a button, cursor will remain at Pointer state even if mouse isn't on a button anymore, but still pressed.  
On native targets cursor resets when mouse leaves button area. Fixed it.