### PR TITLE
Fix Raspberry Pi freeze by adding alpha > 0 check in shader

### DIFF
--- a/openfl/display/Shader.hx
+++ b/openfl/display/Shader.hx
@@ -72,7 +72,9 @@ class Shader {
 				color = vec4 (color.rgb / color.a, color.a);
 				color = vColorOffsets + (color * vColorMultipliers);
 				
-				gl_FragColor = vec4 (color.bgr * color.a * vAlpha, color.a * vAlpha);
+				if( color.a > 0.0) {
+					gl_FragColor = vec4 (color.rgb * color.a * vAlpha, color.a * vAlpha);
+				}
 				
 			} else {
 				


### PR DESCRIPTION
Somehow the Raspberry Pi freezes if we don't check for `color.a > 0.0`  in the colorTransform part of the fragmentShader. This is weird because it even happens when there is no colorTransform in use.

Setting `gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0)` in an else statement doesn't seem to be necessary.