### PR TITLE
Fix TextField auto-sizing remaining too small and cropping text.

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -604,6 +604,27 @@ class TextEngine {
 		}
 		
 		maxScrollV = numLines - bottomScrollV + 1;
+
+
+		if (autoSize != NONE) {
+			
+			switch (autoSize) {
+				
+				case LEFT, RIGHT, CENTER:
+					
+					if (!wordWrap && width < (textWidth + 4)) {
+						
+						width = textWidth + 4;
+						
+					}
+					
+					height = textHeight + 4;
+				
+				default:
+					
+				
+			}
+		}
 		
 	}
 	

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -841,29 +841,12 @@ class TextField extends InteractiveObject {
 		
 		if (__layoutDirty) {
 			
+			var cacheWidth = __textEngine.width;
+			var cacheHeight = __textEngine.height;
+				
 			__textEngine.update ();
 			
 			if (__textEngine.autoSize != NONE) {
-				
-				var cacheWidth = __textEngine.width;
-				var cacheHeight = __textEngine.height;
-				
-				switch (__textEngine.autoSize) {
-					
-					case LEFT, RIGHT, CENTER:
-						
-						if (!__textEngine.wordWrap) {
-							
-							__textEngine.width = __textEngine.textWidth + 4;
-							
-						}
-						
-						__textEngine.height = __textEngine.textHeight + 4;
-					
-					default:
-						
-					
-				}
 				
 				if (__textEngine.width != cacheWidth) {
 					


### PR DESCRIPTION
Before this patch, sometimes one would need to actually set the width to textWidth to get a proper sized textfield after setting `text`:

```
label.text  = str;
label.width = label.textWidth;
```

By moving width and height calculation responsibility to TextEngine.getLineMeasurements() this workaround is no longer required.


---

However I'm not completely sure this works in all cases as intended :)
Are there any TextField behaviour tests?