### PR TITLE
More accurate advances for Input TextFields

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -2102,6 +2102,7 @@ class TextField extends InteractiveObject {
 				addEventListener (Event.ADDED_TO_STAGE, this_onAddedToStage);
 				
 				this_onFocusIn (null);
+				__textEngine.__useIntAdvances = true;
 				
 			} else {
 				
@@ -2110,6 +2111,7 @@ class TextField extends InteractiveObject {
 				removeEventListener (Event.ADDED_TO_STAGE, this_onAddedToStage);
 				
 				__stopTextInput ();
+				__textEngine.__useIntAdvances = null;
 				
 			}
 			


### PR DESCRIPTION
For Input TextFields use always more accurate way of calculating advances, because otherwise the cursor may be rendered quite a bit off.