### PR TITLE
Fix x and y pos being added to width and height.

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -421,7 +421,14 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	private inline function __getLocalBounds (rect:Rectangle):Void {
 		
+		var cacheX = __transform.tx;
+		var cacheY = __transform.ty;
+		__transform.tx = __transform.ty = 0;
+		
 		__getBounds (rect, __transform);
+		
+		__transform.tx = cacheX;
+		__transform.ty = cacheY;
 		
 	}
 	


### PR DESCRIPTION
It’s relative to parent after all. Or am I missing something here?

This bug is easy to test by creating a Sprite with some graphics:
- with `y = 0`, height will be equal to Graphics
- with `y = 1`,  height will be 1 + Graphics height...

