### PR TITLE
Disable leading on embedded text

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -980,7 +980,9 @@ class TextField extends InteractiveObject {
 			format.indent = Std.int (symbol.indent / 20);
 			format.leading = Std.int (symbol.leading / 20);
 			
-			if (embedFonts) format.leading += 4; // TODO: Why is this necessary?
+			//It is unknown why this has been added
+			//Removing for now to match actionscript
+			//if (embedFonts) format.leading += 4; // TODO: Why is this necessary?
 			
 		}
 		


### PR DESCRIPTION
We noticed a difference comparing our original .swf in Flash to our .dat in OpenFL, and it was caused by this line.

Perhaps because we use shared fonts instead of embedded fonts? Not sure. Seems the original author isn't sure, either. So we commented this line out.

All we know is, it doesn't appear that Flash does `format.leading += 4`.

If we had to guess, Flash shows a leading of 1 while OpenFL shows 5... in the end that messes up the text height.

:muscle: credit **Elvir Tatarevic**