### PR TITLE
EventDispatcherTest: add tests for nested behaviors.

### DIFF
--- a/tests/unit/test/openfl/events/EventDispatcherTest.hx
+++ b/tests/unit/test/openfl/events/EventDispatcherTest.hx
@@ -244,4 +244,73 @@ class EventDispatcherTest {
 	}
 	
 	
+	var test01aCallCount = 0;
+	var o:EventDispatcher = null;
+	var test02aCallCount = 0;
+	var test02Sequence:String = "";
+
+	private function test01a (e:Event):Void {
+		++test01aCallCount;
+		if ( test01aCallCount == 1 ) { // avoid infinite recursion, but we still should get a second call
+			o.dispatchEvent( new Event("Test01Event") );
+		}
+	}
+
+	@Test
+	public function testDispatch1()
+	{
+		test01aCallCount = 0;
+		o = new EventDispatcher();
+
+		o.addEventListener( "Test01Event", test01a );
+		o.dispatchEvent( new Event( "Test01Event" ) );
+
+		Assert.areEqual(2, test01aCallCount);
+	}
+
+	public function test02a (e:Event):Void {
+		test02Sequence += "a";
+		++test02aCallCount;
+		if ( test02aCallCount == 1 ) {
+			test02Sequence += "(";
+			o.dispatchEvent( new Event( "Test02Event" ) );
+			test02Sequence += ")";
+
+			// dispatching should still be true here, so this shouldn't modify the list we're traversing over
+			// ...but it does...
+			o.removeEventListener( "Test02Event", test02a );
+			o.removeEventListener( "Test02Event", test02b );
+			o.addEventListener( "Test02Event", test02a, false, 4 );
+			o.addEventListener( "Test02Event", test02b, false, 5 );
+		}
+	}
+	private function test02b (e:Event):Void {
+		test02Sequence += "b";
+	}
+	private function test02c (e:Event):Void {
+		test02Sequence += "c";
+	}
+
+	@Test
+	public function testDispatch2()
+	{
+		test02aCallCount = 0;
+		test02Sequence = "";
+
+		o = new EventDispatcher();
+		// Test 02: Dispatching goes false too soon.
+		// The reset of dispatching at the tail of __dispatchEvent,
+		// namely the __dispatching.set (event.type, false); line,
+		// is unconditional. Clearly we want to keep dispatching true
+		// if we're nested, so we should only unset that if we're the
+		// "outermost" dispatcher.
+		o.addEventListener( "Test02Event", test02a, false, 3 );
+		o.addEventListener( "Test02Event", test02b, false, 2 );
+		o.addEventListener( "Test02Event", test02c, false, 1 );
+		o.dispatchEvent( new Event( "Test02Event" ) );
+
+		Assert.areEqual("a(abc)bc", test02Sequence);
+	}
+	
+	
 }

--- a/tests/unit/test/openfl/events/EventDispatcherTest.hx
+++ b/tests/unit/test/openfl/events/EventDispatcherTest.hx
@@ -244,60 +244,58 @@ class EventDispatcherTest {
 	}
 	
 	
-	var test01aCallCount = 0;
-	var o:EventDispatcher = null;
-	var test02aCallCount = 0;
-	var test02Sequence:String = "";
-
-	private function test01a (e:Event):Void {
-		++test01aCallCount;
-		if ( test01aCallCount == 1 ) { // avoid infinite recursion, but we still should get a second call
-			o.dispatchEvent( new Event("Test01Event") );
-		}
-	}
-
 	@Test
-	public function testDispatch1()
+	public function testSimpleNestedDispatch()
 	{
-		test01aCallCount = 0;
-		o = new EventDispatcher();
-
+		var test01aCallCount = 0;
+		var o = new EventDispatcher();
+		
+		var test01a = function (e:Event):Void {
+			++test01aCallCount;
+			if ( test01aCallCount == 1 ) { // avoid infinite recursion, but we still should get a second call
+				o.dispatchEvent( new Event("Test01Event") );
+			}
+		}
+		
 		o.addEventListener( "Test01Event", test01a );
 		o.dispatchEvent( new Event( "Test01Event" ) );
-
+		
 		Assert.areEqual(2, test01aCallCount);
 	}
-
-	public function test02a (e:Event):Void {
-		test02Sequence += "a";
-		++test02aCallCount;
-		if ( test02aCallCount == 1 ) {
-			test02Sequence += "(";
-			o.dispatchEvent( new Event( "Test02Event" ) );
-			test02Sequence += ")";
-
-			// dispatching should still be true here, so this shouldn't modify the list we're traversing over
-			// ...but it does...
-			o.removeEventListener( "Test02Event", test02a );
-			o.removeEventListener( "Test02Event", test02b );
-			o.addEventListener( "Test02Event", test02a, false, 4 );
-			o.addEventListener( "Test02Event", test02b, false, 5 );
-		}
-	}
-	private function test02b (e:Event):Void {
-		test02Sequence += "b";
-	}
-	private function test02c (e:Event):Void {
-		test02Sequence += "c";
-	}
-
+	
+	
 	@Test
-	public function testDispatch2()
+	public function testDispatchingRemainsTrue()
 	{
-		test02aCallCount = 0;
-		test02Sequence = "";
+		var test02aCallCount = 0;
+		var test02Sequence:String = "";
+		var o = new EventDispatcher();
+		
+		var test02b = function (e:Event):Void {
+			test02Sequence += "b";
+		}
+		
+		var test02c = function (e:Event):Void {
+			test02Sequence += "c";
+		}
+		
+		var test02a = function (e:Event):Void {
+			test02Sequence += "a";
+			++test02aCallCount;
+			if ( test02aCallCount == 1 ) {
+				test02Sequence += "(";
+				o.dispatchEvent( new Event( "Test02Event" ) );
+				test02Sequence += ")";
+				
+				// dispatching should still be true here, so this shouldn't modify the list we're traversing over
+				// ...but it does...
+				o.removeEventListener( "Test02Event", test02b );
+				o.addEventListener( "Test02Event", test02c, false, 4 );
+				o.addEventListener( "Test02Event", test02b, false, 5 );
+			}
+		}
 
-		o = new EventDispatcher();
+		
 		// Test 02: Dispatching goes false too soon.
 		// The reset of dispatching at the tail of __dispatchEvent,
 		// namely the __dispatching.set (event.type, false); line,
@@ -308,7 +306,7 @@ class EventDispatcherTest {
 		o.addEventListener( "Test02Event", test02b, false, 2 );
 		o.addEventListener( "Test02Event", test02c, false, 1 );
 		o.dispatchEvent( new Event( "Test02Event" ) );
-
+		
 		Assert.areEqual("a(abc)bc", test02Sequence);
 	}
 	


### PR DESCRIPTION
The first test succeeds on current `develop` branch; the second fails without #1295 and succeeds when it is present, showing abberant behavior.  Here's the failure:

    FAIL: massive.munit.AssertionException: Value [a(abc)bac] was not equal to expected value [a(abc)bc] at openfl.events.EventDispatcherTest#testDispatch2 (312)

...which indicates we get an additional call to the "a" callback we were not expecting.  (Adds or removes should not affect an in-flight dispatch's list.)

-----

This originally appeared in #1105 as https://github.com/openfl/openfl/pull/1105/commits/636e1d20c91d65a06101e5ccea32f3b4dc2ca893 .