### PR TITLE
add dumpBits (remove bitmapData from RAM while keeping _texture)

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -376,6 +376,18 @@ class BitmapData implements IBitmapDrawable {
 		
 	}
 	
+	public function dumpBits ():Void {
+	
+		__isValid = false;
+		image = null;
+		
+	}
+	
+	public function canBeDump ():Bool {
+		
+		return __isValid && __texture != null;
+		
+	}
 	
 	public function draw (source:IBitmapDrawable, matrix:Matrix = null, colorTransform:ColorTransform = null, blendMode:BlendMode = null, clipRect:Rectangle = null, smoothing:Bool = false):Void {
 		
@@ -714,7 +726,7 @@ class BitmapData implements IBitmapDrawable {
 	
 	public function getTexture (gl:GLRenderContext):GLTexture {
 		
-		if (!__isValid) return null;
+		if (!__isValid) return __texture;
 		
 		if (__texture == null) {
 			


### PR DESCRIPTION
adding `dumpBits`to openfl next allow same behavior as legacy (where a dumpBits method already exists). Some game engine like HaxeFlixel uses dumpBits when compiling with legacy so it will be great to have it in next too.

I've test the method and it works (sometimes I need to call `System.gc()` right after to remove RAM immediately)

Of course we have to call dumpBits after the texture is generated once so I've added `canBeDump()`method.
