### PR TITLE
Event listener recursion not working when the last event listener add…

### DIFF
--- a/openfl/events/EventDispatcher.hx
+++ b/openfl/events/EventDispatcher.hx
@@ -296,7 +296,7 @@ class EventDispatcher implements IEventDispatcher {
 	
 	public function copy ():Void {
 		
-		if (index < list.length && !isCopy) {
+		if (!isCopy) {
 			
 			list = list.copy ();
 			isCopy = true;


### PR DESCRIPTION
Event listener recursion not working when the last event listener ads additional listener to the same event type as it is assigned to.

Namely, there is an eventListener that is being executed, if it is the last one(or the only one) in the list of event listeners for that particular event type, and if it adds another listener to the same event type, the new listener is gonna be added and executed right after the currently executing one. That's not what should happen. If an executing event listener add a additional event listener to the same event type, the added event listener should not execute in the same dispatch.