### PR TITLE
manifest name works better when you want to change the filename on cdn

### DIFF
--- a/openfl/display/Loader.hx
+++ b/openfl/display/Loader.hx
@@ -298,7 +298,7 @@ class Loader extends DisplayObjectContainer {
 				library.load ().onComplete (function (_) {
 					
 					__library = cast library;
-					Assets.registerLibrary (contentLoaderInfo.url, __library);
+					Assets.registerLibrary (manifest.name, __library);
 					
 					content = __library.getMovieClip ("");
 					contentLoaderInfo.content = content;


### PR DESCRIPTION
we think this works better so even if the asset name is unrecognizable on cdn you can still tell what to call it internally. helps with security.