### PR TITLE
support shared fonts

### DIFF
--- a/tools/format/swf/exporters/SWFLiteExporter.hx
+++ b/tools/format/swf/exporters/SWFLiteExporter.hx
@@ -696,6 +696,7 @@ class SWFLiteExporter {
 		symbol.wordWrap = tag.wordWrap;
 		symbol.input = !tag.readOnly;
 		
+		// embedded fonts
 		if (tag.hasFont) {
 			
 			var font:IDefinitionTag = cast data.getCharacter (tag.fontId);
@@ -708,6 +709,13 @@ class SWFLiteExporter {
 			
 			symbol.fontID = tag.fontId;
 			symbol.fontName = cast (font, TagDefineFont2).fontName;
+			
+		}
+		
+		// shared fonts
+		if (tag.hasFontClass) {
+			
+			symbol.fontName = tag.fontClass;
 			
 		}
 		


### PR DESCRIPTION
shared font names appear in a different tag property. they are mutually exclusive of embedded fonts; its one or the other, not both. you have to check in both places. 

in the case of a shared font, you are getting a class name which is camelCased not like normal font proper case title. so it depends on the fuzzy font matching logic we merged earlier, as well. fortunately that part is already there. but we need this, too.