### PR TITLE
fix typo; object needs to be initialized outside of for loop

### DIFF
--- a/tools/format/swf/exporters/SWFLiteExporter.hx
+++ b/tools/format/swf/exporters/SWFLiteExporter.hx
@@ -526,9 +526,10 @@ class SWFLiteExporter {
 			
 			instances.splice (0, instances.length);
 			
+			frame.objects = [];
+			
 			for (object in frameData.getObjectsSortedByDepth ()) {
 				
-				frame.objects = [];
 				instances.push (object.placedAtIndex);
 				
 				if (object.placedAtIndex == 0 && object.characterId != zeroCharacter) {


### PR DESCRIPTION
minor issue. without this patch, you can see it tries to push to the array before it has been initialized. 

ran into that when trying to `openfl process` some of our `.swf` with this upstream version.