### PR TITLE
need to use the version of the function that doesnt prepend length byte

### DIFF
--- a/openfl/net/Socket.hx
+++ b/openfl/net/Socket.hx
@@ -569,7 +569,7 @@ class Socket extends EventDispatcher implements IDataInput implements IDataOutpu
 		if (Std.is (msg.data, String)) {
 			
 			var cachePosition = __inputBuffer.position;
-			__inputBuffer.writeUTF (msg.data);
+			__inputBuffer.writeUTFBytes (msg.data);
 			__inputBuffer.position = cachePosition;
 			
 		} else {


### PR DESCRIPTION
tested and confirmed working

what it looks like for us

```
gamePlay init() - _gamePlayFlashVars.isCreateAccount:false Server Node: 10.102.1.13
SFClient.hx:814 Connected.
DebugUtility.hx:17 [Sending - STR]: %tf%s%zz%-1%10.102.1.13%

DebugUtility.hx:17 [Sending]: <msg t='sys'><body action='rndK' r='-1'></body></msg>

DebugUtility.hx:17 [ RECEIVED ]: <msg t='sys'><body action='rndK' r='-1'><k>LKgEbRoNLSDL_essVnn</k></body></msg>, (len: 79)
SFClient.hx:1224 Random key received from server: LKgEbRoNLSDL_essVnn
```