### PR TITLE
ByteArray : fix big-endian readFloat / writeFloat

### DIFF
--- a/openfl/utils/ByteArray.hx
+++ b/openfl/utils/ByteArray.hx
@@ -242,7 +242,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData {
 	
 	private var __endian:Endian;
 	private var __length:Int;
-	
+	private var __float:Bytes;
 	
 	public function new (length:Int = 0) {
 		
@@ -404,8 +404,19 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData {
 			
 		}
 		
-		position += 4;
-		return getFloat (position - 4);
+		if (endian == LITTLE_ENDIAN) {
+			position += 4;
+			return getFloat (position - 4);
+		} else {
+			if (__float == null) {
+				__float = Bytes.alloc(4);
+			}
+			__float.set(3, get(position++));
+			__float.set(2, get(position++));
+			__float.set(1, get(position++));
+			__float.set(0, get(position++));
+			return __float.getFloat(0);
+		}
 		
 	}
 	
@@ -619,8 +630,19 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData {
 	public function writeFloat (value:Float):Void {
 		
 		__resize (position + 4);
-		setFloat (position, value);
-		position += 4;
+		if (endian == LITTLE_ENDIAN) {
+			setFloat (position, value);
+			position += 4;
+		} else {
+			if (__float == null) {
+				__float = Bytes.alloc(4);
+			}
+			__float.setFloat(0, value);
+			set(position++, __float.get(3));
+			set(position++, __float.get(2));
+			set(position++, __float.get(1));
+			set(position++, __float.get(0));
+		}
 		
 	}
 	


### PR DESCRIPTION
This fixes a crash in `readFloat` observed on flash and iPhone targets (big-endian).

This solution is not ideal because it requires a lazily instantiated private instance of Bytes that is allocated by the first call to either `readFloat` or `writeFloat`.  If there is a way to avoid that allocation (and extra field in the structure) that would be preferred.