### PR TITLE
Add a possibility to loop through dictionary by values

### DIFF
--- a/openfl/utils/Dictionary.hx
+++ b/openfl/utils/Dictionary.hx
@@ -53,6 +53,11 @@ abstract Dictionary<K, V> (IMap<K, V>) {
 		
 	}
 	
+	public inline function values ():Iterator<V> {
+		
+		return this.iterator ();
+		
+	}
 	
 	@:to static inline function toStringMap<K:String, V> (t:IMap<K, V>, weakKeys:Bool):StringMap<V> {
 		


### PR DESCRIPTION
We are currently porting as3 to Haxe/OpenFL and are missing the "for each" feature to loop by values. Of course we are able to work it through but it would be much elegant if it is supported by the Dictionary API.
In the current openfl.utils.Dictionary implementation there is no such possibility. SInce it is a very simple change and will only make Dictionary API reacher I think it would be cool to merge it.
None of the existing Dictionary API is changed.