### PR TITLE
Caret wasn't visible without text on Cairo.

### DIFF
--- a/openfl/_internal/renderer/cairo/CairoTextField.hx
+++ b/openfl/_internal/renderer/cairo/CairoTextField.hx
@@ -63,7 +63,7 @@ class CairoTextField {
 		var width = graphics.__width;
 		var height = graphics.__height;
 		
-		var renderable = (textEngine.border || textEngine.background || (textEngine.text != null && textEngine.text != ""));
+		var renderable = (textEngine.border || textEngine.background || textEngine.text != null);
 		
 		if (cairo != null) {
 			


### PR DESCRIPTION
The [L84](https://github.com/openfl/openfl/blob/develop/openfl/_internal/renderer/cairo/CairoTextField.hx#L84) is executed when the text = "". So the `else` condition in the if [L177](https://github.com/openfl/openfl/blob/develop/openfl/_internal/renderer/cairo/CairoTextField.hx#L177) is never executed.