### PR TITLE
2 small bug fixes for Sound class in html5

### DIFF
--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -1,6 +1,7 @@
 package openfl.media;
 
 
+import haxe.Timer;
 import haxe.io.Path;
 import lime.audio.AudioBuffer;
 import lime.audio.AudioSource;
@@ -69,6 +70,7 @@ class Sound extends EventDispatcher {
 		if (__registeredSounds.exists (__soundID)) {
 			
 			SoundJS.removeSound (__soundID);
+			__registeredSounds.remove (__soundID);
 			
 		}
 		
@@ -113,8 +115,12 @@ class Sound extends EventDispatcher {
 			SoundJS.registerSound (url, __soundID);
 			
 		} else {
-			
-			dispatchEvent (new Event (Event.COMPLETE));
+
+			Timer.delay(function() {
+
+				dispatchEvent (new Event (Event.COMPLETE));
+
+			}, 1);
 			
 		}
 		


### PR DESCRIPTION
- remove from __registeredSounds when closing
- dispatch COMPLETE event after a delay, so that first a listener can be set