### PR TITLE
Measure spacing characters

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -933,8 +933,7 @@ class TextEngine {
 		
 		lineFormat = formatRange.format;
 		var wrap;
-		var maxLoops = text.length;
-		if (multiline) maxLoops++; // Do an extra iteration to ensure a LayoutGroup is created for the last (empty) line.
+		var maxLoops = text.length + 1; // Do an extra iteration to ensure a LayoutGroup is created in case the last line is empty (multiline or trailing line break).
 		
 		while (textIndex < maxLoops) {
 			
@@ -965,7 +964,12 @@ class TextEngine {
 					
 				}
 				
-				offsetY += heightValue;
+				if (breakIndex < text.length - 1) {
+					
+					offsetY += heightValue;
+					
+				}
+				
 				offsetX = 2;
 				
 				if (formatRange.end == breakIndex) {
@@ -1371,7 +1375,7 @@ class TextEngine {
 	
 	private function update ():Void {
 		
-		if (text == null || (!multiline && StringTools.trim (text) == "") || textFormatRanges.length == 0) {
+		if (text == null || text == "" || textFormatRanges.length == 0) {
 			
 			lineAscents.length = 0;
 			lineBreaks.length = 0;


### PR DESCRIPTION
Closes #1475 

Spaces and line breaks possess width and height but weren't accounted for at all. Trailing line breaks do not possess height but do add toward `numLines`.

Test cases: (check `textWidth`, `textHeight`, and `numLines` for each and compare to Flash)
`"a"`
`" "`
`"  "` <- this is two spaces but doesn't show up
`"\n"`
`"\n\n"`
`"a\n"`
`"\na"`
`"a\n\n"`
`"\n\na"`
`"a\n\na"`

Flash:
![image](https://user-images.githubusercontent.com/5033927/29109306-34fc5d2c-7ca8-11e7-8fc8-1e98785e3029.png)

Neko:
![image](https://user-images.githubusercontent.com/5033927/29109314-48228426-7ca8-11e7-8570-62be066da714.png)

They match as far as they're ever going to.
