### PR TITLE
added required @:access(openfl.geom.Point)

### DIFF
--- a/openfl/media/Video.hx
+++ b/openfl/media/Video.hx
@@ -19,6 +19,7 @@ import openfl.net.NetStream;
 
 @:access(openfl.geom.Rectangle)
 @:access(openfl.net.NetStream)
+@:access(openfl.geom.Point)
 
 
 class Video extends DisplayObject {


### PR DESCRIPTION
because __hitTestMask is acccessing Point.__pool