### PR TITLE
Make sure reflected properties are integers. Partial fix for #1225

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -384,8 +384,9 @@ class BitmapData implements IBitmapDrawable {
 		#if (js && html5)
 		
 		if (colorTransform != null) {
-			
-			var copy = new BitmapData (Reflect.getProperty (source, "width"), Reflect.getProperty (source, "height"), true, 0);
+			var width:Int = Math.ceil (Reflect.getProperty (source, "width"));
+			var height:Int = Math.ceil (Reflect.getProperty (source, "height"));
+			var copy = new BitmapData (width, height, true, 0);
 			copy.draw (source);
 			copy.colorTransform (copy.rect, colorTransform);
 			source = copy;


### PR DESCRIPTION
In HTML5 target reflected `source#width` and `source#height` can be floats, which causes type mismatch for width and height temporary BitmapData, causing problems with ColorTransform.

More info in https://github.com/openfl/openfl/issues/1225