### PR TITLE
Fix DOM render when cacheAsBitmap

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -769,7 +769,15 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (__cacheBitmap != null && !__cacheBitmapRender) {
 			
+			var stageReferenceSet:Bool = false;
+			if (__worldVisible) {
+				__cacheBitmap.__setStageReference(stage);
+				stageReferenceSet = true;
+			}
 			DOMBitmap.render (__cacheBitmap, renderSession);
+			if (stageReferenceSet) {
+				__cacheBitmap.__setStageReference(null);
+			}
 			
 		} else {
 			


### PR DESCRIPTION
The __cacheBitmap does not have a stage reference, but DOMBitmap.render expects it.