### PR TITLE
Much much much crispier 2D Vector Graphics

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -239,6 +239,10 @@ class CanvasGraphics {
 		
 	}
 	
+	#if (js && html5)
+	static var hitTestCanvas : js.html.CanvasElement = cast Browser.document.createElement ("canvas");
+	static var hitTestContext = hitTestCanvas.getContext ("2d");
+	#end
 	
 	public static function hitTest (graphics:Graphics, x:Float, y:Float):Bool {
 		
@@ -266,24 +270,10 @@ class CanvasGraphics {
 			x -= transform.__transformX (bounds.x, bounds.y);
 			y -= transform.__transformY (bounds.x, bounds.y);
 			
-			//var width = graphics.__width;
-			//var height = graphics.__height;
-			//var canvas = graphics.__canvas;
-			
-			if (graphics.__canvas == null) {
-				
-				graphics.__canvas = cast Browser.document.createElement ("canvas");
-				graphics.__context = graphics.__canvas.getContext ("2d");
-				//canvas = graphics.__canvas;
-				
-			}
-			
-			//if (canvas.width != width || canvas.height != height) {
-				
-				//canvas.width = width;
-				//canvas.height = height;
-				
-			//}
+			var cacheCanvas = graphics.__canvas;
+			var cacheContext = graphics.__context;
+			graphics.__canvas = hitTestCanvas;
+			graphics.__context = hitTestContext;
 			
 			context = graphics.__context;
 			context.setTransform (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
@@ -350,6 +340,8 @@ class CanvasGraphics {
 						if (hasFill && context.isPointInPath (x, y)) {
 							
 							data.destroy ();
+							graphics.__canvas = cacheCanvas;
+							graphics.__context = cacheContext;
 							return true;
 							
 						}
@@ -357,6 +349,8 @@ class CanvasGraphics {
 						if (hasStroke && (context:Dynamic).isPointInStroke (x, y)) {
 							
 							data.destroy ();
+							graphics.__canvas = cacheCanvas;
+							graphics.__context = cacheContext;
 							return true;
 							
 						}
@@ -372,6 +366,8 @@ class CanvasGraphics {
 						if (hasFill && context.isPointInPath (x, y)) {
 							
 							data.destroy ();
+							graphics.__canvas = cacheCanvas;
+							graphics.__context = cacheContext;
 							return true;
 							
 						}
@@ -379,6 +375,8 @@ class CanvasGraphics {
 						if (hasStroke && (context:Dynamic).isPointInStroke (x, y)) {
 							
 							data.destroy ();
+							graphics.__canvas = cacheCanvas;
+							graphics.__context = cacheContext;
 							return true;
 							
 						}
@@ -451,15 +449,22 @@ class CanvasGraphics {
 			
 			if (hasFill && context.isPointInPath (x, y)) {
 				
+				graphics.__canvas = cacheCanvas;
+				graphics.__context = cacheContext;
 				return true;
 				
 			}
 			
 			if (hasStroke && (context:Dynamic).isPointInStroke (x, y)) {
 				
+				graphics.__canvas = cacheCanvas;
+				graphics.__context = cacheContext;
 				return true;
 				
 			}
+			
+			graphics.__canvas = cacheCanvas;
+			graphics.__context = cacheContext;
 			
 		}
 		

--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -890,12 +890,41 @@ class CanvasGraphics {
 				}
 				
 				context = graphics.__context;
-				
-				graphics.__canvas.width = width;
-				graphics.__canvas.height = height;
-				
 				var transform = graphics.__renderTransform;
-				context.setTransform (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
+				
+				#if dom
+					
+					var devicePixelRatio = untyped window.devicePixelRatio || 1;
+					if (devicePixelRatio > 1) {
+						
+						graphics.__canvas.width  = Std.int( width * devicePixelRatio);
+						graphics.__canvas.height = Std.int(height * devicePixelRatio);
+						graphics.__canvas.style.width  =  width + "px";
+						graphics.__canvas.style.height = height + "px";	
+						
+						var transform = graphics.__renderTransform;
+						context.setTransform (transform.a  * devicePixelRatio,
+						                      transform.b  * devicePixelRatio,
+						                      transform.c  * devicePixelRatio,
+						                      transform.d  * devicePixelRatio,
+						                      transform.tx * devicePixelRatio,
+						                      transform.ty * devicePixelRatio);
+						
+					} else {
+						
+						graphics.__canvas.width  = width;
+						graphics.__canvas.height = height;
+						context.setTransform (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
+						
+					}
+					
+				#else
+					
+					graphics.__canvas.width  = width;
+					graphics.__canvas.height = height;
+					context.setTransform (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
+					
+				#end
 				
 				fillCommands.clear ();
 				strokeCommands.clear ();

--- a/openfl/_internal/renderer/canvas/CanvasRenderer.hx
+++ b/openfl/_internal/renderer/canvas/CanvasRenderer.hx
@@ -54,11 +54,11 @@ class CanvasRenderer extends AbstractRenderer {
 		if (!stage.__transparent && stage.__clearBeforeRender) {
 			
 			context.fillStyle = stage.__colorString;
-			context.fillRect (0, 0, stage.stageWidth, stage.stageHeight);
+			context.fillRect (0, 0, stage.stageWidth * stage.window.scale, stage.stageHeight * stage.window.scale);
 			
 		} else if (stage.__transparent && stage.__clearBeforeRender) {
 			
-			context.clearRect (0, 0, stage.stageWidth, stage.stageHeight);
+			context.clearRect (0, 0, stage.stageWidth * stage.window.scale, stage.stageHeight * stage.window.scale);
 			
 		}
 		

--- a/openfl/_internal/renderer/canvas/CanvasRenderer.hx
+++ b/openfl/_internal/renderer/canvas/CanvasRenderer.hx
@@ -24,7 +24,7 @@ class CanvasRenderer extends AbstractRenderer {
 		
 		renderSession = new RenderSession ();
 		renderSession.context = context;
-		renderSession.roundPixels = true ;
+		renderSession.roundPixels = true;
 		renderSession.renderer = this;
 		#if !neko
 		renderSession.maskManager = new CanvasMaskManager(renderSession);

--- a/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -157,8 +157,32 @@ class CanvasTextField {
 				
 				context = graphics.__context;
 				
-				graphics.__canvas.width = width;
-				graphics.__canvas.height = height;
+				var transform = graphics.__renderTransform;
+				
+				#if dom
+					
+					var devicePixelRatio = untyped window.devicePixelRatio || 1;
+					
+					graphics.__canvas.width  = Std.int( width * devicePixelRatio);
+					graphics.__canvas.height = Std.int(height * devicePixelRatio);
+					graphics.__canvas.style.width  =  width + "px";
+					graphics.__canvas.style.height = height + "px";
+					
+					context.setTransform (transform.a  * devicePixelRatio,
+					                      transform.b  * devicePixelRatio,
+					                      transform.c  * devicePixelRatio,
+					                      transform.d  * devicePixelRatio,
+					                      transform.tx * devicePixelRatio,
+					                      transform.ty * devicePixelRatio);
+					
+				#else
+					
+					graphics.__canvas.width  = width;
+					graphics.__canvas.height = height;
+					
+					context.setTransform (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
+					
+				#end
 				
 				if (clearRect == null) {
 					
@@ -169,18 +193,6 @@ class CanvasTextField {
 				if (clearRect) {
 					
 					context.clearRect (0, 0, graphics.__canvas.width, graphics.__canvas.height);
-					
-				}
-				
-				var transform = graphics.__renderTransform;
-				
-				if (renderSession.roundPixels) {
-					
-					context.setTransform (transform.a, transform.b, transform.c, transform.d, Std.int (transform.tx), Std.int (transform.ty));
-					
-				} else {
-					
-					context.setTransform (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
 					
 				}
 				

--- a/openfl/_internal/renderer/dom/DOMShape.hx
+++ b/openfl/_internal/renderer/dom/DOMShape.hx
@@ -28,7 +28,7 @@ class DOMShape {
 			
 			CanvasGraphics.render (graphics, renderSession, shape.__renderTransform);
 			
-			if (graphics.__dirty || shape.__worldAlphaChanged || (shape.__canvas == null && graphics.__canvas != null)) {
+			if (graphics.__dirty || shape.__worldAlphaChanged || (shape.__canvas != graphics.__canvas)) {
 				
 				if (graphics.__canvas != null) {
 					

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -466,12 +466,12 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 				
 			} else {
 				
-				while (current != stage && current != null) {
+				while (current != null) {
 					
 					list.push (current);
 					current = current.parent;
 					
-					if (current != stage && current.__transformDirty) {
+					if (current != null && current.__transformDirty) {
 						
 						transformDirty = true;
 						
@@ -807,6 +807,11 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			__renderTransform.d = local.c * parentTransform.b + local.d * parentTransform.d;
 			__renderTransform.tx = local.tx * parentTransform.a + local.ty * parentTransform.c + parentTransform.tx;
 			__renderTransform.ty = local.tx * parentTransform.b + local.ty * parentTransform.d + parentTransform.ty;
+			
+			if (parent == stage) {
+				__renderTransform.tx = local.tx;
+				__renderTransform.ty = local.ty;
+			}
 			
 		} else {
 			

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -863,12 +863,6 @@ import js.html.CanvasRenderingContext2D;
 		var width  = __bounds.width  * scaleX;
 		var height = __bounds.height * scaleY;
 		
-		if (Math.abs (width - __width) > 2 || Math.abs (height - __height) > 2) {
-			
-			__dirty = true;
-			
-		}
-		
 		if (width < 1 || height < 1) {
 			
 			__width  = Std.int (width);
@@ -901,9 +895,19 @@ import js.html.CanvasRenderingContext2D;
 		__renderTransform.tx = (tx - __worldTransform.tx);
 		__renderTransform.ty = (ty - __worldTransform.ty);
 		
-		// Grow the canvas bounds to contain the graphics and the extra subpixel
-		__width  = Math.ceil(width  + __renderTransform.tx);
-		__height = Math.ceil(height + __renderTransform.ty);
+		// Calculate the size to contain the graphics and the extra subpixel
+		var newWidth  = Math.ceil(width  + __renderTransform.tx);
+		var newHeight = Math.ceil(height + __renderTransform.ty);
+		
+		// Mark dirty if render size changed
+		if (newWidth != __width || newHeight != __height) {
+			
+			__dirty = true;
+			
+		}
+		
+		__width  = newWidth;
+		__height = newHeight;
 		
 	}
 	

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -878,8 +878,8 @@ import js.html.CanvasRenderingContext2D;
 		
 		// Inlined & simplified `__worldTransform.concat (parentTransform)` below:
 		__worldTransform.a = inverseA * parentTransform.a;
-		__worldTransform.b = inverseD * parentTransform.b;
-		__worldTransform.c = inverseA * parentTransform.c;
+		__worldTransform.b = inverseA * parentTransform.b;
+		__worldTransform.c = inverseD * parentTransform.c;
 		__worldTransform.d = inverseD * parentTransform.d;
 		
 		var x = __bounds.x;

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -893,8 +893,8 @@ import js.html.CanvasRenderingContext2D;
 		__worldTransform.ty = Math.ffloor (ty);
 		
 		// Offset the rendering with the subpixel offset removed by Math.floor above
-		__renderTransform.tx = (tx - __worldTransform.tx);
-		__renderTransform.ty = (ty - __worldTransform.ty);
+		__renderTransform.tx = __worldTransform.__transformInverseX (tx, ty);
+		__renderTransform.ty = __worldTransform.__transformInverseY (tx, ty);
 		
 		// Calculate the size to contain the graphics and the extra subpixel
 		var newWidth  = Math.ceil(width  + __renderTransform.tx);

--- a/openfl/display/Graphics.hx
+++ b/openfl/display/Graphics.hx
@@ -865,8 +865,9 @@ import js.html.CanvasRenderingContext2D;
 		
 		if (width < 1 || height < 1) {
 			
-			__width  = Std.int (width);
-			__height = Std.int (height);
+			if (__width >= 1 || __height >= 1) __dirty = true;
+			__width  = 0;
+			__height = 0;
 			return;
 			
 		}

--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -507,7 +507,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 				
 			}
 			
-			__onMouse (type, Std.int (x * window.scale), Std.int (y * window.scale), button);
+			__onMouse (type, Std.int (x), Std.int (y), button);
 			
 		} catch (e:Dynamic) {
 			
@@ -524,7 +524,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 		
 		try {
 			
-			__onMouse (MouseEvent.MOUSE_MOVE, Std.int (x * window.scale), Std.int (y * window.scale), 0);
+			__onMouse (MouseEvent.MOUSE_MOVE, Std.int (x), Std.int (y), 0);
 			
 		} catch (e:Dynamic) {
 			
@@ -556,7 +556,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 				
 			}
 			
-			__onMouse (type, Std.int (x * window.scale), Std.int (y * window.scale), button);
+			__onMouse (type, Std.int (x), Std.int (y), button);
 			
 			if (!showDefaultContextMenu && button == 2) {
 				
@@ -579,7 +579,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 		
 		try {
 			
-			__onMouseWheel (Std.int (deltaX * window.scale), Std.int (deltaY * window.scale));
+			__onMouseWheel (Std.int (deltaX), Std.int (deltaY));
 			
 		} catch (e:Dynamic) {
 			
@@ -1299,6 +1299,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 		if (button > 2) return;
 		
 		var targetPoint = new Point (x, y);
+		__transform.__transformPoint (targetPoint);
 		__displayMatrix.__transformInversePoint (targetPoint);
 		
 		__mouseX = targetPoint.x;
@@ -1642,7 +1643,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 			var offsetX = Math.round ((windowWidth - (stageWidth * targetScale)) / 2);
 			var offsetY = Math.round ((windowHeight - (stageHeight * targetScale)) / 2);
 			
-			__displayMatrix.scale (targetScale, targetScale);
+			__transform.a = __transform.d = targetScale;
 			__displayMatrix.translate (offsetX, offsetY);
 			
 		}


### PR DESCRIPTION
This PR does a few things:

- gets rid of a lot of "roundPixels" logic...
- AND gets rid of rounding errors altogether, by doing less floating point math.
- properly scales DOM canvas and webgl canvas for high DPI screens
  - (but WebGL only when `<window allow-high-dpi="true">`)

Before, with `allow-high-dpi="false"`: 
![before](https://cloud.githubusercontent.com/assets/326263/22257095/3520c47c-e25d-11e6-8ef1-b074cb33cb55.png)

Before, with `allow-high-dpi="true"` - yes, it's completely broken:
![before-wacky-allowhighdpi](https://cloud.githubusercontent.com/assets/326263/22257107/4325a45c-e25d-11e6-8bb7-d18c112f33a7.png)

After patch:
![after](https://cloud.githubusercontent.com/assets/326263/22257110/481894f6-e25d-11e6-82c2-a89fae80c59e.png)


Just look and weep at those pretty rounded edges ;)