### PR TITLE
HTML5: Replace keyboard fakery with native cut/copy/paste event handling

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -1299,6 +1299,20 @@ class TextField extends InteractiveObject {
 	}
 	
 	
+	private function __setClipboard (cut = false):Void {
+		
+		Clipboard.text = __text.substring (__caretIndex, __selectionIndex);
+		
+		if (cut && __caretIndex != __selectionIndex) {
+			
+			replaceSelectedText ("");
+			dispatchEvent (new Event (Event.CHANGE, true));
+			
+		}
+		
+	}
+	
+	
 	private function __startCursorTimer ():Void {
 		
 		__cursorTimer = Timer.delay (__startCursorTimer, 600);
@@ -2445,6 +2459,20 @@ class TextField extends InteractiveObject {
 				
 			}
 			
+			if (!stage.window.onClipboard.has (window_onClipboard)) {
+				
+				stage.window.onClipboard.add (window_onClipboard);
+				
+			}
+			
+		} else {
+			
+			if (stage.window.onClipboard.has (window_onClipboard)) {
+				
+				stage.window.onClipboard.remove (window_onClipboard);
+				
+			}
+			
 		}
 		
 	}
@@ -2674,30 +2702,23 @@ class TextField extends InteractiveObject {
 				__stopCursorTimer ();
 				__startCursorTimer ();
 			
+			#if !js
 			case C:
 				
-				if (#if mac modifier.metaKey #elseif js modifier.metaKey || modifier.ctrlKey #else modifier.ctrlKey #end) {
+				if (#if mac modifier.metaKey #else modifier.ctrlKey #end) {
 					
-					Clipboard.text = __text.substring (__caretIndex, __selectionIndex);
+					__setClipboard (false);
 					
 				}
 			
 			case X:
 				
-				if (#if mac modifier.metaKey #elseif js modifier.metaKey || modifier.ctrlKey #else modifier.ctrlKey #end) {
+				if (#if mac modifier.metaKey #else modifier.ctrlKey #end) {
 					
-					Clipboard.text = __text.substring (__caretIndex, __selectionIndex);
-					
-					if (__caretIndex != __selectionIndex) {
-						
-						replaceSelectedText ("");
-						dispatchEvent (new Event (Event.CHANGE, true));
-						
-					}
+					__setClipboard (true);
 					
 				}
 			
-			#if !js
 			case V:
 				
 				if (#if mac modifier.metaKey #else modifier.ctrlKey #end) {
@@ -2733,6 +2754,23 @@ class TextField extends InteractiveObject {
 				}
 			
 			default:
+			
+		}
+		
+	}
+	
+	
+	private function window_onClipboard (action:ClipboardAction):Void {
+		
+		switch (action) {
+			
+			case PASTE:
+			
+				window_onTextInput (Clipboard.text);
+			
+			case CUT, COPY:
+			
+				__setClipboard (action == CUT);
 			
 		}
 		


### PR DESCRIPTION
This ensures copying from application or context menus work just as well as using the keyboard.
Additionally, on OSX only `CMD` keyboard shortcuts will respond, leaving `CTRL` free for other use.

Requires https://github.com/openfl/lime/pull/925