### PR TITLE
[Incomplete] Break long words

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -777,6 +777,8 @@ class TextEngine {
 					
 				}
 				
+				if (i == 0) i = 1;
+				
 				layoutGroup = new TextLayoutGroup (formatRange.format, textIndex, textIndex + i);
 				layoutGroup.advances = getAdvances(text, textIndex, textIndex + i);
 				layoutGroup.offsetX = offsetX;

--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -758,7 +758,7 @@ class TextEngine {
 			
 			var tempWidth = getTextWidth(text.substring(textIndex, endIndex));
 			
-			while (tempWidth > width) {
+			while (offsetX + tempWidth > width - 2) {
 				
 				var i = 1;
 				

--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -912,9 +912,7 @@ class TextEngine {
 							
 						}
 						
-						if (wordWrap) {
-							breakLongWords(spaceIndex);
-						}
+						breakLongWords(spaceIndex);
 						
 						layoutGroup = new TextLayoutGroup (formatRange.format, textIndex, spaceIndex);
 						layoutGroup.advances = advances;


### PR DESCRIPTION
Reference #1185 

@larsiusprime, if you don't need multiple formats, I think it's good/only has minor issues

HTML5/Flash results so far:
![image](https://cloud.githubusercontent.com/assets/5033927/16709633/8d27df72-45e4-11e6-9d32-802a5e4637ba.png)

Test string 1-4: `これがうまくいけば、日本語を使用することができることを強調するためにいくつかのテストテキストです。` left, center, right, justify
Test string 5: `これがうまくいけば、日\n本語を使用するこ\nとができ\nることを強調するためにいくつ\nかのテストテキストです。` left

They are different, but HTML5's text is ever so slightly thinner than Flash's for whatever reason, which is causing a few characters to stay on the line when in Flash they would be bumped down. I tried a bunch of English test cases in every text align, but I wouldn't call it thorough.

**Issues:**
1. `RIGHT` align does not give the text a 2px buffer. Hard to see with Japanese, but it was obvious in English (existing issue)
2. I haven't tried multiple formats
3. Selecting text barely works (existing issue)
4. I can't run cpp (still), so I couldn't test there
5. I haven't tested this fully when `wordWrap` is false
