### PR TITLE
Apply ColorTransform directly when rendering text and shapes

### DIFF
--- a/openfl/_internal/renderer/cairo/CairoShape.hx
+++ b/openfl/_internal/renderer/cairo/CairoShape.hx
@@ -22,7 +22,7 @@ class CairoShape {
 		
 		if (graphics != null) {
 			
-			CairoGraphics.render (graphics, renderSession, shape.__worldTransform);
+			CairoGraphics.render (graphics, renderSession, shape.__worldTransform, shape.__worldColorTransform);
 			
 			var bounds = graphics.__bounds;
 			

--- a/openfl/_internal/renderer/cairo/CairoTextField.hx
+++ b/openfl/_internal/renderer/cairo/CairoTextField.hx
@@ -12,6 +12,7 @@ import lime.graphics.cairo.CairoImageSurface;
 import openfl._internal.renderer.RenderSession;
 import openfl._internal.text.TextEngine;
 import openfl.display.BitmapData;
+import openfl.geom.ColorTransform;
 import openfl.geom.Matrix;
 import openfl.geom.Rectangle;
 import openfl.text.TextField;
@@ -24,6 +25,14 @@ import openfl.text.TextFormat;
 
 
 class CairoTextField {
+
+
+	private static inline function setSourceRGB(cairo : Cairo, colorTransform : ColorTransform, input_rgb : Int) : Void
+	{
+		CairoUtils.applyColorTransform(colorTransform, input_rgb, 1.0,
+			cairo.setSourceRGB (r, g, b)
+		);
+	}
 	
 	
 	public static function render (textField:TextField, renderSession:RenderSession, transform:Matrix) {
@@ -32,6 +41,7 @@ class CairoTextField {
 		
 		var textEngine = textField.__textEngine;
 		var bounds = textEngine.bounds;
+		var colorTransform = textField.__worldColorTransform.__isDefault() ? null : textField.__worldColorTransform;
 		var graphics = textField.__graphics;
 		var cairo = graphics.__cairo;
 		
@@ -137,24 +147,14 @@ class CairoTextField {
 			
 		} else {
 			
-			var color = textEngine.backgroundColor;
-			var r = ((color & 0xFF0000) >>> 16) / 0xFF;
-			var g = ((color & 0x00FF00) >>> 8) / 0xFF;
-			var b = (color & 0x0000FF) / 0xFF;
-			
-			cairo.setSourceRGB (r, g, b);
+			setSourceRGB(cairo, colorTransform, textEngine.backgroundColor);
 			cairo.fillPreserve ();
 			
 		}
 		
 		if (textEngine.border) {
 			
-			var color = textEngine.borderColor;
-			var r = ((color & 0xFF0000) >>> 16) / 0xFF;
-			var g = ((color & 0x00FF00) >>> 8) / 0xFF;
-			var b = (color & 0x0000FF) / 0xFF;
-			
-			cairo.setSourceRGB (r, g, b);
+			setSourceRGB(cairo, colorTransform, textEngine.borderColor);
 			cairo.lineWidth = 1;
 			cairo.stroke ();
 			
@@ -191,19 +191,15 @@ class CairoTextField {
 				
 			}
 			
-			var color, r, g, b, font, size, advance;
+			var font, size, advance;
 			
 			for (group in textEngine.layoutGroups) {
 				
 				if (group.lineIndex < textField.scrollV - 1) continue;
 				if (group.lineIndex > textField.scrollV + textEngine.bottomScrollV - 2) break;
 				
-				color = group.format.color;
-				r = ((color & 0xFF0000) >>> 16) / 0xFF;
-				g = ((color & 0x00FF00) >>> 8) / 0xFF;
-				b = (color & 0x0000FF) / 0xFF;
-				
-				cairo.setSourceRGB (r, g, b);
+				setSourceRGB(cairo, colorTransform, group.format.color);
+
 				
 				font = TextEngine.getFontInstance (group.format);
 				

--- a/openfl/_internal/renderer/cairo/CairoUtils.hx
+++ b/openfl/_internal/renderer/cairo/CairoUtils.hx
@@ -1,0 +1,30 @@
+package openfl._internal.renderer.cairo;
+
+
+import haxe.macro.Expr;
+import openfl.geom.ColorTransform;
+
+
+class CairoUtils
+{
+	public static inline var scale = 1/0xFF;
+
+	public static macro function applyColorTransform(colorTransform : ExprOf<ColorTransform>, rgb : ExprOf<Int>, a : ExprOf<Float>, rgbaExpr : Expr) : Expr
+	{
+		return macro ColorTransform.__with_var_rgba($rgb, $a,
+			{
+				var r:Float = r;
+				var g:Float = g;
+				var b:Float = b;
+				
+				if ($colorTransform != null)
+					colorTransform.__apply_to_var_rgba();
+				
+				r *= CairoUtils.scale;
+				g *= CairoUtils.scale;
+				b *= CairoUtils.scale;
+				$rgbaExpr;
+			}
+		);
+	}
+}

--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -144,7 +144,8 @@ class CanvasGraphics {
 			if (colorTransform != null)
 				colorTransform.__apply_to_var_rgba();
 
-			gradientFill.addColorStop (ratio, "rgba(" + r + ", " + g + ", " + b + ", " + a + ")");
+			var rgbaString = CanvasUtils.rgbaString(r,g,b,a);
+			gradientFill.addColorStop (ratio, rgbaString);
 		});
 		
 		return cast (gradientFill);

--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -13,6 +13,7 @@ import openfl.display.GradientType;
 import openfl.display.Graphics;
 import openfl.display.InterpolationMethod;
 import openfl.display.SpreadMethod;
+import openfl.geom.ColorTransform;
 import openfl.geom.Matrix;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
@@ -105,7 +106,7 @@ class CanvasGraphics {
 	}
 	
 	
-	private static function createGradientPattern (type:GradientType, colors:Array<Dynamic>, alphas:Array<Dynamic>, ratios:Array<Dynamic>, matrix:Matrix, spreadMethod:SpreadMethod, interpolationMethod:InterpolationMethod, focalPointRatio:Float) {
+	private static function createGradientPattern (type:GradientType, colors:Array<Dynamic>, alphas:Array<Dynamic>, ratios:Array<Dynamic>, matrix:Matrix, spreadMethod:SpreadMethod, interpolationMethod:InterpolationMethod, focalPointRatio:Float, colorTransform:ColorTransform) {
 	
 		#if (js && html5)
 		
@@ -129,21 +130,22 @@ class CanvasGraphics {
 			
 		}
 		
-		for (i in 0...colors.length) {
-			
-			var rgb = colors[i];
-			var alpha = alphas[i];
-			var r = (rgb & 0xFF0000) >>> 16;
-			var g = (rgb & 0x00FF00) >>> 8;
-			var b = (rgb & 0x0000FF);
+
+		for (i in 0...colors.length) ColorTransform.__with_var_rgba(colors[i], alphas[i],
+		{
+			var r:Float = r;
+			var g:Float = g;
+			var b:Float = b;
 			
 			var ratio = ratios[i] / 0xFF;
 			if (ratio < 0) ratio = 0;
 			if (ratio > 1) ratio = 1;
-			
-			gradientFill.addColorStop (ratio, "rgba(" + r + ", " + g + ", " + b + ", " + alpha + ")");
-			
-		}
+
+			if (colorTransform != null)
+				colorTransform.__apply_to_var_rgba();
+
+			gradientFill.addColorStop (ratio, "rgba(" + r + ", " + g + ", " + b + ", " + a + ")");
+		});
 		
 		return cast (gradientFill);
 		
@@ -214,22 +216,22 @@ class CanvasGraphics {
 	}
 	
 	
-	private static function endFill ():Void {
+	private static function endFill (colorTransform:ColorTransform):Void {
 		
 		#if (js && html5)
 		context.beginPath ();
-		playCommands (fillCommands, false);
+		playCommands (fillCommands, colorTransform, false);
 		fillCommands.clear ();
 		#end
 		
 	}
 	
 	
-	private static function endStroke ():Void {
+	private static function endStroke (colorTransform:ColorTransform):Void {
 		
 		#if (js && html5)
 		context.beginPath ();
-		playCommands (strokeCommands, true);
+		playCommands (strokeCommands, colorTransform, true);
 		context.closePath ();
 		strokeCommands.clear ();
 		#end
@@ -322,8 +324,8 @@ class CanvasGraphics {
 					case END_FILL:
 						
 						data.readEndFill ();
-						endFill ();
-						endStroke ();
+						endFill (null);
+						endStroke (null);
 						
 						if (hasFill && context.isPointInPath (x, y)) {
 							
@@ -344,8 +346,8 @@ class CanvasGraphics {
 					
 					case BEGIN_BITMAP_FILL, BEGIN_FILL, BEGIN_GRADIENT_FILL:
 						
-						endFill ();
-						endStroke ();
+						endFill (null);
+						endStroke (null);
 						
 						if (hasFill && context.isPointInPath (x, y)) {
 							
@@ -415,13 +417,13 @@ class CanvasGraphics {
 			
 			if (fillCommands.length > 0) {
 				
-				endFill ();
+				endFill (null);
 				
 			}
 			
 			if (strokeCommands.length > 0) {
 				
-				endStroke ();
+				endStroke (null);
 				
 			}
 			
@@ -498,7 +500,7 @@ class CanvasGraphics {
 	}
 	
 	
-	private static function playCommands (commands:DrawCommandBuffer, stroke:Bool = false):Void {
+	private static function playCommands (commands:DrawCommandBuffer, colorTransform:ColorTransform, stroke:Bool = false):Void {
 		
 		#if (js && html5)
 		bounds = graphics.__bounds;
@@ -610,20 +612,7 @@ class CanvasGraphics {
 						});
 						
 						context.miterLimit = c.miterLimit;
-						
-						if (c.alpha == 1) {
-							
-							context.strokeStyle = "#" + StringTools.hex (c.color & 0x00FFFFFF, 6);
-							
-						} else {
-							
-							var r = (c.color & 0xFF0000) >>> 16;
-							var g = (c.color & 0x00FF00) >>> 8;
-							var b = (c.color & 0x0000FF);
-							
-							context.strokeStyle = "rgba(" + r + ", " + g + ", " + b + ", " + c.alpha + ")";
-							
-						}
+						context.strokeStyle = CanvasUtils.rgbaStyle(colorTransform, c.color, c.alpha);
 						
 						hasStroke = true;
 						
@@ -639,7 +628,7 @@ class CanvasGraphics {
 					}
 					
 					context.moveTo (positionX - offsetX, positionY - offsetY);
-					context.strokeStyle = createGradientPattern (c.type, c.colors, c.alphas, c.ratios, c.matrix, c.spreadMethod, c.interpolationMethod, c.focalPointRatio);
+					context.strokeStyle = createGradientPattern (c.type, c.colors, c.alphas, c.ratios, c.matrix, c.spreadMethod, c.interpolationMethod, c.focalPointRatio, colorTransform);
 					
 					hasStroke = true;
 				
@@ -685,19 +674,7 @@ class CanvasGraphics {
 						
 					} else {
 						
-						if (c.alpha == 1) {
-							
-							context.fillStyle = "#" + StringTools.hex (c.color, 6);
-							
-						} else {
-							
-							var r = (c.color & 0xFF0000) >>> 16;
-							var g = (c.color & 0x00FF00) >>> 8;
-							var b = (c.color & 0x0000FF);
-							
-							context.fillStyle = "rgba(" + r + ", " + g + ", " + b + ", " + c.alpha + ")";
-							
-						}
+						context.fillStyle = CanvasUtils.rgbaStyle(colorTransform, c.color, c.alpha);
 						
 						bitmapFill = null;
 						hasFill = true;
@@ -707,7 +684,7 @@ class CanvasGraphics {
 				case BEGIN_GRADIENT_FILL:
 					
 					var c = data.readBeginGradientFill ();
-					context.fillStyle = createGradientPattern (c.type, c.colors, c.alphas, c.ratios, c.matrix, c.spreadMethod, c.interpolationMethod, c.focalPointRatio);
+					context.fillStyle = createGradientPattern (c.type, c.colors, c.alphas, c.ratios, c.matrix, c.spreadMethod, c.interpolationMethod, c.focalPointRatio, colorTransform);
 					
 					bitmapFill = null;
 					hasFill = true;
@@ -822,7 +799,7 @@ class CanvasGraphics {
 	}
 	
 	
-	public static function render (graphics:Graphics, renderSession:RenderSession, parentTransform:Matrix):Void {
+	public static function render (graphics:Graphics, renderSession:RenderSession, parentTransform:Matrix, colorTransform:ColorTransform):Void {
 		
 		#if (js && html5)
 		
@@ -902,8 +879,8 @@ class CanvasGraphics {
 						case END_FILL:
 							
 							data.readEndFill ();
-							endFill ();
-							endStroke ();
+							endFill (colorTransform);
+							endStroke (colorTransform);
 							hasFill = false;
 							bitmapFill = null;
 						
@@ -924,8 +901,8 @@ class CanvasGraphics {
 						
 						case BEGIN_BITMAP_FILL, BEGIN_FILL, BEGIN_GRADIENT_FILL:
 							
-							endFill ();
-							endStroke ();
+							endFill (colorTransform);
+							endStroke (colorTransform);
 							
 							if (type == BEGIN_BITMAP_FILL) {
 								
@@ -973,8 +950,8 @@ class CanvasGraphics {
 						
 						case DRAW_TRIANGLES:
 							
-							endFill ();
-							endStroke ();
+							endFill (colorTransform);
+							endStroke (colorTransform);
 							
 							var c = data.readDrawTriangles ();
 							
@@ -1144,13 +1121,13 @@ class CanvasGraphics {
 				
 				if (fillCommands.length > 0) {
 					
-					endFill ();
+					endFill (colorTransform);
 					
 				}
 				
 				if (strokeCommands.length > 0) {
 					
-					endStroke ();
+					endStroke (colorTransform);
 					
 				}
 				

--- a/openfl/_internal/renderer/canvas/CanvasShape.hx
+++ b/openfl/_internal/renderer/canvas/CanvasShape.hx
@@ -21,7 +21,7 @@ class CanvasShape {
 		
 		if (graphics != null) {
 			
-			CanvasGraphics.render (graphics, renderSession, shape.__worldTransform);
+			CanvasGraphics.render (graphics, renderSession, shape.__worldTransform, shape.__worldColorTransform.__isDefault() ? null : shape.__worldColorTransform);
 			
 			var bounds = graphics.__bounds;
 			var width = graphics.__width;

--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -9,6 +9,7 @@ import openfl.display.BitmapData;
 import openfl.display.BitmapDataChannel;
 import openfl.display.Graphics;
 import openfl.events.Event;
+import openfl.geom.ColorTransform;
 import openfl.geom.Matrix;
 import openfl.geom.Rectangle;
 import openfl.text.TextField;
@@ -114,6 +115,7 @@ class CanvasTextField {
 		
 		var textEngine = textField.__textEngine;
 		var bounds = textEngine.bounds;
+		var colorTransform = textField.__worldColorTransform.__isDefault() ? null : textField.__worldColorTransform;
 		var graphics = textField.__graphics;
 		
 		if (textField.__dirty) {
@@ -211,7 +213,7 @@ class CanvasTextField {
 						
 						if (textEngine.background) {
 							
-							context.fillStyle = "#" + StringTools.hex (textEngine.backgroundColor, 6);
+							context.fillStyle = CanvasUtils.rgbaStyle(colorTransform, textEngine.backgroundColor, 1);
 							context.fill ();
 							
 						}
@@ -219,7 +221,7 @@ class CanvasTextField {
 						if (textEngine.border) {
 							
 							context.lineWidth = 1;
-							context.strokeStyle = "#" + StringTools.hex (textEngine.borderColor, 6);
+							context.strokeStyle = CanvasUtils.rgbaStyle(colorTransform, textEngine.borderColor, 1);
 							context.stroke ();
 							
 						}
@@ -252,7 +254,8 @@ class CanvasTextField {
 						if (group.lineIndex > textField.scrollV + textEngine.bottomScrollV - 2) break;
 						
 						context.font = TextEngine.getFont (group.format);
-						context.fillStyle = "#" + StringTools.hex (group.format.color, 6);
+
+						context.fillStyle = CanvasUtils.rgbaStyle(colorTransform, group.format.color, 1);
 						
 						if (applyHack) {
 							
@@ -347,7 +350,7 @@ class CanvasTextField {
 						
 						if (textEngine.background) {
 							
-							context.fillStyle = "#" + StringTools.hex (textEngine.backgroundColor, 6);
+							context.fillStyle = CanvasUtils.rgbaStyle(colorTransform, textEngine.backgroundColor, 1);
 							context.fill ();
 							
 						}
@@ -356,7 +359,7 @@ class CanvasTextField {
 							
 							context.lineWidth = 1;
 							context.lineCap = "square";
-							context.strokeStyle = "#" + StringTools.hex (textEngine.borderColor, 6);
+							context.strokeStyle = CanvasUtils.rgbaStyle(colorTransform, textEngine.borderColor, 1);
 							context.stroke ();
 							
 						}

--- a/openfl/_internal/renderer/canvas/CanvasUtils.hx
+++ b/openfl/_internal/renderer/canvas/CanvasUtils.hx
@@ -7,6 +7,18 @@ import openfl.geom.ColorTransform.__with_var_rgba;
 
 class CanvasUtils
 {
+	public static inline function rgbaString(r : Float, g : Float, b : Float, a : Float) : String
+	{
+		var r = Std.int(r);
+		var g = Std.int(g);
+		var b = Std.int(b);
+
+		return if (a >= 1)
+			"#" + StringTools.hex ((r << 16) | (g << 8) | b, 6)
+		else
+			"rgba(" + r + ", " + g + ", " + b + ", " + a + ")";
+	}
+
 	public static inline function rgbaStyle(colorTransform : ColorTransform, input_rgb : Int, input_a : Float) : String
 	{
 		return if (colorTransform == null)
@@ -17,7 +29,7 @@ class CanvasUtils
 			}
 			else
 				__with_var_rgba(input_rgb, input_a,
-					"rgba(" + r + ", " + g + ", " + b + ", " + input_a + ")"
+					rgbaString(r,g,b, input_a)
 				);
 		}
 		else __with_var_rgba(input_rgb, input_a,
@@ -27,10 +39,7 @@ class CanvasUtils
 				var b:Float = b;
 				colorTransform.__apply_to_var_rgba();
 				
-				if (a >= 1)
-					"#" + StringTools.hex ((Std.int(r) << 16) | (Std.int(g) << 8) | Std.int(b), 6)
-				else
-					"rgba(" + r + ", " + g + ", " + b + ", " + a + ")";
+				rgbaString(r,g,b,a);
 			});
 	}
 }

--- a/openfl/_internal/renderer/canvas/CanvasUtils.hx
+++ b/openfl/_internal/renderer/canvas/CanvasUtils.hx
@@ -1,0 +1,36 @@
+package openfl._internal.renderer.canvas;
+
+
+import openfl.geom.ColorTransform;
+import openfl.geom.ColorTransform.__with_var_rgba;
+
+
+class CanvasUtils
+{
+	public static inline function rgbaStyle(colorTransform : ColorTransform, input_rgb : Int, input_a : Float) : String
+	{
+		return if (colorTransform == null)
+		{
+			if (input_a >= 1)
+			{
+				"#" + StringTools.hex (input_rgb, 6);
+			}
+			else
+				__with_var_rgba(input_rgb, input_a,
+					"rgba(" + r + ", " + g + ", " + b + ", " + input_a + ")"
+				);
+		}
+		else __with_var_rgba(input_rgb, input_a,
+			{
+				var r:Float = r;
+				var g:Float = g;
+				var b:Float = b;
+				colorTransform.__apply_to_var_rgba();
+				
+				if (a >= 1)
+					"#" + StringTools.hex ((Std.int(r) << 16) | (Std.int(g) << 8) | Std.int(b), 6)
+				else
+					"rgba(" + r + ", " + g + ", " + b + ", " + a + ")";
+			});
+	}
+}

--- a/openfl/_internal/renderer/dom/DOMShape.hx
+++ b/openfl/_internal/renderer/dom/DOMShape.hx
@@ -31,7 +31,7 @@ class DOMShape {
 				
 				// TODO: Implement scaling
 				
-				CanvasGraphics.render (graphics, renderSession, matrix);
+				CanvasGraphics.render (graphics, renderSession, matrix, shape.__worldColorTransform.__isDefault() ? null : shape.__worldColorTransform);
 				
 				if (graphics.__canvas != null) {
 					

--- a/openfl/_internal/renderer/opengl/GLShape.hx
+++ b/openfl/_internal/renderer/opengl/GLShape.hx
@@ -28,9 +28,9 @@ class GLShape {
 		if (graphics != null) {
 			
 			#if (js && html5)
-			CanvasGraphics.render (graphics, renderSession, shape.__worldTransform);
+			CanvasGraphics.render (graphics, renderSession, shape.__worldTransform, shape.__worldColorTransform.__isDefault() ? null : shape.__worldColorTransform);
 			#elseif lime_cairo
-			CairoGraphics.render (graphics, renderSession, shape.__worldTransform);
+			CairoGraphics.render (graphics, renderSession, shape.__worldTransform, shape.__worldColorTransform.__isDefault() ? null : shape.__worldColorTransform);
 			#end
 			
 			var bounds = graphics.__bounds;

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -591,6 +591,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if !disa
 		}
 		
 	}
+
+
+	private function __setGraphicsDirty ():Void {
+
+		// implemented in subclasses that have Graphics or renderable Text
+		
+	}
 	
 	
 	private inline function __setTransformDirty ():Void {

--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -817,6 +817,19 @@ class DisplayObjectContainer extends InteractiveObject {
 	}
 	
 	
+	public override function __setGraphicsDirty ():Void {
+		
+		super.__setGraphicsDirty ();
+		
+		for (child in __children) {
+			
+			child.__setGraphicsDirty ();
+			
+		}
+		
+	}
+	
+	
 	
 	
 	// Get & Set Methods

--- a/openfl/display/Shape.hx
+++ b/openfl/display/Shape.hx
@@ -15,6 +15,13 @@ class Shape extends DisplayObject {
 		super ();
 		
 	}
+
+
+	public override function __setGraphicsDirty ():Void {
+
+		graphics.__dirty = true;
+		
+	}
 	
 	
 	

--- a/openfl/display/Sprite.hx
+++ b/openfl/display/Sprite.hx
@@ -56,6 +56,14 @@ class Sprite extends DisplayObjectContainer {
 	}
 	
 	
+	public override function __setGraphicsDirty ():Void {
+
+		graphics.__dirty = true;
+		
+		super.__setGraphicsDirty();
+
+	}
+
 	private override function __getCursor ():MouseCursor {
 		
 		return (buttonMode && useHandCursor) ? POINTER : null;

--- a/openfl/geom/ColorTransform.hx
+++ b/openfl/geom/ColorTransform.hx
@@ -1,5 +1,6 @@
 package openfl.geom;
 
+import haxe.macro.Expr;
 
 import lime.math.ColorMatrix;
 import lime.utils.Float32Array;
@@ -84,12 +85,40 @@ class ColorTransform {
 	}
 	
 	
-	private function __isDefault ():Bool {
+	public function __isDefault ():Bool {
 		
 		return (redMultiplier == 1 && greenMultiplier == 1 && blueMultiplier == 1 && alphaMultiplier == 1 && redOffset == 0 && greenOffset == 0 && blueOffset == 0 && alphaOffset == 0);
 		
 	}
+
+
+	public static macro function __with_var_rgba (input_rgb : ExprOf<Int>, input_a : ExprOf<Float>, rgbaExpr : Expr) : Expr
+	{
+		return macro
+		{
+			var rgb = $input_rgb;
+			var r : Int   = ((rgb & 0xFF0000) >> 16);
+			var g : Int   = ((rgb & 0x00FF00) >>  8);
+			var b : Int   =  (rgb & 0x0000FF)       ;
+			var a : Float = $input_a;
+
+			${rgbaExpr}
+		}
+	}
+
 	
+	public macro function __apply_to_var_rgba (self : ExprOf<ColorTransform>) : Expr
+	{
+		return macro
+		{
+			var t = $self;
+			r = r * t   .redMultiplier + t   .redOffset;
+			g = g * t .greenMultiplier + t .greenOffset;
+			b = b * t  .blueMultiplier + t  .blueOffset;
+			a = a * t .alphaMultiplier + t .alphaOffset;
+		}
+	}
+
 	
 	
 	

--- a/openfl/geom/Transform.hx
+++ b/openfl/geom/Transform.hx
@@ -61,8 +61,8 @@ class Transform {
 				
 			}
 			
-			__displayObject.__setRenderDirty ();
-			
+			__displayObject.__setGraphicsDirty ();
+
 		}
 		
 		return __colorTransform;

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -887,6 +887,14 @@ class TextField extends InteractiveObject {
 		}
 		
 	}
+
+
+	public override function __setGraphicsDirty ():Void {
+
+		__dirty = true;
+		
+	}
+
 	
 	
 	


### PR DESCRIPTION
This patch refactors and de-duplicates code in the Cairo and Canvas rendering classes and implements the application of color transforms to TextFields and (Shape) Graphics.

Luckily worldColorTransform was already implemented so it turned out to be fairly straightforward :-)

It introduces 2 new macros to ColorTransform that help calculate the RGBA values without temporary allocations. If and when Haxe supports multiple inline return values, these could be rewritten. Hopefully you'll find these readable enough... :)

Added some ColorTransforms to [my little test program here](https://github.com/vizanto/openfl-linestyle-bug/tree/colortransform)

Before this patch, the ColorTransforms change nothing on targets other than Flash:

HTML5:
![HTML5](https://github.com/vizanto/openfl-linestyle-bug/blob/colortransform/broken-html5.png?raw=true)

Flash:
![Flash](https://github.com/vizanto/openfl-linestyle-bug/blob/colortransform/flash.png?raw=true)


Drawing Bitmaps with ColorTransform is untested and not implemented by this patch.