### PR TITLE
MovieClip implements Dynamic<DisplayObjectContainer>

### DIFF
--- a/openfl/display/MovieClip.hx
+++ b/openfl/display/MovieClip.hx
@@ -30,7 +30,7 @@ import hscript.Parser;
 @:access(openfl._internal.symbols.SWFSymbol)
 
 
-class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObject> #end {
+class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObjectContainer> #end {
 	
 	
 	private static var __initSWF:SWFLite;


### PR DESCRIPTION
since `DisplayObjectContainer` extends `DisplayObject`, i don't see how this could break anything.

but it does seem more useful in practice. any objection?