### PR TITLE
Bugfix Utils3d - projectVectors()

### DIFF
--- a/openfl/geom/Utils3D.hx
+++ b/openfl/geom/Utils3D.hx
@@ -52,8 +52,7 @@ class Utils3D {
 			projectedVerts.push( x1 / w1 );
 			projectedVerts.push( y1 / w1 );
 			
-			uvts.push( 0 );
-			uvts.push( 1/w1 );
+			uvts[i + 2] = 1 / w1;
 			
 			i += 3;
 		}


### PR DESCRIPTION
In flash the projectVectors() function expects the uvts vector to be pre-allocated with U, V values as well as a temporary value
T for each vertice.
-The U and V values shouldn't be touched by projectVectors()
-It should just fill the T value which is the projection depth used by drawTriangles()