### PR TITLE
Fix input textfield when cached as bitmap

### DIFF
--- a/openfl/_internal/text/HtmlParser.hx
+++ b/openfl/_internal/text/HtmlParser.hx
@@ -8,7 +8,7 @@ class HtmlParser {
     private static var __regexBreakTag = ~/<br\s*\/?>/gi;
     private static var __regexBlockIndent = ~/blockindent=("([^"]+)"|'([^']+)')/i;
     private static var __regexColor = ~/color=("#([^"]+)"|'#([^']+)')/i;
-    private static var __regexEntities = [ ~/&quot;/g, ~/&apos;/g, ~/&amp;/g, ~/&lt;/g, ~/&gt;/g ];
+    private static var __regexEntities = [ ~/&quot;/g, ~/&apos;/g, ~/&amp;/g, ~/&lt;/g, ~/&gt;/g, ~/&nbsp;/g ];
     private static var __regexFace = ~/face=("([^"]+)"|'([^']+)')/i;
     private static var __regexHTMLTag = ~/<.*?>/g;
     private static var __regexHref = ~/href=("([^"]+)"|'([^']+)')/i;
@@ -25,6 +25,7 @@ class HtmlParser {
         value = __regexEntities[0].replace (value, "\"");
         value = __regexEntities[1].replace (value, "'");
         value = __regexEntities[2].replace (value, "&");
+        value = __regexEntities[5].replace (value, " ");
 
         // crude solution
 

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -118,6 +118,7 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 	#if dom
 		private var __renderedOnCanvasWhileOnDOM:Bool = false;
 		private var __rawHtmlText:String;
+		private var __forceCachedBitmapUpdate:Bool = false;
 	#end
 
 	
@@ -1360,8 +1361,8 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 	private override function __renderDOM (renderSession:RenderSession):Void {
 		
 		#if dom
-		__updateCacheBitmap (renderSession, !__worldColorTransform.__isDefault ());
-		
+		__updateCacheBitmap (renderSession, __forceCachedBitmapUpdate || !__worldColorTransform.__isDefault ());
+		__forceCachedBitmapUpdate = false;
 		if (__cacheBitmap != null && !__cacheBitmapRender) {
 			
 			__renderDOMClear (renderSession);
@@ -1520,7 +1521,13 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 	
 	
 	private function __updateText (value:String):Void {
-		
+
+		#if dom
+		if (__renderedOnCanvasWhileOnDOM) {
+			__forceCachedBitmapUpdate = __text != value;
+		}
+		#end
+
 		__text = value;
 		
 		if (__text.length < __caretIndex) {
@@ -2296,6 +2303,10 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 				#if !dom
 				__dirty = true;
 				__setRenderDirty ();
+				#else
+				if (__renderedOnCanvasWhileOnDOM) {
+					__forceCachedBitmapUpdate = true;
+				}
 				#end
 				
 			}
@@ -2336,6 +2347,12 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 				
 				__stopCursorTimer ();
 				__startCursorTimer ();
+
+				#if dom
+				if (__renderedOnCanvasWhileOnDOM) {
+					__forceCachedBitmapUpdate = true;
+				}
+				#end
 				
 			}
 			


### PR DESCRIPTION
This PR fixes several issues on Textfield on DOM:
1. Input textfield isn't editable when cached as bitmap - Fixed.
2. Password masking isn't working on DOM - Now it is working only on cached as bitmap textfields.
3. Html text is not working on cached as bitmap textfields. The raw html text is shown - Fixed.