### PR TITLE
Fix rendering bug in Chrome 59

### DIFF
--- a/openfl/_internal/renderer/dom/DOMBitmap.hx
+++ b/openfl/_internal/renderer/dom/DOMBitmap.hx
@@ -94,6 +94,9 @@ class DOMBitmap {
 			
 			ImageCanvasUtil.convertToCanvas (bitmap.bitmapData.image);
 			
+			// Next line is workaround, to fix rendering bug in Chrome 59 (https://vimeo.com/222938554)
+			bitmap.__canvas.width = bitmap.bitmapData.width + 1;
+			
 			bitmap.__canvas.width = bitmap.bitmapData.width;
 			bitmap.__canvas.height = bitmap.bitmapData.height;
 			


### PR DESCRIPTION
This pull request fixes rendering bug in Chrome 59 (stable channel, not canary).

Demonstration: https://vimeo.com/222938554
