### PR TITLE
remove deprecated meta tag from html5 template

### DIFF
--- a/templates/html5/template/index.html
+++ b/templates/html5/template/index.html
@@ -3,7 +3,6 @@
 <head>
 	
 	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	
 	<title>::APP_TITLE::</title>
 	


### PR DESCRIPTION
> The X-UA-Compatible meta tag allows web authors to choose what version of Internet Explorer the page should be rendered as. IE11 has made changes to these modes; see the IE11 note below. Microsoft Edge, the browser that will be released after IE11, will only honor the X-UA-Compatible meta tag in certain circumstances

> Depending upon what Microsoft browsers you support you may not need to continue using the X-UA-Compatible tag. If you need to support IE 9 or IE 8, then I would recommend using the tag. If you only support the latest browsers (IE 11 and/or Edge) then I would consider dropping this tag altogether. 

> There is also chrome=1 that you can use or use together with one of the above options, EX: <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"> chrome=1 is for Google's Chrome Frame

> Google Chrome Frame is an open source browser plug-in. Users who have the plug-in installed have access to Google Chrome's open web technologies and speedy JavaScript engine when they open pages in the browser.

> Google Chrome Frame is no longer supported and retired as of February 25, 2014. If you have Chrome Frame installed, please uninstall it.

see also: http://stackoverflow.com/a/6771584

see also: https://github.com/openfl/lime/pull/937