### PR TITLE
Add MIT header to Matrix.hx

### DIFF
--- a/openfl/geom/Matrix.hx
+++ b/openfl/geom/Matrix.hx
@@ -1,3 +1,27 @@
+/* 
+ * MIT License
+ *
+ * Copyright (c) 2013-2016 Joshua Granick and other OpenFL contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package openfl.geom;
 
 


### PR DESCRIPTION
Hi,

The Apache Flex project uses a modified version of Matrix.hx and it would be a help the project if a MIT header was added to the original file. This is not needed by the terms of the MIT license (as you already have a LICENSE file with the MIT text in it) but does help if that file becomes separated from the LICENSE file (as is the case in the Apache Flex project). I can also understand that you may not want to add this header and if that is the case please just reject this PR.

You may also want to consider adding MIT headers to all files but that's totally up to your project.

Thanks,
Justin
