### PR TITLE
socket needs to remember position for parsing long multi-packet messages

### DIFF
--- a/openfl/net/Socket.hx
+++ b/openfl/net/Socket.hx
@@ -567,7 +567,8 @@ class Socket extends EventDispatcher implements IDataInput implements IDataOutpu
 		
 		#if (js && html5)
 		if (Std.is (msg.data, String)) {
-			
+
+			__inputBuffer.position = __inputBuffer.length;
 			var cachePosition = __inputBuffer.position;
 			__inputBuffer.writeUTFBytes (msg.data);
 			__inputBuffer.position = cachePosition;


### PR DESCRIPTION
buffer was writing from position 0 on every new packet, causing long messages to be truncated if they couldn't fit in one packet (one pass).

