### PR TITLE
Fix Raspberry Pi freeze in fragmentshader

### DIFF
--- a/openfl/display/Shader.hx
+++ b/openfl/display/Shader.hx
@@ -103,7 +103,9 @@ class Shader {
 				color = vec4 (color.rgb / color.a, color.a);
 				color = vColorOffsets + (color * vColorMultipliers);
 				
-				gl_FragColor = vec4 (color.rgb * color.a * vAlpha, color.a * vAlpha);
+				if(color.a > 0.0){
+					gl_FragColor = vec4 (color.rgb * color.a * vAlpha, color.a * vAlpha);
+				}
 				
 			} else {
 				


### PR DESCRIPTION
Raspberry Pi (OpenGLES) freezes if you don't check for `color.a > 0.0` in the fragmentshader  in the colorTransform part. Even if you're not using a colortransform  and bool uColorTransform=false

No clue as to why this is happening

An else clause that sets gl_fragcolor to vec4(0.0) doesn't seem te be needed.