### PR TITLE
Fix Sound.length for HTML5 howler.js based Audio

### DIFF
--- a/openfl/media/Sound.hx
+++ b/openfl/media/Sound.hx
@@ -169,10 +169,17 @@ class Sound extends EventDispatcher {
 	private function get_length ():Int {
 		
 		if (__buffer != null) {
+
+			#if (js && html5 && howlerjs)
+			
+			return Std.int(__buffer.src.duration() * 1000);
+
+			#else
 			
 			var samples = (__buffer.data.length * 8) / (__buffer.channels * __buffer.bitsPerSample);
 			return Std.int (samples / __buffer.sampleRate * 1000);
 			
+			#end
 		}
 		
 		return 0;


### PR DESCRIPTION
In HTML5, `__buffer.data` is never actually set and before this patch calling `length` would result in a null-pointer exception.