### PR TITLE
FocusEventTest: re-use listener, vary useCapture and type.

### DIFF
--- a/tests/unit/test/openfl/events/FocusEventTest.hx
+++ b/tests/unit/test/openfl/events/FocusEventTest.hx
@@ -195,12 +195,17 @@ class FocusEventTest {
 		// First put focus on the old...
 		Lib.current.stage.focus = old2;
 		
-		// Now register our listeners... (using anonymous functions to prevent repeat listener optimization)
+		// Now register our listeners...
+		//
+		// We should be able to reuse listener; see addEventListener:
+		// "subsequent calls to addEventListener() with a different type
+		// or useCapture value result in the creation of a separate
+		// listener registration."
 		for (s in [ root, old1, old2, new1, new2 ]) {
-			s.addEventListener(FocusEvent.FOCUS_IN, function (e) { checkEvent(e); });
-			s.addEventListener(FocusEvent.FOCUS_IN, function (e) { checkEvent(e); }, true);
-			s.addEventListener(FocusEvent.FOCUS_OUT, function (e) { checkEvent(e); });
-			s.addEventListener(FocusEvent.FOCUS_OUT, function (e) { checkEvent(e); }, true);
+			s.addEventListener(FocusEvent.FOCUS_IN, checkEvent );
+			s.addEventListener(FocusEvent.FOCUS_IN, checkEvent, true );
+			s.addEventListener(FocusEvent.FOCUS_OUT, checkEvent );
+			s.addEventListener(FocusEvent.FOCUS_OUT, checkEvent, true );
 		}
 		
 		// Set up the expected sequence for the checker...


### PR DESCRIPTION
This tests the behavior of addEventListener as documented in EventDispatcher.addEventListener:

```
 * <p>Keep in mind that after the listener is registered, subsequent calls to
 * <code>addEventListener()</code> with a different <code>type</code> or
 * <code>useCapture</code> value result in the creation of a separate
 * listener registration.
```

In Flash Player 23.0.0.162, AS3 munit tests, this works as documented.

This test change will fail for other platforms (cpp, js, neko, etc) before #1293.