### PR TITLE
Reset name, filters and color-transforms between frames.

### DIFF
--- a/openfl/display/MovieClip.hx
+++ b/openfl/display/MovieClip.hx
@@ -28,6 +28,7 @@ import openfl.Assets;
 class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObject> #end {
 	
 	
+	private static var __noColorTranform = new openfl.geom.ColorTransform();
 	private static var __initSWF:SWFLite;
 	private static var __initSymbol:SpriteSymbol;
 	
@@ -351,11 +352,7 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 	
 	private function __placeObject (displayObject:DisplayObject, frameObject:FrameObject):Void {
 		
-		if (frameObject.name != null) {
-			
-			displayObject.name = frameObject.name;
-			
-		}
+		displayObject.name = (frameObject.name != null)? frameObject.name : "";
 		
 		if (frameObject.matrix != null) {
 			
@@ -363,15 +360,11 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 			
 		}
 		
-		if (frameObject.colorTransform != null) {
-			
-			displayObject.transform.colorTransform = frameObject.colorTransform;
-			
-		}
+		displayObject.transform.colorTransform = (frameObject.colorTransform != null) ? frameObject.colorTransform : __noColorTranform;
+		
+		var filters:Array<BitmapFilter> = [];
 		
 		if (frameObject.filters != null) {
-			
-			var filters:Array<BitmapFilter> = [];
 			
 			for (filter in frameObject.filters) {
 				
@@ -397,9 +390,9 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 				
 			}
 			
-			displayObject.filters = filters;
-			
 		}
+		
+		displayObject.filters = filters;
 		
 		displayObject.visible = frameObject.visible;
 		


### PR DESCRIPTION
Before this patch, when a filter or transform is applied in frame 2 (and none are in frame 1) the filter or transform would not be removed when going back to frame 1.


See also: https://github.com/openfl/swf/pull/95