### PR TITLE
Don't make negative dimensions. Fixes rendering of mirrored shapes.

### DIFF
--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -822,7 +822,7 @@ import js.html.CanvasRenderingContext2D;
 		
 		if (parentTransform.b == 0) {
 			
-			scaleX = parentTransform.a;
+			scaleX = Math.abs(parentTransform.a);
 			
 		} else {
 			
@@ -832,7 +832,7 @@ import js.html.CanvasRenderingContext2D;
 		
 		if (parentTransform.c == 0) {
 			
-			scaleY = parentTransform.d;
+			scaleY = Math.abs(parentTransform.d);
 			
 		} else {
 			


### PR DESCRIPTION
Fixes bug where objects are not rendered when the transformation matrix is mirrored along the x or y axis.

Graphics.__update special cases scaling when the matrix is non-rotated. However the special case may produce negative dimensions of the rendered object if the object is mirrored, i.e. has negative a or d entries.