### PR TITLE
Fix: cursor not visible on the last empty line

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -246,9 +246,6 @@ class CanvasTextField {
 							
 						}
 						
-						trace (scrollY);
-						trace (textField.scrollV);
-						
 						context.fillText (text.substring (group.startIndex, group.endIndex), group.offsetX + scrollX, group.offsetY + offsetY + scrollY);
 						
 						if (textField.__caretIndex > -1 && textEngine.selectable) {

--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -816,8 +816,10 @@ class TextEngine {
 		
 		lineFormat = formatRange.format;
 		var wrap;
+		var maxLoops = text.length;
+		if (multiline) maxLoops++; // Do an extra iteration to ensure a LayoutGroup is created for the last (empty) line.
 		
-		while (textIndex < text.length) {
+		while (textIndex < maxLoops) {
 			
 			if ((breakIndex > -1) && (spaceIndex == -1 || breakIndex < spaceIndex) && (formatRange.end >= breakIndex)) {
 				
@@ -1020,7 +1022,7 @@ class TextEngine {
 					
 					break;
 					
-				} else if (textIndex < formatRange.end) {
+				} else if (textIndex < formatRange.end || textIndex == text.length) {
 					
 					layoutGroup = new TextLayoutGroup (formatRange.format, textIndex, formatRange.end);
 					layoutGroup.advances = getAdvances (text, textIndex, formatRange.end);
@@ -1160,7 +1162,7 @@ class TextEngine {
 	
 	private function update ():Void {
 		
-		if (text == null || StringTools.trim (text) == "" || textFormatRanges.length == 0) {
+		if (text == null || (!multiline && StringTools.trim (text) == "") || textFormatRanges.length == 0) {
 			
 			lineAscents.length = 0;
 			lineBreaks.length = 0;

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -472,8 +472,8 @@ class TextField extends InteractiveObject {
 		
 		replaceText (startIndex, endIndex, value);
 		
-		__caretIndex = startIndex + value.length;
-		__selectionIndex = __caretIndex;
+		var i = startIndex + value.length;
+		setSelection(i,i);
 		
 	}
 	


### PR DESCRIPTION
As discussed on Slack:

Before this patch when typing ENTER in a multiline TextField in HTML5 or Native target, the cursor disappeared. As soon as any non-space character was entered after, the cursor would appear again.

This patch fixes it by ensuring a TextLayoutGroup is created for the last empty line.

`//end of painful debug session`