### PR TITLE
Convolution filter implementation for gl renderer

### DIFF
--- a/openfl/_internal/renderer/opengl/GLBitmap.hx
+++ b/openfl/_internal/renderer/opengl/GLBitmap.hx
@@ -26,7 +26,7 @@ class GLBitmap {
 			
 			if (bitmap.__filters != null && bitmap.__filters.length > 0) {
 				
-				shader = bitmap.__filters[0].__initShader (renderSession);
+				shader = bitmap.__filters[0].__initShader (renderSession, bitmap);
 				
 			} else {
 				

--- a/openfl/_internal/renderer/opengl/GLShape.hx
+++ b/openfl/_internal/renderer/opengl/GLShape.hx
@@ -41,7 +41,7 @@ class GLShape {
 				
 				if (shape.__filters != null && shape.__filters.length > 0) {
 					
-					shader = shape.__filters[0].__initShader (renderSession);
+					shader = shape.__filters[0].__initShader (renderSession, shape);
 					
 				} else {
 					

--- a/openfl/_internal/renderer/opengl/GLTilemap.hx
+++ b/openfl/_internal/renderer/opengl/GLTilemap.hx
@@ -32,7 +32,7 @@ class GLTilemap {
 		
 		if (tilemap.__filters != null && tilemap.__filters.length > 0) {
 			
-			shader = tilemap.__filters[0].__initShader (renderSession);
+			shader = tilemap.__filters[0].__initShader (renderSession, tilemap);
 			
 		} else {
 			

--- a/openfl/filters/BitmapFilter.hx
+++ b/openfl/filters/BitmapFilter.hx
@@ -3,6 +3,7 @@ package openfl.filters;
 
 import openfl._internal.renderer.RenderSession;
 import openfl.display.BitmapData;
+import openfl.display.DisplayObject;
 import openfl.display.Shader;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
@@ -32,7 +33,7 @@ class BitmapFilter {
 	}
 	
 	
-	private function __initShader (renderSession:RenderSession):Shader {
+	private function __initShader (renderSession:RenderSession, object:DisplayObject):Shader {
 		
 		return renderSession.shaderManager.defaultShader;
 		

--- a/openfl/filters/ColorMatrixFilter.hx
+++ b/openfl/filters/ColorMatrixFilter.hx
@@ -4,6 +4,7 @@ package openfl.filters;
 import lime.graphics.utils.ImageCanvasUtil;
 import openfl._internal.renderer.RenderSession;
 import openfl.display.BitmapData;
+import openfl.display.DisplayObject;
 import openfl.display.Shader;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
@@ -79,7 +80,7 @@ import openfl.geom.Rectangle;
 	}
 	
 	
-	private override function __initShader (renderSession:RenderSession):Shader {
+	private override function __initShader (renderSession:RenderSession, object:DisplayObject):Shader {
 		
 		__colorMatrixShader.init (matrix);
 		return __colorMatrixShader;

--- a/openfl/filters/ConvolutionFilter.hx
+++ b/openfl/filters/ConvolutionFilter.hx
@@ -1,8 +1,17 @@
 package openfl.filters;
 
+import openfl._internal.renderer.RenderSession;
+import openfl.display.BitmapData;
+import openfl.display.DisplayObject;
+import openfl.display.Shader;
+import openfl.geom.Point;
+import openfl.geom.Rectangle;
+
 
 class ConvolutionFilter extends BitmapFilter {
 	
+	
+	private static var __convolutionShader = new ConvolutionShader ();
 	
 	public var alpha:Float;
 	public var bias:Float;
@@ -37,6 +46,12 @@ class ConvolutionFilter extends BitmapFilter {
 		
 	}
 	
+	private override function __initShader (renderSession:RenderSession, object:DisplayObject):Shader {
+		
+		__convolutionShader.init (matrix, object);
+		return __convolutionShader;
+		
+	}
 	
 	
 	
@@ -60,6 +75,121 @@ class ConvolutionFilter extends BitmapFilter {
 		}
 		
 		return matrix = v;
+		
+	}
+	
+	
+}
+
+private class ConvolutionShader extends Shader {
+	
+	
+	private static var GL_FRAGMENT_SOURCE = 
+		
+		"varying vec2 vBlurCoords[9];
+		varying float vAlpha;
+		varying vec2 vTexCoord;
+		
+		uniform sampler2D uImage0;
+		
+		uniform mat3 uConvoMatrix;
+		
+		void main(void) {
+			
+			vec4 tc = texture2D(uImage0, vBlurCoords[4]);
+			
+			vec4 c = vec4(0.0);
+			c += texture2D(uImage0, vBlurCoords[0]) * uConvoMatrix[0][0];
+			c += texture2D(uImage0, vBlurCoords[1]) * uConvoMatrix[0][1];
+			c += texture2D(uImage0, vBlurCoords[2]) * uConvoMatrix[0][2];
+			
+			c += texture2D(uImage0, vBlurCoords[3]) * uConvoMatrix[1][0];
+			c += tc * uConvoMatrix[1][1];
+			c += texture2D(uImage0, vBlurCoords[5]) * uConvoMatrix[1][2];
+			
+			c += texture2D(uImage0, vBlurCoords[6]) * uConvoMatrix[2][0];
+			c += texture2D(uImage0, vBlurCoords[7]) * uConvoMatrix[2][1];
+			c += texture2D(uImage0, vBlurCoords[8]) * uConvoMatrix[2][2];
+			
+			gl_FragColor = vec4(c.rgb, tc.a);
+			
+		}";
+	
+	private static var GL_VERTEX_SOURCE = 
+		
+		"attribute float aAlpha;
+		attribute vec4 aPosition;
+		attribute vec2 aTexCoord;
+		
+		varying vec2 vBlurCoords[9];
+		varying float vAlpha;
+		varying vec2 vTexCoord;
+		
+		uniform mat4 uMatrix;
+		uniform vec2 uTextureSize;
+		
+		void main(void) {
+			
+			vec2 r = vec2(1.0, 1.0) / uTextureSize;
+			vec2 t = aTexCoord;
+			
+			vBlurCoords[0] = t + r * vec2( -1.0, -1.0);
+			vBlurCoords[1] = t + r * vec2( 0.0, -1.0);
+			vBlurCoords[2] = t + r * vec2( 1.0, -1.0);
+			
+			vBlurCoords[3] = t + r * vec2( -1.0, 0.0);
+			vBlurCoords[4] = t;
+			vBlurCoords[5] = t + r * vec2( 1.0,  0.0);
+			
+			vBlurCoords[6] = t + r * vec2(-1.0,  1.0);
+			vBlurCoords[7] = t + r * vec2( 0.0,  1.0);
+			vBlurCoords[8] = t + r * vec2( 1.0,  1.0);
+			
+			vAlpha = aAlpha;
+			vTexCoord = aTexCoord;
+			gl_Position = uMatrix * aPosition;
+			
+		}";
+	
+	private var multipliers:Array<Float>;
+	private var size:Array<Float>;
+	
+	
+	public function new () {
+		
+		glVertexSource = GL_VERTEX_SOURCE;
+		glFragmentSource = GL_FRAGMENT_SOURCE;
+		
+		super ();
+		
+	}
+	
+	
+	public function init (matrix:Array<Float>, object:DisplayObject):Void {
+		
+		for (i in 0...9)
+		{
+			multipliers[i] = matrix[i];
+		}
+		
+		size[0] = object.width;
+		size[1] = object.height;
+	}
+	
+	
+	private override function __init ():Void {
+		
+		super.__init ();
+		
+		if (data.uConvoMatrix != null && data.uConvoMatrix.value == null) {
+			
+			data.uConvoMatrix.value = [0, 0, 0, 0, 1, 0, 0, 0, 0];
+			multipliers = cast data.uConvoMatrix.value;
+			
+			data.uTextureSize.value = [0, 0];
+			size = cast data.uTextureSize.value;
+			
+		}
 		
 	}
 	

--- a/openfl/filters/ShaderFilter.hx
+++ b/openfl/filters/ShaderFilter.hx
@@ -2,6 +2,7 @@ package openfl.filters;
 
 
 import openfl._internal.renderer.RenderSession;
+import openfl.display.DisplayObject;
 import openfl.display.Shader;
 
 
@@ -36,7 +37,7 @@ class ShaderFilter extends BitmapFilter {
 	}
 	
 	
-	private override function __initShader (renderSession:RenderSession):Shader {
+	private override function __initShader (renderSession:RenderSession, object:DisplayObject):Shader {
 		
 		return shader;
 		


### PR DESCRIPTION
i've tried to make as less changes to other classes as possible, but convolution shader needs to know the size of texture, so i've added `object:DisplayObject` parameter to filter's `__initShader()` method. Not sure if it's correct, but hope to get some feedback about it.