### PR TITLE
Fix for segmentation error in textfield on linux

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -243,7 +243,9 @@ class TextEngine {
 			instance = findFont (format.font);
 			if (instance != null) return instance;
 			
+			#if (!linux) // this cause segmentation error on linux
 			var systemFontDirectory = System.fontsDirectory;
+			#end
 			
 			switch (format.font) {
 				
@@ -329,7 +331,11 @@ class TextEngine {
 				
 				default:
 					
+					#if linux
+					fontList = [ new sys.io.Process('fc-match', ['sans', '-f%{file}']).stdout.readLine() ];
+					#else
 					fontList = [ systemFontDirectory + "/" + format.font ];
+					#end
 				
 			}
 			


### PR DESCRIPTION
This can fix segmentation error on Linux.