### PR TITLE
fixes SimpleButton over/down state DOM render

### DIFF
--- a/openfl/display/SimpleButton.hx
+++ b/openfl/display/SimpleButton.hx
@@ -307,7 +307,11 @@ class SimpleButton extends InteractiveObject {
 		__previousStates.length = 0;
 		
 		if (__currentState != null) {
-			
+
+			if (__currentState.stage != stage) {
+				__currentState.__setStageReference(stage);
+			}
+
 			__currentState.__renderDOM (renderSession);
 			
 		}


### PR DESCRIPTION
the DOM renderer requires a stage reference to render a DisplayObject. for SimpleButtons it gets set for __currentState (which is the upState) once when they are added to the stage. this fix sets stage reference for over and down states when they are rendered.