### PR TITLE
Fix for #1488 - Empty filename when saving

### DIFF
--- a/openfl/net/FileReference.hx
+++ b/openfl/net/FileReference.hx
@@ -146,7 +146,7 @@ class FileReference extends EventDispatcher {
 		var saveFileDialog = new FileDialog ();
 		saveFileDialog.onCancel.add (saveFileDialog_onCancel);
 		saveFileDialog.onSelect.add (saveFileDialog_onSelect);
-		saveFileDialog.browse (SAVE, defaultFileName != null ? Path.extension (defaultFileName) : null);
+		saveFileDialog.browse (SAVE, defaultFileName != null ? Path.extension (defaultFileName) : null, defaultFileName);
 		
 		#end
 		


### PR DESCRIPTION
Fix empty filename when saving