### PR TITLE
run DocumentClass constructor before adding it to stage

### DIFF
--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -319,9 +319,9 @@ class DocumentClass {
 				var fields = Context.getBuildFields ();
 				
 				var method = macro {
-					
-					current.addChild (this);
+
 					super ();
+					current.addChild (this);
 					dispatchEvent (new openfl.events.Event (openfl.events.Event.ADDED_TO_STAGE, false, false));
 					
 				}


### PR DESCRIPTION
avoids a situation where children don't have a stage reference