### PR TITLE
Fixed of `BitmapData#encode`

### DIFF
--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -609,14 +609,17 @@ class BitmapData implements IBitmapDrawable {
 		// TODO: Support rect
 		
 		if (!readable || rect == null) return byteArray = null;
+		if (byteArray == null) byteArray = new ByteArray();
 		
 		if (Std.is (compressor, PNGEncoderOptions)) {
 			
-			return byteArray = ByteArray.fromBytes (image.encode ("png"));
+			byteArray.writeBytes(ByteArray.fromBytes (image.encode ("png")));
+			return byteArray;
 			
 		} else if (Std.is (compressor, JPEGEncoderOptions)) {
 			
-			return byteArray = ByteArray.fromBytes (image.encode ("jpg", cast (compressor, JPEGEncoderOptions).quality));
+			byteArray.writeBytes(ByteArray.fromBytes (image.encode ("jpg", cast (compressor, JPEGEncoderOptions).quality)));
+			return byteArray;
 			
 		}
 		


### PR DESCRIPTION
Now method `BitmapData#encode` works according to offical documentation http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/BitmapData.html#encode() properly