### PR TITLE
Immediately blink the caret when position changes

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -526,7 +526,9 @@ class TextField extends InteractiveObject {
 		
 		__selectionIndex = beginIndex;
 		__caretIndex = endIndex;
-		
+		__stopCursorTimer ();
+		__startCursorTimer ();
+
 	}
 	
 	


### PR DESCRIPTION
When for example using a keyboard event handler to change the caret position, it's hard to see the caret changed until you wait 600ms.

This patch makes it immediately show up.
