### PR TITLE
Added ProgressEvent support for HTML5 target

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -580,10 +580,10 @@ class BitmapData implements IBitmapDrawable {
 	#end
 	
 	
-	public static function fromFile (path:String, onload:BitmapData -> Void = null, onerror:Void -> Void = null):BitmapData {
+	public static function fromFile (path:String, onload:BitmapData -> Void = null, onerror:Void -> Void = null, onprog:Float -> Float -> Void = null):BitmapData {
 		
 		var bitmapData = new BitmapData (0, 0, true);
-		bitmapData.__fromFile (path, onload, onerror);
+		bitmapData.__fromFile (path, onload, onerror, onprog);
 		return bitmapData;
 		
 	}
@@ -1183,7 +1183,7 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	private function __fromFile (path:String, onload:BitmapData -> Void, onerror:Void -> Void):Void {
+	private function __fromFile (path:String, onload:BitmapData -> Void, onerror:Void -> Void, onprog:Float -> Float -> Void = null):Void {
 		
 		Image.fromFile (path, function (image) {
 			
@@ -1195,7 +1195,7 @@ class BitmapData implements IBitmapDrawable {
 				
 			}
 			
-		}, onerror);
+		}, onerror, onprog);
 		
 	}
 	


### PR DESCRIPTION
This change adds ProgressEvent functionality to the Loader/LoaderInfo classes in HTML5.
The underlying functionality is slightly different, so to opt-out of the new functionality (if for example, it's not behaving correctly in some browser), remove the ProgressEvent listener, which doesn't work in older versions of openfl anyway.

It depends on this Lime commit:
https://github.com/ImaginationSydney/lime/commit/a6bf5edf959d14672782aede9dbc0629030fac66

Which has a pull request to Lime:
https://github.com/openfl/lime/pull/769
