### PR TITLE
Fix alpha animation with -Ddom

### DIFF
--- a/openfl/_internal/renderer/dom/DOMBitmap.hx
+++ b/openfl/_internal/renderer/dom/DOMBitmap.hx
@@ -97,15 +97,13 @@ class DOMBitmap {
 			bitmap.__canvas.width = bitmap.bitmapData.width;
 			bitmap.__canvas.height = bitmap.bitmapData.height;
 			
-			bitmap.__context.globalAlpha = bitmap.__worldAlpha;
 			bitmap.__context.drawImage (bitmap.bitmapData.image.buffer.__srcCanvas, 0, 0);
-			
 			bitmap.__imageVersion = bitmap.bitmapData.image.version;
 			
 		}
 		
 		DOMRenderer.updateClip (bitmap, renderSession);
-		DOMRenderer.applyStyle (bitmap, renderSession, true, false, true);
+		DOMRenderer.applyStyle (bitmap, renderSession, true, true, true);
 		#end
 		
 	}


### PR DESCRIPTION
This commit (https://github.com/openfl/openfl/commit/54e7235c82f2427a68e592e87adf8c1afbf87e24) breaks alpha animation. This pull request fixes it.

**Sample code:**

```haxe
class App extends Sprite {
    private var bitmap : Bitmap;
    private var startTime : Float;

    public function new() {
        super();

        var spritesheetBitmapData = Assets.getBitmapData("drawable/spritesheet.png");

        var bitmapData = new BitmapData(58, 51, true, 0);
        bitmapData.copyPixels(spritesheetBitmapData, new Rectangle(66, 0, 58, 81), new Point(0, 0), null, null, true);

        bitmap = new Bitmap(bitmapData, PixelSnapping.AUTO, true);
        bitmap.x = 50;
        bitmap.y = 50;
        addChild(bitmap);

        startTime = Timer.stamp();
        addEventListener(Event.ENTER_FRAME, onEnterFrame);
    }

    private function onEnterFrame(_) : Void {
        bitmap.alpha = Math.sin(Timer.stamp() - startTime) * 0.5 + 0.5;
    }
}
```

Full project - http://pub.zame-dev.org/openfl-bitmap-data-alpha/project.zip

**Example:**

- `-Ddom` (without fix) - http://pub.zame-dev.org/openfl-bitmap-data-alpha/dom/index.html
- `-Dcanvas` (to compare) - http://pub.zame-dev.org/openfl-bitmap-data-alpha/canvas/index.html
- `-Ddom` (with fix) - http://pub.zame-dev.org/openfl-bitmap-data-alpha/dom-with-fix/index.html
