### PR TITLE
fix for ascent/descent change in TextEngine

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -247,12 +247,12 @@ class TextEngine {
 		#if (js && html5)
 		
 		__context.font = getFont (format);
-		
+
 		if (format.__ascent != null) {
-			
-			ascent = format.__ascent;
-			descent = format.__descent;
-			
+
+			ascent = format.size * format.__ascent;
+			descent = format.size * format.__descent;
+
 		} else {
 			
 			ascent = format.size;
@@ -267,15 +267,15 @@ class TextEngine {
 		var font = getFontInstance (format);
 		
 		if (format.__ascent != null) {
-			
-			ascent = format.__ascent;
-			descent = format.__descent;
-			
+
+			ascent = format.size * format.__ascent;
+			descent = format.size * format.__descent;
+
 		} else if (font != null) {
-			
+
 			ascent = (font.ascender / font.unitsPerEM) * format.size;
 			descent = Math.abs ((font.descender / font.unitsPerEM) * format.size);
-			
+
 		} else {
 			
 			ascent = format.size;
@@ -881,12 +881,12 @@ class TextEngine {
 				#if (js && html5)
 				
 				__context.font = getFont (currentFormat);
-				
+
 				if (currentFormat.__ascent != null) {
-					
-					ascent = currentFormat.__ascent;
-					descent = currentFormat.__descent;
-					
+
+					ascent = currentFormat.size * currentFormat.__ascent;
+					descent = currentFormat.size * currentFormat.__descent;
+
 				} else {
 					
 					ascent = currentFormat.size;
@@ -903,15 +903,15 @@ class TextEngine {
 				font = getFontInstance (currentFormat);
 				
 				if (currentFormat.__ascent != null) {
-					
-					ascent = currentFormat.__ascent;
-					descent = currentFormat.__descent;
-					
+
+					ascent = currentFormat.size * currentFormat.__ascent;
+					descent = currentFormat.size * currentFormat.__descent;
+
 				} else if (font != null) {
-					
+
 					ascent = (font.ascender / font.unitsPerEM) * currentFormat.size;
 					descent = Math.abs ((font.descender / font.unitsPerEM) * currentFormat.size);
-					
+
 				} else {
 					
 					ascent = currentFormat.size;

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -930,10 +930,10 @@ class TextField extends InteractiveObject {
 			//format.italic = font.italic;
 			//format.leading = Std.int (font.leading / 20 + (format.size * 0.2) #if flash + 2 #end);
 			//embedFonts = true;
-			
-			format.__ascent = ((font.ascent / 20) / 1024) * format.size;
-			format.__descent = ((font.descent / 20) / 1024) * format.size;
-			
+
+			format.__ascent = ((font.ascent / 20) / 1024);
+			format.__descent = ((font.descent / 20) / 1024);
+
 		}
 		
 		format.font = symbol.fontName;


### PR DESCRIPTION
With htmlText format.size isn't constant for a `TextField`, hence the multiplication needs to be done in `TextEngine`.