### PR TITLE
HTML5 Clipboard support (and Select-All)

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -2230,6 +2230,15 @@ class TextField extends InteractiveObject {
 					
 				}
 			
+			case A:
+				
+				if (#if mac modifier.metaKey #elseif js modifier.metaKey || #end modifier.ctrlKey) {
+					
+					__caretIndex = __text.length;
+					__selectionIndex = 0;
+					
+				}
+			
 			default:
 			
 		}

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -2206,9 +2206,10 @@ class TextField extends InteractiveObject {
 					
 				}
 			
+			#if !js
 			case V:
 				
-				if (modifier == #if mac KeyModifier.LEFT_META #else KeyModifier.LEFT_CTRL #end || modifier == #if mac KeyModifier.RIGHT_META #else KeyModifier.RIGHT_CTRL #end) {
+				if (#if mac modifier.metaKey #else modifier.ctrlKey #end) {
 					
 					var text = Clipboard.text;
 					
@@ -2229,6 +2230,7 @@ class TextField extends InteractiveObject {
 					__textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end = __text.length;
 					
 				}
+			#end
 			
 			case A:
 				

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -2185,7 +2185,7 @@ class TextField extends InteractiveObject {
 			
 			case C:
 				
-				if (modifier == #if mac KeyModifier.LEFT_META #else KeyModifier.LEFT_CTRL #end || modifier == #if mac KeyModifier.RIGHT_META #else KeyModifier.RIGHT_CTRL #end) {
+				if (#if mac modifier.metaKey #elseif js modifier.metaKey || #end modifier.ctrlKey) {
 					
 					Clipboard.text = __text.substring (__caretIndex, __selectionIndex);
 					
@@ -2193,7 +2193,7 @@ class TextField extends InteractiveObject {
 			
 			case X:
 				
-				if (modifier == #if mac KeyModifier.LEFT_META #else KeyModifier.LEFT_CTRL #end || modifier == #if mac KeyModifier.RIGHT_META #else KeyModifier.RIGHT_CTRL #end) {
+				if (#if mac modifier.metaKey #elseif js modifier.metaKey || #end modifier.ctrlKey) {
 					
 					Clipboard.text = __text.substring (__caretIndex, __selectionIndex);
 					


### PR DESCRIPTION
Requires: https://github.com/openfl/lime/pull/841

The system clipboard paste event will fire after any keypress events, causing previous Clipboard.text contents to be pasted instead of the expected system clipboard contents.

This patch simply ignores CMD-V to fix this.