### PR TITLE
EventDispatcherTest: comment out ineffective `useCapture=true` test.

### DIFF
--- a/tests/unit/test/openfl/events/EventDispatcherTest.hx
+++ b/tests/unit/test/openfl/events/EventDispatcherTest.hx
@@ -51,7 +51,7 @@ class EventDispatcherTest {
 		
 		// Capture is true
 		
-		var correctPhase = true;
+		var correctPhase = false; // fail unless we see correct event
 		var dispatcher = new EventDispatcher ();
 		
 		var listener = function (event:Event) {
@@ -63,7 +63,11 @@ class EventDispatcherTest {
 		dispatcher.addEventListener ("event", listener, true);
 		dispatcher.dispatchEvent (new Event ("event"));
 		
-		Assert.isTrue (correctPhase);
+		// TODO: this dispatchEvent will never go through CAPTURING_PHASE.
+		// It needs to come from Stage
+		// (or possibly through e.g. DisplayObject.__fireEvent)
+		// See FocusEventTest for an example.
+		//DISABLED//Assert.isTrue (correctPhase);
 		
 		// Capture is false
 		


### PR DESCRIPTION
As it stands, this test defaulted to success (`var correctPhase = true;`) and was succeeding, but only because the `listener` was never called.

To go through CAPTURING_PHASE, it's my understanding that events have to go through a `DisplayObject` hierarchy, possibly from a `Stage` instance.  (It's unclear what the behavior is supposed to be re detached `DisplayObject` trees, may be worth testing that and bugging.)

Discovered that this test was ineffective on AS3 and other platforms while looking into how to test #1293 properly.

Submitting this PR as an RFC of sorts; it may want to be merged as a warning of a non-functional test anyway?