### PR TITLE
Fix for stroking too early when changing lineStyle

### DIFF
--- a/openfl/_internal/renderer/cairo/CairoGraphics.hx
+++ b/openfl/_internal/renderer/cairo/CairoGraphics.hx
@@ -584,9 +584,9 @@ class CairoGraphics {
 				case LINE_STYLE:
 					
 					var c = data.readLineStyle ();
-					if (stroke && hasStroke) {
+					if (stroke) {
 						
-						closePath (c.thickness == null);
+						closePath (hasStroke);
 						
 					}
 					

--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -587,9 +587,9 @@ class CanvasGraphics {
 				case LINE_STYLE:
 					
 					var c = data.readLineStyle ();
-					if (stroke && hasStroke) {
+					if (stroke) {
 						
-						closePath (c.thickness == null);
+						closePath (hasStroke);
 						
 					}
 					


### PR DESCRIPTION
Before this patch, the speech bubble in [this test program](https://github.com/vizanto/openfl-linestyle-bug) gets a diagonal line drawn trough it, while the Flash version is obviously correct.

Here's a picture of what's wrong:
![HTML5](https://raw.githubusercontent.com/vizanto/openfl-linestyle-bug/master/broken-html5.png)


This is how Flash renders the same code:
![Flash](https://raw.githubusercontent.com/vizanto/openfl-linestyle-bug/master/flash.png)