### PR TITLE
Fix DisplayObject.removeEventListener() to remove old listeners

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -301,9 +301,45 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	
 	public override function removeEventListener (type:String, listener:Dynamic->Void, useCapture:Bool = false):Void {
-		
-		super.removeEventListener (type, listener, useCapture);
-		
+
+		if (__eventMap == null || listener == null) return;
+
+		var list = __eventMap.get (type);
+		if (list == null) return;
+
+		var iterators = __iterators.get (type);
+
+		for (i in 0...list.length) {
+
+			if (((untyped listener.method) == (untyped list[i].callback.method) && untyped list[i].useCapture == useCapture)) {
+
+				for (iterator in iterators) {
+
+					iterator.remove (list[i], i);
+
+				}
+
+				list.splice (i, 1);
+				break;
+
+			}
+
+		}
+
+		if (list.length == 0) {
+
+			__eventMap.remove (type);
+			__iterators.remove (type);
+
+		}
+
+		if (!__eventMap.iterator ().hasNext ()) {
+
+			__eventMap = null;
+			__iterators = null;
+
+		}
+
 		switch (type) {
 			
 			case Event.ACTIVATE, Event.DEACTIVATE, Event.ENTER_FRAME, Event.EXIT_FRAME, Event.FRAME_CONSTRUCTED, Event.RENDER:


### PR DESCRIPTION
EventDispatcher's removeEventListener was not properly removing old listeners, due to the match() method being used, which incorrectly determined equal scopes to not be equal. All of the logic has been duplicated here, with the exception being how listeners are compared. 

Without this correction, event listener callbacks continued to be added by user input triggers (e.g., hovering over a button) without ever being removed after evaluation. This caused the corresponding event to fire more and more times with every user interaction.

:muscle: all credit to @sidpitt89 