### PR TITLE
Make bitmapdata draw work with filters when readable is false

### DIFF
--- a/openfl/_internal/renderer/opengl/GLFilterManager.hx
+++ b/openfl/_internal/renderer/opengl/GLFilterManager.hx
@@ -62,6 +62,7 @@ class GLFilterManager extends AbstractFilterManager {
 			
 			if (object.__filters.length == 1 && object.__filters[0].__numPasses == 0) {
 				
+				renderer.getRenderTarget (false);
 				return object.__filters[0].__initShader (renderSession, 0);
 				
 			} else {
@@ -143,9 +144,10 @@ class GLFilterManager extends AbstractFilterManager {
 					// TODO: Properly handle filter-within-filter rendering
 					
 					filterDepth--;
+					currentTarget = renderer.currentRenderTarget;
 					renderer.getRenderTarget(filterDepth > 0);
 					
-					renderPass(renderer.currentRenderTarget, renderSession.shaderManager.defaultShader);
+					renderPass(currentTarget, renderSession.shaderManager.defaultShader);
 					
 				}
 				

--- a/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -2,6 +2,7 @@ package openfl._internal.renderer.opengl;
 
 
 import lime.graphics.GLRenderContext;
+import lime.graphics.opengl.GLFramebuffer;
 import lime.math.Matrix4;
 import openfl._internal.renderer.AbstractRenderer;
 import openfl.display.BitmapData;
@@ -27,6 +28,8 @@ class GLRenderer extends AbstractRenderer {
 	public var projection:Matrix4;
 	public var projectionFlipped:Matrix4;
 	
+	public var defaultRenderTarget:BitmapData;
+	
 	// private var cacheObject:BitmapData;
 	private var currentRenderTarget:BitmapData;
 	private var displayHeight:Int;
@@ -42,12 +45,13 @@ class GLRenderer extends AbstractRenderer {
 	private var values:Array<Float>;
 	
 	
-	public function new (stage:Stage, gl:GLRenderContext, flipped:Bool = true) {
+	public function new (stage:Stage, gl:GLRenderContext, ?defaultRenderTarget:BitmapData) {
 		
 		super (stage);
 		
 		this.gl = gl;
-		this.flipped = flipped;
+		this.defaultRenderTarget = defaultRenderTarget;
+		this.flipped = (defaultRenderTarget == null);
 		
 		matrix = new Matrix4 ();
 		values = new Array ();
@@ -70,7 +74,10 @@ class GLRenderer extends AbstractRenderer {
 				
 			}
 			
-			resize (Math.ceil (stage.window.width * stage.window.scale), Math.ceil (stage.window.height * stage.window.scale));
+			var width:Int = (defaultRenderTarget != null) ? defaultRenderTarget.width : Math.ceil (stage.window.width * stage.window.scale);
+			var height:Int = (defaultRenderTarget != null) ? defaultRenderTarget.height : Math.ceil (stage.window.height * stage.window.scale);
+			
+			resize (width, height);
 			
 		}
 		
@@ -184,10 +191,12 @@ class GLRenderer extends AbstractRenderer {
 			
 		} else {
 			
-			gl.bindFramebuffer (gl.FRAMEBUFFER, null);
+			currentRenderTarget = defaultRenderTarget;
+			var frameBuffer:GLFramebuffer = (currentRenderTarget != null) ? currentRenderTarget.__getFramebuffer (gl) : null;
 			
-			flipped = true;
+			gl.bindFramebuffer (gl.FRAMEBUFFER, frameBuffer);
 			
+			flipped = (currentRenderTarget == null);
 		}
 		
 	}
@@ -283,12 +292,15 @@ class GLRenderer extends AbstractRenderer {
 			
 		}
 		
-		displayMatrix = stage.__displayMatrix;
+		displayMatrix = (defaultRenderTarget == null) ? stage.__displayMatrix : new Matrix ();
+		
+		var w = (defaultRenderTarget == null) ? stage.stageWidth : defaultRenderTarget.width;
+		var h = (defaultRenderTarget == null) ? stage.stageHeight : defaultRenderTarget.height;
 		
 		offsetX = Math.round (displayMatrix.__transformX (0, 0));
 		offsetY = Math.round (displayMatrix.__transformY (0, 0));
-		displayWidth = Math.round (displayMatrix.__transformX (stage.stageWidth, 0) - offsetX);
-		displayHeight = Math.round (displayMatrix.__transformY (0, stage.stageHeight) - offsetY);
+		displayWidth = Math.round (displayMatrix.__transformX (w, 0) - offsetX);
+		displayHeight = Math.round (displayMatrix.__transformY (0, h) - offsetY);
 		
 		projection = Matrix4.createOrtho (offsetX, displayWidth + offsetX, offsetY, displayHeight + offsetY, -1000, 1000);
 		projectionFlipped = Matrix4.createOrtho (offsetX, displayWidth + offsetX, displayHeight + offsetY, offsetY, -1000, 1000);

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -473,12 +473,11 @@ class BitmapData implements IBitmapDrawable {
 				gl.bindFramebuffer (gl.FRAMEBUFFER, __getFramebuffer (gl));
 				gl.viewport (0, 0, width, height);
 				
-				var renderer = new GLRenderer (Lib.current.stage, gl, false);
-				renderer.resize (width, height);
+				var renderer = new GLRenderer (Lib.current.stage, gl, this);
 				
 				var renderSession = renderer.renderSession;
 				renderSession.clearDirtyFlags = false;
-				renderSession.shaderManager = cast (Lib.current.stage.__renderer, GLRenderer).renderSession.shaderManager;
+				renderSession.shaderManager = cast(Lib.current.stage.__renderer, GLRenderer).renderSession.shaderManager;
 				
 				var matrixCache = source.__worldTransform;
 				source.__updateTransforms (matrix);
@@ -1513,8 +1512,7 @@ class BitmapData implements IBitmapDrawable {
 				gl.bindFramebuffer (gl.FRAMEBUFFER, __getFramebuffer (gl));
 				gl.viewport (0, 0, width, height);
 				
-				var renderer = new GLRenderer (Lib.current.stage, gl, false);
-				renderer.resize (width, height);
+				var renderer = new GLRenderer (Lib.current.stage, gl, this);
 				
 				var renderSession = renderer.renderSession;
 				renderSession.clearDirtyFlags = true;


### PR DESCRIPTION
Currently there is no support for filters in bitmapdata's draw() method.
This pull request adds this feature for cases when bitmapdata isn't readable (so this feature works only with gl renderer).