### PR TITLE
Size of .draw() area using GL framebuffer fix

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -438,7 +438,7 @@ class BitmapData implements IBitmapDrawable {
 				
 				gl.bindFramebuffer (gl.FRAMEBUFFER, __framebuffer);
 				
-				gl.viewport (0, 0, width, height);
+				gl.viewport (0, 0, Math.round(Lib.current.stage.stageWidth), Math.round(Lib.current.stage.stageHeight));
 				gl.clear (gl.COLOR_BUFFER_BIT);
 				
 				var renderer = new GLRenderer (Lib.current.stage, gl, false);


### PR DESCRIPTION
This should fix the size and scale of drawn area when using bitmapData.draw() with GL framebuffer rendering (bitmapData.readable = false). Now it should work equivalently to Cairo.

Warning!: Only tested on mac target. Needs more testing on other targets.

More info here: http://community.openfl.org/t/render-sprites-to-texture-for-gl-targets/8452/5?u=wildfireheart