### PR TITLE
Update transform when cacheAsBitmap needs re-rendering.

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1007,7 +1007,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 				rect = Rectangle.__pool.get ();
 				matrix.identity ();
 				
-				__getFilterBounds (rect, matrix);
+				__getFilterBounds (rect, __renderTransform);
 				
 			}
 			
@@ -1065,14 +1065,14 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 				
 				__cacheBitmap.__worldTransform.copyFrom (__worldTransform);
 				
-				matrix.tx = Math.round (rect.x);
-				matrix.ty = Math.round (rect.y);
-				
-				__cacheBitmap.__renderTransform.copyFrom (matrix);
-				__cacheBitmap.__renderTransform.concat (__renderTransform);
-				
-				matrix.tx *= -1;
-				matrix.ty *= -1;
+				__cacheBitmap.__renderTransform.identity();
+				__cacheBitmap.__renderTransform.tx = rect.x;
+				__cacheBitmap.__renderTransform.ty = rect.y;
+
+				matrix.concat( __renderTransform );
+				matrix.tx -= Math.round (rect.x);
+				matrix.ty -= Math.round (rect.y);
+
 				
 			}
 			

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1061,7 +1061,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 				
 			}
 			
-			if (updateTransform) {
+			if (updateTransform || needRender) {
 				
 				__cacheBitmap.__worldTransform.copyFrom (__worldTransform);
 				


### PR DESCRIPTION
Transform needs re-calculating when cacheBitmap needs to be re rendered. Also  fixes the render transform and draw matrix for the cached bitmap to correct filter rendering, reduce pixelization and match Flash more closely.