### PR TITLE
add linkageBaseClass name MovieClip constructor support

### DIFF
--- a/openfl/_internal/symbols/SpriteSymbol.hx
+++ b/openfl/_internal/symbols/SpriteSymbol.hx
@@ -17,7 +17,7 @@ class SpriteSymbol extends SWFSymbol {
 	
 	
 	public var frames:Array<Frame>;
-	
+	public var linkageBaseClass:String;
 	
 	public function new () {
 		
@@ -37,7 +37,23 @@ class SpriteSymbol extends SWFSymbol {
 		MovieClip.__initSymbol = this;
 		#end
 		
-		if (className != null) {
+		
+		if (linkageBaseClass != null) {
+			
+			var symbolType = Type.resolveClass (linkageBaseClass);
+			
+			if (symbolType != null) {
+				
+				movieClip = Type.createInstance (symbolType, []);
+				
+			} else {
+				
+				trace("Error: Could not resolve .linkageBaseClass = \""+ linkageBaseClass +"\" for symbol \"" + className + "\"!");
+				
+			}
+			
+		}
+		else if (className != null) {
 			
 			var symbolType = Type.resolveClass (className);
 			


### PR DESCRIPTION
For example, we have a subclass of `MovieClip` which initializes custom Button objects with click sounds and common behaviors.

Without this change, attaching these AFTER `MovieClip` is instantiated is your only option--which is too late. You really need a way to inject some code as part of the `MovieClip` constructor, and subclasses or "Base Class" as Flash called it, are ideal. Especially since the artist can define which ones they mean during their creative process, and developers can just pull it out of the .swf.

This implies that the `.linkageBaseClass:String` names are being added to the correct spot in the `SWFSymbol` classes instantiated by the SWFLite `.dat` file format. Currently we use a proprietary script to inject these values into our `.bundle/swflite.dat` after `haxelib run openfl process` is done with them, but before runtime downloads them from CDN.

We may release that injector script once its cleaned up, or we may introduce something cleaner that can export `.FLA` to `.dat` in one pass that has everything in it.

This code should be merge-able as-is today, however. Shouldn't hurt anyone not using the feature.