### PR TITLE
Fix for Video size with GL renderer

### DIFF
--- a/openfl/media/Video.hx
+++ b/openfl/media/Video.hx
@@ -83,8 +83,8 @@ class Video extends DisplayObject {
 	
 	private function __getBuffer (gl:GLRenderContext, alpha:Float):GLBuffer {
 		
-		var width = videoWidth;
-		var height = videoHeight;
+		var width = __width;
+		var height = __height;
 		
 		if (width == 0 || height == 0) return null;
 		


### PR DESCRIPTION
Otherwise all videos are rendered with original media size, rather than the set values.