### PR TITLE
addEventListener fix for varying useCapture:

### DIFF
--- a/openfl/events/EventDispatcher.hx
+++ b/openfl/events/EventDispatcher.hx
@@ -68,7 +68,7 @@ class EventDispatcher implements IEventDispatcher {
 			
 			for (i in 0...list.length) {
 				
-				if (Reflect.compareMethods (list[i].callback, listener)) return;
+				if (list[i].match (listener, useCapture)) return;
 				
 			}
 			


### PR DESCRIPTION
Per docs from externs/core/openfl/openfl/events/EventDispatcher.hx:

```
 * <p>Keep in mind that after the listener is registered, subsequent calls to
 * <code>addEventListener()</code> with a different <code>type</code> or
 * <code>useCapture</code> value result in the creation of a separate
 * listener registration.
```

Using `list[i].match` here and comparing both `listener` and `useCapture`, rather than just `compareMethods` on the `listener`, will ensure we do add two listener entries if called once with useCapture = true and once with useCapture = false.  This allows you to listen for the event both during capture and target/bubbling phases with the same method.

See also http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/events/EventDispatcher.html#addEventListener()

Reviewed-by: Chris Howe