### PR TITLE
Sorting of the eventlisteners with same priority doesn't preserve the order they are added for html5 target

### DIFF
--- a/openfl/events/EventDispatcher.hx
+++ b/openfl/events/EventDispatcher.hx
@@ -366,6 +366,7 @@ class EventDispatcher implements IEventDispatcher {
 		this.list = list;
 		
 		active = true;
+		isCopy = false;
 		index = 0;
 		
 	}

--- a/openfl/events/EventDispatcher.hx
+++ b/openfl/events/EventDispatcher.hx
@@ -74,7 +74,7 @@ class EventDispatcher implements IEventDispatcher {
 				
 			}
 			
-			__addListinerByPriority(list, new Listener (listener, useCapture, priority));
+			__addListenerByPriority(list, new Listener (listener, useCapture, priority));
 						
 		}
 		
@@ -245,7 +245,7 @@ class EventDispatcher implements IEventDispatcher {
 	}
 	
 	
-	private function __addListinerByPriority(list: Array<Listener>, listener: Listener): Void {
+	private function __addListenerByPriority(list: Array<Listener>, listener: Listener): Void {
 
 		var numElements: Int = list.length;
 		var addAtPosition: Int = numElements;	

--- a/openfl/events/EventDispatcher.hx
+++ b/openfl/events/EventDispatcher.hx
@@ -74,9 +74,8 @@ class EventDispatcher implements IEventDispatcher {
 				
 			}
 			
-			list.push (new Listener (listener, useCapture, priority));
-			list.sort (__sortByPriority);
-			
+			__addListinerByPriority(list, new Listener (listener, useCapture, priority));
+						
 		}
 		
 	}
@@ -246,9 +245,24 @@ class EventDispatcher implements IEventDispatcher {
 	}
 	
 	
-	private static function __sortByPriority (l1:Listener, l2:Listener):Int {
-		
-		return l1.priority == l2.priority ? 0 : (l1.priority > l2.priority ? -1 : 1);
+	private function __addListinerByPriority(list: Array<Listener>, listener: Listener): Void {
+
+		var numElements: Int = list.length;
+		var addAtPosition: Int = numElements;	
+
+		for (i in 0...numElements) {
+
+			if (list[i].priority < listener.priority) {
+
+				addAtPosition = i;
+
+				break;	
+
+			}
+
+		}
+
+		list.insert(addAtPosition, listener);
 		
 	}
 	


### PR DESCRIPTION
As it is written in the [documentation](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) of the Array's sort method in JavaScript, the order of the elements that have the same value against which the sorting is performed is not garanteed. 
Namely, what we have experienced is when we have multiple event listeners for the same event with the same priority(=0), they are not executed in the order they are added. If you check the list after sort method, at some point, the list is gonna get shuffled. It doesn't happen on every sort call.