### PR TITLE
Adds frame script support (JS/HTML5 target only!)

### DIFF
--- a/openfl/_internal/symbols/SpriteSymbol.hx
+++ b/openfl/_internal/symbols/SpriteSymbol.hx
@@ -17,8 +17,10 @@ class SpriteSymbol extends SWFSymbol {
 	
 	
 	public var frames:Array<Frame>;
-	
-	
+	public var frameScripts : Map<Int, Void->Void>;
+	public var frameScriptDefs : Map<Int, String>;
+
+
 	public function new () {
 		
 		super ();
@@ -35,6 +37,7 @@ class SpriteSymbol extends SWFSymbol {
 		#if !macro
 		MovieClip.__initSWF = swf;
 		MovieClip.__initSymbol = this;
+		MovieClip.__initScripts = frameScripts;
 		#end
 		
 		if (className != null) {

--- a/openfl/_internal/timeline/Frame.hx
+++ b/openfl/_internal/timeline/Frame.hx
@@ -12,6 +12,8 @@ package openfl._internal.timeline;
 	
 	public var label:String;
 	public var objects:Array <FrameObject>;
+	public var scriptDef:Map<Int,String>;
+	public var scripts:Map<Int,Void->Void>;
 	
 	
 	public function new () {


### PR DESCRIPTION
targets not using this feature shouldn't notice the difference.

- assumes you inject your own frame scripts as strings into SWFLite `.dat` format
  as `SpriteSymbol.frameScriptDefs:Map<Int,String>`
  (our proprietary injection tool needs cleanup before it can be shared)
- evals string as javascript `Function` at runtime during frame animation
- provides context (this == current `MovieClip` instance)
- provides error handling w/ stack traces

ideas to make compatible with other targets:
- provide macros for them at runtime that eval in specific languages that make sense (e.g., for neko/cpp maybe lua script evaluation), or;
- provide hxscript implementation that provides fast runtime evaluation in all targets


:muscle: credit goes to each of: @asciiascetic, @sbijoshj, and @sbimikesmullin for this one. 