### PR TITLE
fixes multiple spaces bug

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -1117,6 +1117,8 @@ class TextEngine {
 							if (lineFormat.align != JUSTIFY) {
 								
 								layoutGroup.endIndex = spaceIndex;
+								layoutGroup.advances = layoutGroup.advances.concat (advances);
+								layoutGroup.width += widthValue;
 								
 							}
 							


### PR DESCRIPTION
<img width="144" alt="screen shot 2017-08-08 at 10 54 50 am" src="https://user-images.githubusercontent.com/743481/29061957-769563da-7c28-11e7-8daa-6ecc5e51e1c2.png">

fixes a bug in TextEngine, where advances are lost, when there are multiple sequential space chars