### PR TITLE
Stage3d texture upload improvements

### DIFF
--- a/openfl/_internal/aglsl/AGLSLParser.hx
+++ b/openfl/_internal/aglsl/AGLSLParser.hx
@@ -107,10 +107,13 @@ class AGLSLParser {
 			
 		}
 		
-		#if js
-		if (desc.header.type == "fragment")
+		if (desc.header.type == "fragment") {
+			
 			header += "vec4 texture2DYFlip(in sampler2D s, in vec2 coord) {return texture2D(s, vec2(coord.x, 1.0 - coord.y));}\n";
-		#end
+			header += "vec4 textureCubeYFlip(in samplerCube s, in vec3 coord) {return textureCube(s, vec3(coord.x, coord.y, coord.z));}\n";
+			
+		}
+		
 		// extra gl fluff: setup position and depth adjust temps
 		if (desc.header.type == "vertex") {
 			

--- a/openfl/_internal/aglsl/Mapping.hx
+++ b/openfl/_internal/aglsl/Mapping.hx
@@ -59,11 +59,7 @@ class Mapping {
 				//         s 															flags  	dest    a     b 	    mw 	  mh    ndwm  scale dm	  lod 
 				new OpLUT ("%dest = %cast(texture%texdimLod(%b,%texsize(%a)).%dm);\n", null, true, true, true, null, null, null, null, true, null),
 				new OpLUT ("if ( float(%a)<0.0 ) discard;\n", null, false, true, false, null, null, null, true, null, null),
-                #if js
-					new OpLUT ("%dest = %cast(texture%texdimYFlip(%b,%texsize(%a)%lod).%dm);\n", null, true, true, true, null, null, true, null, true, true),
-				#else
-					new OpLUT ("%dest = %cast(texture%texdim(%b,%texsize(%a)%lod).%dm);\n", null, true, true, true, null, null, true, null, true, true),
-				#end
+				new OpLUT ("%dest = %cast(texture%texdimYFlip(%b,%texsize(%a)%lod).%dm);\n", null, true, true, true, null, null, true, null, true, true),
 				new OpLUT ("%dest = %cast(greaterThanEqual(%a,%b).%dm);\n", 0, true, true, true, null, null, true, null, true, null),
 				new OpLUT ("%dest = %cast(lessThan(%a,%b).%dm);\n", 0, true, true, true, null, null, true, null, true, null),
 				new OpLUT ("%dest = %cast(sign(%a));\n", 0, true, true, false, null, null, null, null, null, null),

--- a/openfl/display3D/Context3D.hx
+++ b/openfl/display3D/Context3D.hx
@@ -99,10 +99,6 @@ import openfl.Lib;
 		
 		stage.addChildAt(ogl, 0);
 		
-		#if js
-		GL.pixelStorei (GL.UNPACK_FLIP_Y_WEBGL, 1);
-		GL.pixelStorei (GL.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
-		#end
 	}
 	
 	

--- a/openfl/display3D/textures/CubeTexture.hx
+++ b/openfl/display3D/textures/CubeTexture.hx
@@ -4,9 +4,7 @@ package openfl.display3D.textures;
 import openfl.display3D.Context3D;
 import openfl.gl.GL;
 import openfl.gl.GLTexture;
-import openfl.geom.Rectangle;
 import openfl.utils.ByteArray;
-import openfl.utils.UInt8Array;
 
 using openfl.display.BitmapData;
 
@@ -53,6 +51,10 @@ using openfl.display.BitmapData;
 	public function uploadFromBitmapData (bitmapData:BitmapData, side:Int, miplevel:Int = 0):Void {
 		
 		var source = bitmapData.image.data;
+		
+		#if (js && html5)
+		GL.pixelStorei (GL.UNPACK_FLIP_Y_WEBGL, 0);
+		#end
 		
 		GL.bindTexture (GL.TEXTURE_CUBE_MAP, glTexture);
 		

--- a/openfl/display3D/textures/TextureBase.hx
+++ b/openfl/display3D/textures/TextureBase.hx
@@ -1,10 +1,13 @@
 package openfl.display3D.textures;
 
 
-import openfl.gl.GL;
-import openfl.gl.GLTexture;
-import openfl.gl.GLFramebuffer;
 import openfl.events.EventDispatcher;
+import openfl.gl.GLFramebuffer;
+import openfl.gl.GLTexture;
+import openfl.utils.ArrayBufferView;
+import openfl.utils.ByteArray;
+import openfl.utils.ByteArray.ByteArrayData;
+import openfl.utils.UInt8Array;
 
 
 class TextureBase extends EventDispatcher {
@@ -34,5 +37,68 @@ class TextureBase extends EventDispatcher {
 		
 	}
 	
+	private function flipPixels (inData:ArrayBufferView, _width:Int, _height:Int):UInt8Array {
+		
+		#if native
+		if (inData == null) {
+			
+			return null;
+			
+		}
+		
+		var data = getUInt8ArrayFromArrayBufferView (inData);
+		var data2 = new UInt8Array (data.length);
+		var bpp = 4;
+		var bytesPerLine = _width * bpp;
+		var srcPosition = (_height - 1) * bytesPerLine;
+		var dstPosition = 0;
+		
+		for (i in 0 ... _height) {
+			
+			data2.set (data.subarray (srcPosition, srcPosition + bytesPerLine), dstPosition);
+			srcPosition -= bytesPerLine;
+			dstPosition += bytesPerLine;
+			
+		}
+		
+		return data2;
+		#else
+		return null;
+		#end
+		
+	}
 	
+	private function getUInt8ArrayFromByteArray (data:ByteArray, byteArrayOffset:Int):UInt8Array {
+		
+		#if js
+		return byteArrayOffset == 0 ? @:privateAccess (data:ByteArrayData).b : new UInt8Array (data.toArrayBuffer (), byteArrayOffset);
+		#else
+		return new UInt8Array (data.toArrayBuffer (), byteArrayOffset);
+		#end
+		
+	}
+	
+	private function getUInt8ArrayFromArrayBufferView (data:ArrayBufferView):UInt8Array {
+		
+		return new UInt8Array (data.buffer, data.byteOffset, data.byteLength);
+		
+	}
+	
+	private function getSizeForMipLevel (miplevel:Int): {width:Int, height:Int} {
+		
+		var _width = width;
+		var _height = height;
+		var lv = miplevel;
+		
+		while (lv > 0) {
+			
+			_width >>= 1;
+			_height >>= 1;
+			lv >>= 1;
+			
+		}
+		
+		return {width:_width, height:_height};
+		
+	}
 }


### PR DESCRIPTION
This PR fixes following issues:
- Upload texture y-flipped on all platforms. This is needed for making texture y coordinate consistent with render-target textures. We cannot use UNPACK_FLIP_Y_WEBGL on native platforms, so I manually flipped pixels in Haxe code to emulate this behavior. We might be able to improve performance further by implementing this with native code.
- Added uploadFromTypedArray and deprecate uploadFromUInt8Array. I realized that pixels doesn't have to always be UInt8Array. It just has to be ArrayBufferView. We need this change for implementing floating-point textures in the future. I didn't remove uploadFromUInt8Array immediately, so that people can prepare for this change.
- Added yFlipped in addition to existing parameters from uploadFromUInt8Array. Might be useful for uploading images which are already in bottom-up format.

I didn't y-flip pixels for CubeTexture. Rendering seems OK, but do I need some changes to make this consistent with other parts?