### PR TITLE
Non-preloaded external SWF(Lite) loading

### DIFF
--- a/openfl/Assets.hx
+++ b/openfl/Assets.hx
@@ -80,7 +80,7 @@ class Assets {
 	 */
 	public static function exists (id:String, type:AssetType = null):Bool {
 		
-		return LimeAssets.exists (id, cast type);
+		return LimeAssets.exists (id, type);
 		
 	}
 	
@@ -215,9 +215,9 @@ class Assets {
 		
 		if (library != null) {
 			
-			if (library.exists (symbolName, cast AssetType.MOVIE_CLIP)) {
+			if (library.exists (symbolName, AssetType.MOVIE_CLIP)) {
 				
-				if (library.isLocal (symbolName, cast AssetType.MOVIE_CLIP)) {
+				if (library.isLocal (symbolName, AssetType.MOVIE_CLIP)) {
 					
 					return library.getMovieClip (symbolName);
 					
@@ -384,7 +384,7 @@ class Assets {
 		
 		if (library != null) {
 			
-			return library.isLocal (symbolName, cast type);
+			return library.isLocal (symbolName, type);
 			
 		}
 		
@@ -448,7 +448,7 @@ class Assets {
 	 */
 	public static function list (type:AssetType = null):Array<String> {
 		
-		return LimeAssets.list (cast type);
+		return LimeAssets.list (type);
 		
 	}
 	
@@ -709,7 +709,7 @@ class Assets {
 
 			if (library != null) {
 				
-				if (library.exists (symbolName, cast AssetType.MOVIE_CLIP)) {
+				if (library.exists (symbolName, AssetType.MOVIE_CLIP)) {
 					
 					promise.completeWith (library.loadMovieClip (symbolName));
 					
@@ -898,17 +898,14 @@ class Assets {
 	
 	override public function getAsset (id:String, type:String):Dynamic {
 		
-		var type : AssetType = cast type;
-		return switch (type) {
-			case BINARY:     getBytes(id);
-			case FONT:       getFont(id);
-			case IMAGE:      getImage(id);
-			case MUSIC:      getAudioBuffer(id);
-			case SOUND:      getAudioBuffer(id);
-			case TEMPLATE:   throw "Not sure how to get template: " + id;
-			case TEXT:       getText(id);
-			case MOVIE_CLIP: getMovieClip(id);
-		}
+		return if (type == MOVIE_CLIP) getMovieClip(id) else super.getAsset(id, type);
+		
+	}
+	
+	
+	override public function loadAsset (id:String, type:String):Future<Dynamic> {
+		
+		return if (type == MOVIE_CLIP) loadMovieClip(id) else super.loadAsset(id, type);
 		
 	}
 	
@@ -1146,7 +1143,7 @@ class Assets {
 }
 
 
-@:dox(hide) @:enum abstract AssetType(String) {
+@:dox(hide) @:enum abstract AssetType(String) to String {
 	
 	var BINARY = "BINARY";
 	var FONT = "FONT";
@@ -1156,6 +1153,19 @@ class Assets {
 	var SOUND = "SOUND";
 	var TEMPLATE = "TEMPLATE";
 	var TEXT = "TEXT";
+	
+	@:to function toLimeAssetType () : LimeAssetType {
+		
+		return switch (this) {
+			
+			case BINARY, FONT, IMAGE, MUSIC, SOUND, TEMPLATE, TEXT:
+				cast this;
+			
+			default:
+				throw "Unknown lime.AssetType: " + this;
+		}
+		
+	}
 	
 }
 

--- a/openfl/_internal/swf/SWFLite.hx
+++ b/openfl/_internal/swf/SWFLite.hx
@@ -14,7 +14,6 @@ import haxe.Unserializer;
 import openfl.Assets;
 
 @:access(openfl._internal.symbols.SWFSymbol)
-@:access(openfl.display.MovieClip)
 
 
 @:keep class SWFLite {
@@ -57,7 +56,7 @@ import openfl.Assets;
 					
 					if (Std.is (symbol, SpriteSymbol)) {
 						
-						return cast symbol.__createObject (this);
+						return cast (symbol, SpriteSymbol).__createObject (this);
 						
 					}
 					

--- a/openfl/_internal/swf/SWFLite.hx
+++ b/openfl/_internal/swf/SWFLite.hx
@@ -79,8 +79,7 @@ import openfl.Assets;
 				
 				if (Std.is (symbol, BitmapSymbol)) {
 					
-					var bitmap:BitmapSymbol = cast symbol;
-					return Assets.getBitmapData (bitmap.path);
+					return cast (symbol, BitmapSymbol).getBitmapData ();
 					
 				}
 				

--- a/openfl/_internal/swf/SWFLiteLibrary.hx
+++ b/openfl/_internal/swf/SWFLiteLibrary.hx
@@ -55,7 +55,7 @@ import openfl.Assets;
 		
 		if (type == (cast AssetType.IMAGE) || type == (cast AssetType.MOVIE_CLIP)) {
 			
-			return swf.hasSymbol (id);
+			return swf != null && swf.hasSymbol (id);
 			
 		}
 		
@@ -66,17 +66,46 @@ import openfl.Assets;
 	
 	public override function getImage (id:String):Image {
 		
-		return Image.fromBitmapData (swf.getBitmapData (id));
+		return swf != null? Image.fromBitmapData (swf.getBitmapData (id)) : null;
 		
 	}
 	
 	
 	public override function getMovieClip (id:String):MovieClip {
 		
-		return swf.createMovieClip (id);
+		return swf != null? swf.createMovieClip (id) : null;
 		
 	}
 	
+	
+	public override function isLocal (id:String, type:String):Bool {
+		
+		return swf != null && switch (cast(type, Assets.AssetType)) {
+			
+			case MOVIE_CLIP: true;
+			
+			default:         Assets.cache.exists(id, cast type);
+			
+		}
+		
+	}
+	
+	
+	public override function loadText (id:String):Future<String> {
+		
+		var text = super.loadText (id);
+		
+		if (swf == null) {
+			
+			return text.onComplete (function(text) {
+				swf = SWFLite.unserialize(text);
+			});
+			
+		}
+			
+		return text;
+		
+	}
 	
 	public override function load ():Future<lime.Assets.AssetLibrary> {
 		

--- a/openfl/_internal/swf/SWFLiteLibrary.hx
+++ b/openfl/_internal/swf/SWFLiteLibrary.hx
@@ -98,9 +98,7 @@ import openfl.Assets;
 		
 		if (swf == null) {
 			
-			return text.onComplete (function(text) {
-				swf = SWFLite.unserialize(text);
-			});
+			text.onComplete (function (text) this.swf = SWFLite.unserialize (text));
 			
 		}
 			
@@ -132,7 +130,7 @@ import openfl.Assets;
 		
 		var bitmapSymbols:Array<BitmapSymbol> = [];
 		
-		for (symbol in swf.symbols) {
+		if (swf != null) for (symbol in swf.symbols) {
 			
 			if (Std.is (symbol, BitmapSymbol)) {
 				

--- a/openfl/_internal/swf/SWFLiteLibrary.hx
+++ b/openfl/_internal/swf/SWFLiteLibrary.hx
@@ -109,22 +109,19 @@ import openfl.Assets;
 	}
 	
 	
-	public override function preload (manifest:Array<{type:String, id:String}>) : Future<LimeAssetLibrary> {
-		
-		var library : LimeAssetLibrary = this; 
-		var preloadedLibrary = Future.withValue(library);
+	public override function loadFromManifest (manifest:Array<{type:String, id:String}>):Future<LimeAssetLibrary> {
 		
 		for (asset in manifest) {
 			
 			if (asset.type == cast TEXT) {
 				
-				return loadText (asset.id).then (function (_) return preloadedLibrary);
+				return loadText (asset.id).then (function (_) return this.load ());
 				
 			}
 			
 		}
 		
-		return preloadedLibrary;
+		return load ();
 		
 	}
 	

--- a/openfl/_internal/swf/SWFLiteLibrary.hx
+++ b/openfl/_internal/swf/SWFLiteLibrary.hx
@@ -172,9 +172,9 @@ import openfl.Assets;
 					
 				} else {
 					
-					symbol.loadBitmapData()
-						.onComplete(onLoad)
-						.onError(promise.error);
+					symbol.loadBitmapData (this)
+						.onComplete (onLoad)
+						.onError (promise.error);
 					
 				}
 				

--- a/openfl/_internal/swf/SWFLiteLibrary.hx
+++ b/openfl/_internal/swf/SWFLiteLibrary.hx
@@ -194,6 +194,8 @@ import openfl.Assets;
 	
 	public override function unload ():Void {
 		
+		if (swf == null) return;
+		
 		var bitmap:BitmapSymbol;
 		
 		for (symbol in swf.symbols) {

--- a/openfl/_internal/symbols/BitmapSymbol.hx
+++ b/openfl/_internal/symbols/BitmapSymbol.hx
@@ -85,17 +85,17 @@ class BitmapSymbol extends SWFSymbol {
 	}
 	
 	
-	public function loadBitmapData () : Future<BitmapData> {
+	public function loadBitmapData (library:AssetLibrary) : Future<BitmapData> {
 		
 		var promise = new Promise<BitmapData> ();
 		
-		LimeAssets.loadImage (path, false).onComplete (function (image) {
+		library.loadImage (path).onComplete (function (image) {
 			
 			if (image != null) {
 				
 				if (this.hasAlpha) {
 					
-					LimeAssets.loadImage (alpha, false).onComplete (function (alpha) {
+					library.loadImage (alpha).onComplete (function (alpha) {
 						
 						if (alpha != null) {
 							

--- a/openfl/_internal/symbols/BitmapSymbol.hx
+++ b/openfl/_internal/symbols/BitmapSymbol.hx
@@ -1,6 +1,9 @@
 package openfl._internal.symbols;
 
 
+import lime.app.Future;
+import lime.app.Promise;
+import lime.graphics.Image;
 import lime.graphics.ImageChannel;
 import lime.math.Vector2;
 import lime.Assets in LimeAssets;
@@ -78,6 +81,51 @@ class BitmapSymbol extends SWFSymbol {
 			return cachedAsBitmapData (source, alphaBitmapData);
 			
 		}
+		
+	}
+	
+	
+	public function loadBitmapData () : Future<BitmapData> {
+		
+		var promise = new Promise<BitmapData> ();
+		
+		LimeAssets.loadImage (path, false).onComplete (function (image) {
+			
+			if (image != null) {
+				
+				if (this.hasAlpha) {
+					
+					LimeAssets.loadImage (alpha, false).onComplete (function (alpha) {
+						
+						if (alpha != null) {
+							
+							var bitmapData = cachedAsBitmapData (image, alpha);
+							promise.complete (bitmapData);
+							
+						} else {
+							
+							promise.error ('Failed to load image alpha : ${alpha}');
+							
+						}
+						
+					}).onError (promise.error);
+					
+				} else {
+					
+					var bitmapData = cachedAsBitmapData (image);
+					promise.complete (bitmapData);
+					
+				}
+				
+			} else {
+				
+				promise.error ('Failed to load image : ${path}');
+				
+			}
+			
+		});
+		
+		return promise.future;
 		
 	}
 	

--- a/openfl/_internal/symbols/ButtonSymbol.hx
+++ b/openfl/_internal/symbols/ButtonSymbol.hx
@@ -2,7 +2,6 @@ package openfl._internal.symbols;
 
 
 import openfl._internal.swf.SWFLite;
-import openfl.display.DisplayObject;
 import openfl.display.SimpleButton;
 
 @:access(openfl.display.SimpleButton)
@@ -24,7 +23,7 @@ class ButtonSymbol extends SWFSymbol {
 	}
 	
 	
-	private override function __createObject (swf:SWFLite):DisplayObject {
+	private override function __createObject (swf:SWFLite):SimpleButton {
 		
 		var simpleButton:SimpleButton = null;
 		

--- a/openfl/_internal/symbols/DynamicTextSymbol.hx
+++ b/openfl/_internal/symbols/DynamicTextSymbol.hx
@@ -2,7 +2,6 @@ package openfl._internal.symbols;
 
 
 import openfl._internal.swf.SWFLite;
-import openfl.display.DisplayObject;
 import openfl.text.TextField;
 
 @:access(openfl.text.TextField)
@@ -41,7 +40,7 @@ class DynamicTextSymbol extends SWFSymbol {
 	}
 	
 	
-	private override function __createObject (swf:SWFLite):DisplayObject {
+	private override function __createObject (swf:SWFLite):TextField {
 		
 		var textField = new TextField ();
 		textField.__fromSymbol (swf, this);

--- a/openfl/_internal/symbols/ShapeSymbol.hx
+++ b/openfl/_internal/symbols/ShapeSymbol.hx
@@ -23,7 +23,7 @@ class ShapeSymbol extends SWFSymbol {
 	}
 	
 	
-	private override function __createObject (swf:SWFLite):DisplayObject {
+	private override function __createObject (swf:SWFLite):Shape {
 		
 		var shape = new Shape ();
 		var graphics = shape.graphics;

--- a/openfl/_internal/symbols/ShapeSymbol.hx
+++ b/openfl/_internal/symbols/ShapeSymbol.hx
@@ -6,8 +6,6 @@ import openfl._internal.swf.SWFLite;
 import openfl.display.DisplayObject;
 import openfl.display.Shape;
 
-@:access(openfl._internal.symbols.BitmapSymbol)
-
 
 class ShapeSymbol extends SWFSymbol {
 	
@@ -49,7 +47,7 @@ class ShapeSymbol extends SWFSymbol {
 					
 					if (bitmap != null && bitmap.path != "") {
 						
-						graphics.beginBitmapFill (bitmap.__getBitmap (), matrix, repeat, smooth);
+						graphics.beginBitmapFill (bitmap.getBitmapData (), matrix, repeat, smooth);
 						
 					}
 				

--- a/openfl/_internal/symbols/SpriteSymbol.hx
+++ b/openfl/_internal/symbols/SpriteSymbol.hx
@@ -3,7 +3,6 @@ package openfl._internal.symbols;
 
 import openfl._internal.swf.SWFLite;
 import openfl._internal.timeline.Frame;
-import openfl.display.DisplayObject;
 import openfl.display.MovieClip;
 
 @:access(openfl.display.MovieClip)
@@ -24,7 +23,7 @@ class SpriteSymbol extends SWFSymbol {
 	}
 	
 	
-	private override function __createObject (swf:SWFLite):DisplayObject {
+	private override function __createObject (swf:SWFLite):MovieClip {
 		
 		var movieClip:MovieClip = null;
 		
@@ -41,7 +40,7 @@ class SpriteSymbol extends SWFSymbol {
 				
 			} else {
 				
-				//Log.warn ("Could not resolve class \"" + symbol.className + "\"");
+				//Log.warn ("Could not resolve class \"" + className + "\"");
 				
 			}
 			

--- a/openfl/_internal/symbols/StaticTextSymbol.hx
+++ b/openfl/_internal/symbols/StaticTextSymbol.hx
@@ -2,7 +2,6 @@ package openfl._internal.symbols;
 
 
 import openfl._internal.swf.SWFLite;
-import openfl.display.DisplayObject;
 import openfl.display.Shape;
 import openfl.geom.Matrix;
 
@@ -22,7 +21,7 @@ class StaticTextSymbol extends SWFSymbol {
 	}
 	
 	
-	private override function __createObject (swf:SWFLite):DisplayObject {
+	private override function __createObject (swf:SWFLite):Shape {
 		
 		var shape = new Shape ();
 		var graphics = shape.graphics;

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -704,7 +704,7 @@ class BitmapData implements IBitmapDrawable {
 	#end
 	
 	
-	public static function fromFile (path:String, onload:BitmapData -> Void = null, onerror:Void -> Void = null):BitmapData {
+	public static function fromFile (path:String, onload:BitmapData -> Void = null, onerror:Dynamic -> Void = null):BitmapData {
 		
 		var bitmapData = new BitmapData (0, 0, true, 0);
 		bitmapData.__fromFile (path, onload, onerror);
@@ -1394,7 +1394,7 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	private function __fromFile (path:String, onload:BitmapData -> Void, onerror:Void -> Void):Void {
+	private function __fromFile (path:String, onload:BitmapData -> Void, onerror:Dynamic -> Void):Void {
 		
 		Image.fromFile (path, function (image) {
 			

--- a/openfl/display/Loader.hx
+++ b/openfl/display/Loader.hx
@@ -116,11 +116,7 @@ class Loader extends DisplayObjectContainer {
 				contentLoaderInfo.dispatchEvent (event);
 				
 			});
-			loader.addEventListener (IOErrorEvent.IO_ERROR, function (e) {
-				
-				BitmapData_onError (e);
-				
-			});
+			loader.addEventListener (IOErrorEvent.IO_ERROR, BitmapData_onError);
 			loader.dataFormat = URLLoaderDataFormat.TEXT;
 			loader.load (request);
 			#else
@@ -163,11 +159,7 @@ class Loader extends DisplayObjectContainer {
 				libraryLoading.onError (BitmapData_onError);
 				
 			});
-			loader.addEventListener (IOErrorEvent.IO_ERROR, function (e) {
-				
-				BitmapData_onError (e);
-				
-			});
+			loader.addEventListener (IOErrorEvent.IO_ERROR, BitmapData_onError);
 			loader.dataFormat = URLLoaderDataFormat.TEXT;
 			loader.load (request);
 			
@@ -182,11 +174,7 @@ class Loader extends DisplayObjectContainer {
 				BitmapData_onLoad (BitmapData.fromBytes (loader.data));
 				
 			});
-			loader.addEventListener (IOErrorEvent.IO_ERROR, function (e) {
-				
-				BitmapData_onError (e);
-				
-			});
+			loader.addEventListener (IOErrorEvent.IO_ERROR, BitmapData_onError);
 			loader.dataFormat = URLLoaderDataFormat.BINARY;
 			loader.load (request);
 			return;
@@ -199,7 +187,7 @@ class Loader extends DisplayObjectContainer {
 			
 			worker.doWork.add (function (_) {
 				
-				BitmapData.fromFile (path, function (bitmapData) worker.sendComplete (bitmapData), function () worker.sendError (IOErrorEvent.IO_ERROR));
+				BitmapData.fromFile (path, function (bitmapData) worker.sendComplete (bitmapData), function (e) worker.sendError (IOErrorEvent.IO_ERROR));
 				
 			});
 			

--- a/openfl/display/Loader.hx
+++ b/openfl/display/Loader.hx
@@ -56,17 +56,19 @@ class Loader extends DisplayObjectContainer {
 	public function load (request:URLRequest, context:LoaderContext = null):Void {
 		
 		var extension = "";
-		var parts = request.url.split (".");
+		var path = request.url;
 		
-		if (parts.length > 0) {
+		var queryIndex = path.indexOf ('?');
+		if (queryIndex > -1) {
 			
-			extension = parts[parts.length - 1].toLowerCase ();
+			path = path.substring (0, queryIndex);
 			
 		}
 		
-		if (extension.indexOf ('?') != -1) {
+		var extIndex = path.lastIndexOf('.');
+		if (extIndex > -1) {
 			
-			extension = extension.split ('?')[0];
+			extension = path.substring(extIndex + 1);
 			
 		}
 		
@@ -259,18 +261,6 @@ class Loader extends DisplayObjectContainer {
 			var worker = new BackgroundWorker ();
 			
 			worker.doWork.add (function (_) {
-				
-				var path = request.url;
-				
-				#if sys
-				var index = path.indexOf ("?");
-				
-				if (index > -1) {
-					
-					path = path.substring (0, index);
-					
-				}
-				#end
 				
 				BitmapData.fromFile (path, function (bitmapData) worker.sendComplete (bitmapData), function () worker.sendError (IOErrorEvent.IO_ERROR));
 				

--- a/openfl/display/MovieClip.hx
+++ b/openfl/display/MovieClip.hx
@@ -1,10 +1,7 @@
 package openfl.display;
 
 
-import lime.graphics.ImageChannel;
-import lime.math.Vector2;
 import lime.utils.Log;
-import lime.Assets in LimeAssets;
 import openfl._internal.swf.SWFLite;
 import openfl._internal.symbols.BitmapSymbol;
 import openfl._internal.symbols.ButtonSymbol;
@@ -18,11 +15,8 @@ import openfl._internal.timeline.FrameObjectType;
 import openfl.events.Event;
 import openfl.filters.*;
 import openfl.text.TextField;
-import openfl.Assets;
 
 @:access(openfl._internal.symbols.SWFSymbol)
-@:access(openfl.display.SimpleButton)
-@:access(openfl.text.TextField)
 
 
 class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObject> #end {
@@ -491,9 +485,9 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 					
 					if (!__objects.exists (frameObject.id)) {
 						
-						if (__swf.symbols.exists (frameObject.symbol)) {
+						var symbol = __swf.symbols.get (frameObject.symbol);
+						if (symbol != null) {
 							
-							symbol = __swf.symbols.get (frameObject.symbol);
 							displayObject = symbol.__createObject (__swf);
 							
 						}


### PR DESCRIPTION
Requires https://github.com/openfl/lime/pull/850

This enables the HTML5 target to load a `library.dat` that's not "embedded" in the DefaultAssetLibrary and default Preloader.