### PR TITLE
CanvasGraphics issue fixed when drawing shape on bitmapdata on retina displays

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -951,26 +951,6 @@ class CanvasGraphics {
 				var scaledWidth = Std.int (width * devicePixelRatio);
 				var scaledHeight = Std.int (height * devicePixelRatio);
 				
-				#if dom
-				
-				if (canvas.width == scaledWidth && canvas.height == scaledHeight) {
-					
-					context.clearRect (0, 0, scaledWidth, scaledHeight);
-					
-				} else {
-				
-					canvas.width = scaledWidth;
-					canvas.height = scaledHeight;
-					canvas.style.width = width + "px";
-					canvas.style.height = height + "px";
-					
-				}
-				
-				var transform = graphics.__renderTransform;
-				context.setTransform (transform.a * devicePixelRatio, transform.b * devicePixelRatio, transform.c * devicePixelRatio, transform.d * devicePixelRatio, transform.tx * devicePixelRatio, transform.ty * devicePixelRatio);
-				
-				#else
-				
 				if (canvas.width == scaledWidth && canvas.height == scaledHeight) {
 					
 					context.clearRect (0, 0, scaledWidth, scaledHeight);
@@ -983,8 +963,6 @@ class CanvasGraphics {
 				}
 				
 				context.setTransform (transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty);
-				
-				#end
 				
 				fillCommands.clear ();
 				strokeCommands.clear ();


### PR DESCRIPTION
Currently there is an issue when you try to draw a shape into bitmap data `bitmapData.draw(shape)` on retina(HIRes) displays. Namely the `width` and `height` of the `canvas` where the shape is rendered is scaled according to pixel ratio. This breaks the bitmapData drawing because it is dependent on canvas `width` and `height`.
Scaling the canvas is unnecessary and therefore I removed it.   