### PR TITLE
socket connected should be false after socket close

### DIFF
--- a/openfl/net/Socket.hx
+++ b/openfl/net/Socket.hx
@@ -535,8 +535,9 @@ class Socket extends EventDispatcher implements IDataInput implements IDataOutpu
 			__socket.close ();
 			
 		} catch (e:Dynamic) {}
-		
+
 		__socket = null;
+		__connected = false;
 		Lib.current.removeEventListener (Event.ENTER_FRAME, this_onEnterFrame);
 		
 	}
@@ -680,14 +681,12 @@ class Socket extends EventDispatcher implements IDataInput implements IDataOutpu
 		
 		if (doClose && connected) {
 			
-			__connected = false;
 			__cleanSocket ();
 			
 			dispatchEvent (new Event (Event.CLOSE));
 			
 		} else if (doClose) {
 			
-			__connected = false;
 			__cleanSocket ();
 			
 			dispatchEvent (new IOErrorEvent (IOErrorEvent.IO_ERROR, true, false, "Connection failed"));


### PR DESCRIPTION
otherwise calling `Socket::close()` twice will throw an error, and there is no way to check since `Socket::__connected == true` still


this change enables app code to be written like

`if (socket.connected) socket.close();`