### PR TITLE
Canvas: Do not render when mask is 0-sized

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -577,7 +577,11 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	private function __renderCanvas (renderSession:RenderSession):Void {
 		
-		CanvasDisplayObject.render (this, renderSession);
+		if (mask == null || (mask.width > 0 && mask.height > 0)) {
+			
+			CanvasDisplayObject.render (this, renderSession);
+			
+		}
 		
 	}
 	

--- a/openfl/display/DisplayObjectContainer.hx
+++ b/openfl/display/DisplayObjectContainer.hx
@@ -614,7 +614,7 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	private override function __renderCanvas (renderSession:RenderSession):Void {
 		
-		if (!__renderable || __worldAlpha <= 0) return;
+		if (!__renderable || __worldAlpha <= 0 || (mask != null && (mask.width <= 0 || mask.height <= 0))) return;
 		
 		#if !neko
 		


### PR DESCRIPTION
This is not just an optimisation but required because drawing an empty clip, doesn’t mask anything at all.