### PR TITLE
Make sure to save to url on all targets, not just HTML5.

### DIFF
--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -95,13 +95,14 @@ class Sound extends EventDispatcher {
 	
 	public function load (stream:URLRequest, context:SoundLoaderContext = null):Void {
 		
+		url = stream.url;
+
 		#if !html5
 		
 		AudioBuffer.fromURL (stream.url, AudioBuffer_onURLLoad);
 		
 		#else
 		
-		url = stream.url;
 		__soundID = Path.withoutExtension (stream.url);
 		
 		if (!__registeredSounds.exists (__soundID)) {


### PR DESCRIPTION
Needed when getting the url via the completed event.