### PR TITLE
Fix drawTriangles texture mapping when scaling the container object

### DIFF
--- a/openfl/_internal/renderer/cairo/CairoGraphics.hx
+++ b/openfl/_internal/renderer/cairo/CairoGraphics.hx
@@ -458,6 +458,12 @@ class CairoGraphics {
 			}
 			
 		}
+
+		if ( !skipT ) {
+
+			return { max: max, uvt: uvt };
+		
+		}		
 		
 		var result = new Vector<Float> ();
 		
@@ -469,7 +475,7 @@ class CairoGraphics {
 				
 			}
 			
-			result.push ((uvt[t - 1] / max));
+			result.push (uvt[t - 1]);
 			
 		}
 		
@@ -745,6 +751,7 @@ class CairoGraphics {
 					
 					var width = 0;
 					var height = 0;
+					var currentMatrix = graphics.__renderTransform.__toMatrix3 ();
 					
 					if (!colorFill) {
 						
@@ -879,6 +886,13 @@ class CairoGraphics {
 							
 						}
 						
+						x1*=currentMatrix.a;
+						x2*=currentMatrix.a;
+						x3*=currentMatrix.a;
+						y1*=currentMatrix.d;
+						y2*=currentMatrix.d;
+						y3*=currentMatrix.d;
+
 						t1 = - (uvy1 * (x3 - x2) - uvy2 * x3 + uvy3 * x2 + (uvy2 - uvy3) * x1) / denom;
 						t2 = (uvy2 * y3 + uvy1 * (y2 - y3) - uvy3 * y2 + (uvy3 - uvy2) * y1) / denom;
 						t3 = (uvx1 * (x3 - x2) - uvx2 * x3 + uvx3 * x2 + (uvx2 - uvx3) * x1) / denom;

--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -478,6 +478,12 @@ class CanvasGraphics {
 			}
 			
 		}
+
+		if ( !skipT ) {
+
+			return { max: max, uvt: uvt };
+		
+		}
 		
 		var result = new Vector<Float> ();
 		
@@ -489,7 +495,7 @@ class CanvasGraphics {
 				
 			}
 			
-			result.push ((uvt[t - 1] / max));
+			result.push (uvt[t - 1]);
 			
 		}
 		


### PR DESCRIPTION
Texture mapping was failing if you scale the Sprite where you draw the triangles.
Not it's working for Cairo and Canvas.

Also, UVT normalization was fixed (at least when skipT is false... didn't change the case where skipT is true). I guess we can just remove the SkipT variable... ?
