### PR TITLE
Tools.hx generatedPath bug fix

### DIFF
--- a/tools/Tools.hx
+++ b/tools/Tools.hx
@@ -905,7 +905,7 @@ class Tools {
 				
 			} else {
 				
-				generatedPath = PathHelper.combine (targetDirectory, "/haxe/_generated");
+				generatedPath = PathHelper.combine (targetDirectory, "haxe/_generated");
 				
 			}
 			


### PR DESCRIPTION
```
PathHelper.combine (targetDirectory, "/haxe/_generated")
```
returns "/haxe/_generated"