### PR TITLE
ATF support

### DIFF
--- a/openfl/display3D/textures/TextureBase.hx
+++ b/openfl/display3D/textures/TextureBase.hx
@@ -29,7 +29,11 @@ class TextureBase extends EventDispatcher {
 	private static var __supportsBGRA:Null<Bool> = null;
 	private static var __textureFormat:Int;
 	private static var __textureInternalFormat:Int;
-	
+
+	private static var __supportsCompressed:Null<Bool> = null;
+	private static var __textureFormatCompressed:Int;
+	private static var __textureFormatCompressedAlpha:Int;
+
 	private var __alphaTexture:Texture;
 	private var __compressedMemoryUsage:Int;
 	private var __context:Context3D;
@@ -56,7 +60,7 @@ class TextureBase extends EventDispatcher {
 		
 		__textureID = GL.createTexture ();
 		__textureContext = GL.context;
-		
+
 		if (__supportsBGRA == null) {
 			
 			__textureInternalFormat = GL.RGBA;
@@ -88,6 +92,28 @@ class TextureBase extends EventDispatcher {
 				__supportsBGRA = false;
 				__textureFormat = GL.RGBA;
 				
+			}
+			
+		}
+
+		if (__supportsCompressed == null) {
+			
+			#if (js && html5)
+			var compressedExtension = GL.getExtension ("WEBGL_compressed_texture_s3tc");
+			#else
+			var compressedExtension = GL.getExtension ("EXT_texture_compression_s3tc");
+			#end
+			
+			if (compressedExtension != null) {
+
+				__supportsCompressed = true;
+				__textureFormatCompressed = compressedExtension.COMPRESSED_RGBA_S3TC_DXT1_EXT;
+				__textureFormatCompressedAlpha = compressedExtension.COMPRESSED_RGBA_S3TC_DXT5_EXT;
+
+			} else {
+
+				__supportsCompressed = false;
+
 			}
 			
 		}


### PR DESCRIPTION
Supports compressed textures on HTML5 and Neko targets. Can read block compressed textures in Adobe Texture Format (ATF). Cube Maps are not supported.

Compiles fine against lime master branch, but needs lime on develop branch for Neko targets and lime branch feature/fast-webgl-bindings to support HTML5.



