### PR TITLE
Optimization: Re-use MovieClip child DisplayObjects between frames

### DIFF
--- a/openfl/display/MovieClip.hx
+++ b/openfl/display/MovieClip.hx
@@ -444,7 +444,6 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 					}
 					
 					__objectDepths.splice (i, 1);
-					__objects.remove (timelineObject.id);
 					
 				} else {
 					
@@ -483,7 +482,6 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 						}
 						
 						__objectDepths.remove (__objects.get (0));
-						__objects.remove (0);
 						timelineObject = null;
 						__zeroSymbol = frameObject.symbol;
 						
@@ -505,7 +503,6 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 							timelineObject = new TimelineObject (frameObject.id, frameObject.depth, displayObject);
 							
 							__objectDepths.push (timelineObject);
-							__objectDepths.sort (__sortTimelineDepth);
 							
 							depthChange = true;
 							
@@ -517,6 +514,14 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 						
 						timelineObject = __objects.get (frameObject.id);
 						displayObject = timelineObject.displayObject;
+
+						if (timelineObject.displayObject.parent == null) {
+							
+							__objectDepths.push(timelineObject);
+							
+							depthChange = true;
+							
+						}
 						
 					}
 					
@@ -565,7 +570,6 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 						}
 						
 						__objectDepths.remove (timelineObject);
-						__objects.remove (timelineObject.id);
 						
 						depthChange = true;
 						
@@ -578,6 +582,8 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 		}
 		
 		if (depthChange) {
+			
+			__objectDepths.sort (__sortTimelineDepth);
 			
 			var i = __objectDepths.length - 1;
 			


### PR DESCRIPTION
Is there a need to re-construct every object every frame?