### PR TITLE
Add <noscript> warning to HTML5 template.

### DIFF
--- a/templates/html5/template/index.html
+++ b/templates/html5/template/index.html
@@ -41,6 +41,8 @@
 </head>
 <body>
 	
+	<noscript>This webpage makes extensive use of JavaScript. Please enable JavaScript in your web browser to view this page.</noscript>
+	
 	<div id="openfl-content"></div>
 	
 	<script type="text/javascript">


### PR DESCRIPTION
Just a simple warning message to add for those who have disabled JavaScript in their web browsers (or their web browser doesn't support it).