### PR TITLE
HtmlText metrics fix, scroll event dispatched when textfield scrolled

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -123,7 +123,7 @@ class TextEngine {
 	private var __hiddenInput:InputElement;
 	#end
 	
-	
+
 	public function new (textField:TextField) {
 		
 		this.textField = textField;
@@ -541,14 +541,20 @@ class TextEngine {
 	
 	
 	public function getLineBreakIndex (startIndex:Int = 0):Int {
-		
+
+		var br = text.indexOf ("<br>", startIndex);
 		var cr = text.indexOf ("\n", startIndex);
 		var lf = text.indexOf ("\r", startIndex);
 		
-		if (cr == -1) return lf;
-		if (lf == -1) return cr;
-		
-		return cr < lf ? cr : lf;
+		if (cr == -1 && br == -1) return lf;
+		if (lf == -1 && br == -1) return cr;
+		if (lf == -1 && cr == -1) return br;
+
+		if (cr == -1) return Std.int(Math.min(br, lf));
+		if (lf == -1) return Std.int(Math.min(br, cr));
+		if (br == -1) return Std.int(Math.min(cr, lf));
+
+		return Std.int(Math.min(Math.min(cr, lf), br));
 		
 	}
 	

--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -1860,17 +1860,30 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 		__rawHtmlText = value;
 		#end
 		
-		if (#if (js && html5) __div == null #else true #end) {
-			
-			value = HtmlParser.parse(value, __textFormat, __textEngine.textFormatRanges);
-			
-		}
-		
+		value = HtmlParser.parse(value, __textFormat, __textEngine.textFormatRanges);
+
 		#if (js && html5 && dom)
+
+		if (__textEngine.textFormatRanges.length > 1) {
+
+			__textEngine.textFormatRanges.splice (1, __textEngine.textFormatRanges.length - 1);
+
+		}
+
+		var range = __textEngine.textFormatRanges[0];
+		range.format = __textFormat;
+		range.start = 0;
+
 		if (__renderedOnCanvasWhileOnDOM) {
+
+			range.end = value.length;
 			__updateText (value);
+
 		} else {
+
+			range.end = __rawHtmlText.length;
 			__updateText (__rawHtmlText);
+
 		}
 		#else
 		__updateText (value);
@@ -2011,6 +2024,7 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 			
 			__dirty = true;
 			__setRenderDirty ();
+			dispatchEvent(new Event(Event.SCROLL));
 			
 		}
 		
@@ -2037,6 +2051,7 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 			
 			__dirty = true;
 			__setRenderDirty ();
+			dispatchEvent(new Event(Event.SCROLL));
 			
 		}
 		


### PR DESCRIPTION
This PR fixes htmlText metrics as well as dispatching of an Event.SCROLL when a text field is scrolled. Namely, width and height as well as textWidth and textHeight are not working on DOM when html text is being appended to the `htmlText` property. For instance `tf.htmlText += "text <br>";`. 