### PR TITLE
openfl_dynamic Reflect.fields() only

### DIFF
--- a/openfl/display/MovieClip.hx
+++ b/openfl/display/MovieClip.hx
@@ -406,7 +406,7 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 		
 		displayObject.visible = frameObject.visible;
 		
-		#if openfl_dynamic
+		#if (openfl_dynamic || openfl_dynamic_fields_only)
 		Reflect.setField (this, displayObject.name, displayObject);
 		#end
 		


### PR DESCRIPTION
we wanted dynamic `Reflect.field()` additions for all `(MovieClip.__children:DisplayObject).__name`s, but not the `MovieClip` to be `implements Dynamic<DisplayObject>`, because not all our dynamic properties are `DisplayObjects`; we don't think Flash views them that way, either.