### PR TITLE
The text field stops to work when you write an accent or dieresis in a vocal letter (CPP)

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -483,8 +483,8 @@ class TextField extends InteractiveObject {
 		var endIndex = __caretIndex > __selectionIndex ? __caretIndex : __selectionIndex;
 		
 		replaceText (startIndex, endIndex, value);
-		
-		var i = startIndex + value.length;
+
+        var i = startIndex + cast(value, UTF8String).length;
 		setSelection(i,i);
 		
 	}

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -484,7 +484,7 @@ class TextField extends InteractiveObject {
 		
 		replaceText (startIndex, endIndex, value);
 
-        var i = startIndex + cast(value, UTF8String).length;
+		var i = startIndex + cast(value, UTF8String).length;
 		setSelection(i,i);
 		
 	}


### PR DESCRIPTION
If you write "á" or "ö" then the text field doesn't work, because the `"á".length` is 2 in CPP. Then the `endIndex > __text.length` is satisfied in [TextField.hx L495](https://github.com/openfl/openfl/blob/develop/openfl/text/TextField.hx#L495). `__text` is UTF8String, so it has the good length.

