### PR TITLE
Added more cursors to Openfl Mouse

### DIFF
--- a/openfl/ui/Mouse.hx
+++ b/openfl/ui/Mouse.hx
@@ -53,6 +53,14 @@ import openfl.Lib;
 			case MouseCursor.BUTTON: LimeMouse.cursor = POINTER;
 			case MouseCursor.HAND: LimeMouse.cursor = MOVE;
 			case MouseCursor.IBEAM: LimeMouse.cursor = TEXT;
+			case MouseCursor.CROSSHAIR: LimeMouse.cursor = CROSSHAIR;
+			case MouseCursor.RESIZE_NESW: LimeMouse.cursor = RESIZE_NESW;
+			case MouseCursor.RESIZE_NS: LimeMouse.cursor = RESIZE_NS;
+			case MouseCursor.RESIZE_NWSE: LimeMouse.cursor = RESIZE_NWSE;
+			case MouseCursor.RESIZE_WE: LimeMouse.cursor = RESIZE_WE;
+			case MouseCursor.WAIT: LimeMouse.cursor = WAIT;
+			case MouseCursor.WAIT_ARROW: LimeMouse.cursor = WAIT_ARROW;
+				
 			default:
 			
 		}

--- a/openfl/ui/MouseCursor.hx
+++ b/openfl/ui/MouseCursor.hx
@@ -8,5 +8,13 @@ package openfl.ui;
 	public var BUTTON = "button";
 	public var HAND = "hand";
 	public var IBEAM = "ibeam";
+	public var CROSSHAIR = "crosshair";
+	public var MOVE = "move";
+	public var WAIT = "wait";
+	public var WAIT_ARROW = "waitarrow";
+	public var RESIZE_NESW = "resize_nesw";
+	public var RESIZE_NS = "resize_ns";
+	public var RESIZE_NWSE = "resize_nwse";
+	public var RESIZE_WE = "resize_we";
 	
 }


### PR DESCRIPTION
`WAIT_ARROW` does not appear any differently to `WAIT` on Windows 10, I've left it in as I'm not sure if it is platform dependent 