### PR TITLE
`Asset.getMovieClip()` on `.bundle/` should load globally

### DIFF
--- a/openfl/display/Loader.hx
+++ b/openfl/display/Loader.hx
@@ -278,8 +278,12 @@ class Loader extends DisplayObjectContainer {
 			if (Std.is (library, AssetLibrary)) {
 				
 				library.load ().onComplete (function (_) {
+					var _library = cast (library, AssetLibrary);
 					
-					contentLoaderInfo.content = cast (library, AssetLibrary).getMovieClip ("");
+					contentLoaderInfo.content = _library.getMovieClip ("");
+					
+					Assets.registerLibrary(Path.withoutDirectory(Path.withoutExtension(manifest.rootPath)), _library);
+					
 					addChild (contentLoaderInfo.content);
 					
 					contentLoaderInfo.dispatchEvent (new Event (Event.COMPLETE));


### PR DESCRIPTION
prior to this change, if we did not keep our own reference to a `.bundle` loaded at runtime, we were not able to access to again from any other scope. 

this adds it to the Lime/OpenFL AssetLibrary Map so we can find it by its url when using `Asset.getMovieClip()`