### PR TITLE
force roundPixels = true for TextFields in -Ddom

### DIFF
--- a/openfl/_internal/renderer/dom/DOMTextField.hx
+++ b/openfl/_internal/renderer/dom/DOMTextField.hx
@@ -330,8 +330,16 @@ class DOMTextField {
 			
 			if (textField.__div != null) {
 				
+				// force roundPixels = true for TextFields
+				// Chrome shows blurry text if coordinates are fractional
+				
+				var old = renderSession.roundPixels;
+				renderSession.roundPixels = true;
+				
 				DOMRenderer.updateClip (textField, renderSession);
 				DOMRenderer.applyStyle (textField, renderSession, true, true, true);
+				
+				renderSession.roundPixels = old;
 				
 			}
 			


### PR DESCRIPTION
Chrome shows blurry text if matrix3d coordinates are fractional. However having always roundPixels = true is also problematic as it creates "shaky" rotation for Bitmaps. A reasonable solution seems to be to use false everywhere and true only for TextFields.

See: https://github.com/openfl/openfl/issues/1570