### PR TITLE
extract sound to bundle mp3 files

### DIFF
--- a/tools/Tools.hx
+++ b/tools/Tools.hx
@@ -659,6 +659,37 @@ class Tools {
 			}
 			
 		}
+
+		createdDirectory = false;
+		for (id in exporter.sounds.keys ()) {
+
+			if (!createdDirectory) {
+
+				PathHelper.mkdir (PathHelper.combine (targetPath, "sounds"));
+				createdDirectory = true;
+
+			}
+
+			var symbolClassName = exporter.soundSymbolClassNames.get (id);
+			var typeId = exporter.soundTypes.get (id);
+			trace("exporting sound id "+id+", type "+ typeId +", symbol class name "+ symbolClassName);
+			var type;
+			switch (typeId) {
+				case SoundType.MP3: type = "mp3";
+				case SoundType.ADPCM: type = "wav";
+				// TODO: this WAV header may become necessary to prepend in some cases
+				// "524946464409000057415645666D7420100000000100010044AC0000885801000200100064617461"
+				case _:
+					throw "unsupported sound type "+id+", type "+ typeId +", symbol class name "+ symbolClassName;
+			};
+			var path = "sounds/"+ symbolClassName + "." + type;
+			var assetData = exporter.sounds.get (id);
+
+			File.saveBytes (PathHelper.combine (targetPath, path), assetData);
+
+			var soundAsset = new Asset ("", path, AssetType.SOUND);
+			project.assets.push (soundAsset);
+		}
 		
 		var swfLiteAsset = new Asset ("", "swflite.dat", AssetType.TEXT);
 		var swfLiteAssetData = swfLite.serialize ();


### PR DESCRIPTION
- all sounds will be placed inside `.bundle/sounds/*.mp3` where the file basename will equal the linkage class name (assumes all sounds have linkage names; technically may not be always true but has been so far; can't imagine a scenario where sound is used without linkage name; could provide character id as fallback for that scenario if proven possible)
- sounds exported will also be listed inside `.bundle/library.json` `assets:Asset[]` with their name containing  a relative path from the `.bundle/` folder
- .mp3 files just work!
- .wav files need testing. may need their header bytes prefixed when writing to disk. notice that code is there but commented until we get a chance to test further.
- other sound formats are possible but were not used by our codebase so we are skipping implementation for now.
- ideally sounds should all be translated to .mp3 and/or .ogg regardless of what format they were in. perhaps some .exe tool can be provided similar to how webfonts are processed. (ffmpeg is ideal but a HUGE project)

🚧 👷 **CAUTION!** This branch is still experimental and should be thoroughly tested. 🏗 

**TODO:** currently adding support to read and cache the sounds before `.bundle` is finished loading at runtime. all sounds should be preloaded before the `.bundle/` is considered done loading, and able to be referred to and run from anywhere (globally) by their `library + ":" + linkageName`, similar to the way MovieClips are.

**NOTICE:** Depends on PR #1636 being merged first.