### PR TITLE
support for shared font names in swflite

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -933,13 +933,14 @@ class TextField extends InteractiveObject {
 			
 		}
 		
-		format.font = symbol.fontName;
 		
 		var found = false;
 		
-		switch (format.font) {
+		switch (symbol.fontName) {
 			
 			case "_sans", "_serif", "_typewriter", "", null:
+				
+				format.font = symbol.fontName;
 				
 				found = true;
 			
@@ -947,9 +948,26 @@ class TextField extends InteractiveObject {
 				
 				for (font in Font.enumerateFonts ()) {
 					
-					if (font.fontName == format.font) {
+					// we have to do a tricky match on font name
+					// by limiting to alpha numeric characters
+					// so that the .fontClass string value can feasibly match
+					// the proper-cased and spaced font.fontName value
+					// mostly because Animate CC disallows spaces in font class names
+					// which are used for shared fonts.
+					// we also only match up to the same length on both sides,
+					// because the TrueType font name can differ from its font class name
+					// by having extra designations suffixed which are not important.
+					// e.g., we are angling for a "close enough" match.
+					//       could alternatively try soundex match.
+					
+					var sanitizedFontName = ~/[^a-zA-Z]+/.replace(font.fontName, "").substr(0, symbol.fontName.length);
+					 
+					if (sanitizedFontName == symbol.fontName) {
 						
+						format.font = font.fontName;
+
 						found = true;
+						
 						break;
 						
 					}

--- a/tools/format/swf/exporters/SWFLiteExporter.hx
+++ b/tools/format/swf/exporters/SWFLiteExporter.hx
@@ -706,6 +706,11 @@ class SWFLiteExporter {
 			
 		}
 		
+		if (tag.hasFontClass)
+		{
+			symbol.fontName = tag.fontClass;
+		}
+		
 		var bounds = tag.bounds.rect;
 		symbol.x = bounds.x;
 		symbol.y = bounds.y;

--- a/tools/format/swf/instance/DynamicText.hx
+++ b/tools/format/swf/instance/DynamicText.hx
@@ -102,6 +102,12 @@ class DynamicText extends TextField {
 			
 		}
 		
+		if (tag.hasFontClass) {
+			
+			trace("TODO: Implement .hasFontClass for DynamicText");
+			
+		}
+		
 		if (tag.hasLayout) {
 			
 			switch (tag.align) {


### PR DESCRIPTION
A little-known and poorly-documented feature in Adobe Flash/Animate CC.

Lets you declare fonts in a single .SWF and reuse them in subsequently loaded .SWF. 

Saves bandwidth.

Lets you centralize your creative font collection and update them in a single place.

Notice the way we match names; sneaky, but effective!