### PR TITLE
Haxe4 support for open.utils.ByteArray

### DIFF
--- a/openfl/display3D/textures/CubeTexture.hx
+++ b/openfl/display3D/textures/CubeTexture.hx
@@ -3,7 +3,7 @@ package openfl.display3D.textures;
 
 import haxe.Timer;
 import lime.graphics.opengl.GL;
-import lime.utils.ArrayBufferView;
+import lime.utils.DataPointer;
 import lime.utils.UInt8Array;
 import openfl._internal.stage3D.GLUtils;
 import openfl._internal.stage3D.SamplerState;
@@ -107,7 +107,7 @@ import openfl.utils.ByteArray;
 		#if js
 		if (byteArrayOffset == 0) {
 			
-			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).b, side);
+			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.getData(), side);
 			return;
 			
 		}
@@ -118,9 +118,7 @@ import openfl.utils.ByteArray;
 	}
 	
 	
-	public function uploadFromTypedArray (data:ArrayBufferView, side:UInt, miplevel:UInt = 0):Void {
-		
-		if (data == null) return;
+	public function uploadFromTypedArray (data:DataPointer, side:UInt, miplevel:UInt = 0):Void {
 		
 		var size = __size >> miplevel;
 		if (size == 0) return;

--- a/openfl/display3D/textures/CubeTexture.hx
+++ b/openfl/display3D/textures/CubeTexture.hx
@@ -121,6 +121,7 @@ import openfl.utils.ByteArray;
 	public function uploadFromTypedArray (data:ArrayBufferView, side:UInt, miplevel:UInt = 0):Void {
 		
 		if (data == null) return;
+		
 		var size = __size >> miplevel;
 		if (size == 0) return;
 		

--- a/openfl/display3D/textures/CubeTexture.hx
+++ b/openfl/display3D/textures/CubeTexture.hx
@@ -3,7 +3,7 @@ package openfl.display3D.textures;
 
 import haxe.Timer;
 import lime.graphics.opengl.GL;
-import lime.utils.DataPointer;
+import lime.utils.ArrayBufferView;
 import lime.utils.UInt8Array;
 import openfl._internal.stage3D.GLUtils;
 import openfl._internal.stage3D.SamplerState;
@@ -107,7 +107,7 @@ import openfl.utils.ByteArray;
 		#if js
 		if (byteArrayOffset == 0) {
 			
-			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.getData(), side);
+			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.b, side);
 			return;
 			
 		}
@@ -118,8 +118,9 @@ import openfl.utils.ByteArray;
 	}
 	
 	
-	public function uploadFromTypedArray (data:DataPointer, side:UInt, miplevel:UInt = 0):Void {
+	public function uploadFromTypedArray (data:ArrayBufferView, side:UInt, miplevel:UInt = 0):Void {
 		
+		if (data == null) return;
 		var size = __size >> miplevel;
 		if (size == 0) return;
 		

--- a/openfl/display3D/textures/RectangleTexture.hx
+++ b/openfl/display3D/textures/RectangleTexture.hx
@@ -2,7 +2,7 @@ package openfl.display3D.textures;
 
 
 import lime.graphics.opengl.GL;
-import lime.utils.ArrayBufferView;
+import lime.utils.DataPointer;
 import lime.utils.UInt8Array;
 import openfl._internal.stage3D.GLUtils;
 import openfl._internal.stage3D.SamplerState;
@@ -55,7 +55,7 @@ import openfl.utils.ByteArray;
 		#if js
 		if (byteArrayOffset == 0) {
 			
-			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).b);
+			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.getData());
 			return;
 			
 		}
@@ -66,7 +66,7 @@ import openfl.utils.ByteArray;
 	}
 	
 	
-	public function uploadFromTypedArray (data:ArrayBufferView):Void {
+	public function uploadFromTypedArray (data:Null<DataPointer>):Void {
 		
 		//if (__format != Context3DTextureFormat.BGRA) {
 			//

--- a/openfl/display3D/textures/RectangleTexture.hx
+++ b/openfl/display3D/textures/RectangleTexture.hx
@@ -2,7 +2,7 @@ package openfl.display3D.textures;
 
 
 import lime.graphics.opengl.GL;
-import lime.utils.DataPointer;
+import lime.utils.ArrayBufferView;
 import lime.utils.UInt8Array;
 import openfl._internal.stage3D.GLUtils;
 import openfl._internal.stage3D.SamplerState;
@@ -55,7 +55,7 @@ import openfl.utils.ByteArray;
 		#if js
 		if (byteArrayOffset == 0) {
 			
-			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.getData());
+			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.b);
 			return;
 			
 		}
@@ -66,7 +66,7 @@ import openfl.utils.ByteArray;
 	}
 	
 	
-	public function uploadFromTypedArray (data:Null<DataPointer>):Void {
+	public function uploadFromTypedArray (data:ArrayBufferView):Void {
 		
 		//if (__format != Context3DTextureFormat.BGRA) {
 			//

--- a/openfl/display3D/textures/Texture.hx
+++ b/openfl/display3D/textures/Texture.hx
@@ -145,7 +145,7 @@ import haxe.io.Bytes;
 	public function uploadFromTypedArray (data:ArrayBufferView, miplevel:UInt = 0):Void {
 		
 		if (data == null) return;
-
+		
 		var width = __width >> miplevel;
 		var height = __height >> miplevel;
 		

--- a/openfl/display3D/textures/Texture.hx
+++ b/openfl/display3D/textures/Texture.hx
@@ -48,8 +48,6 @@ import haxe.io.Bytes;
 		
 		GL.bindTexture (__textureTarget, null);
 		
-		uploadFromTypedArray (null);
-		
 	}
 	
 	
@@ -133,7 +131,7 @@ import haxe.io.Bytes;
 		#if js
 		if (byteArrayOffset == 0) {
 			
-			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).b, miplevel);
+			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.getData(), miplevel);
 			return;
 			
 		}
@@ -144,9 +142,7 @@ import haxe.io.Bytes;
 	}
 	
 	
-	public function uploadFromTypedArray (data:ArrayBufferView, miplevel:UInt = 0):Void {
-		
-		if (data == null) return;
+	public function uploadFromTypedArray (data:lime.utils.DataPointer, miplevel:UInt = 0):Void {
 		
 		var width = __width >> miplevel;
 		var height = __height >> miplevel;

--- a/openfl/display3D/textures/Texture.hx
+++ b/openfl/display3D/textures/Texture.hx
@@ -131,7 +131,7 @@ import haxe.io.Bytes;
 		#if js
 		if (byteArrayOffset == 0) {
 			
-			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.getData(), miplevel);
+			uploadFromTypedArray (@:privateAccess (data:ByteArrayData).bytes.b, miplevel);
 			return;
 			
 		}
@@ -142,8 +142,10 @@ import haxe.io.Bytes;
 	}
 	
 	
-	public function uploadFromTypedArray (data:lime.utils.DataPointer, miplevel:UInt = 0):Void {
+	public function uploadFromTypedArray (data:ArrayBufferView, miplevel:UInt = 0):Void {
 		
+		if (data == null) return;
+
 		var width = __width >> miplevel;
 		var height = __height >> miplevel;
 		

--- a/openfl/net/URLLoader.hx
+++ b/openfl/net/URLLoader.hx
@@ -13,7 +13,6 @@ import openfl.events.IOErrorEvent;
 import openfl.events.ProgressEvent;
 import openfl.events.SecurityErrorEvent;
 import openfl.net.URLRequestMethod;
-import openfl.utils.ByteArray;
 
 
 class URLLoader extends EventDispatcher {
@@ -60,13 +59,13 @@ class URLLoader extends EventDispatcher {
 		#if !macro
 		if (dataFormat == BINARY) {
 			
-			var httpRequest = new HTTPRequest<ByteArray> ();
+			var httpRequest = new HTTPRequest<Bytes> ();
 			__prepareRequest (httpRequest, request);
 			
 			httpRequest.load ()
 				.onProgress (httpRequest_onProgress)
 				.onError (httpRequest_onError)
-				.onComplete (function (data:ByteArray):Void {
+				.onComplete (function (data:Bytes):Void {
 					
 					__dispatchStatus ();
 					this.data = data;

--- a/openfl/utils/ByteArray.hx
+++ b/openfl/utils/ByteArray.hx
@@ -842,7 +842,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData {
 	public function set( pos : Int, v : Int ) : Void {
 		bytes.set(pos, v);
 	}
-	@:deprecated("toString: openfl.utils.ByteArray no longer derives from haxe.io.Bytes")
+	//@:deprecated("toString: openfl.utils.ByteArray no longer derives from haxe.io.Bytes")
 	public function toString() : String {
 		return bytes.toString();
 	}

--- a/tests/unit/test/openfl/utils/ByteArrayTest.hx
+++ b/tests/unit/test/openfl/utils/ByteArrayTest.hx
@@ -379,11 +379,6 @@ class ByteArrayTest {
 		// an empty ByteArray and doesn't crash
 		testString = data.readUTFBytes(data.length);
 		Assert.areEqual( 0, testString.length );
-		
-		// Test toString as well just in case it gets changed
-		// to not just call readUTFBytes
-		testString = data.toString();
-		Assert.areEqual( 0, testString.length );
 	}
 	
 	
@@ -604,6 +599,22 @@ class ByteArrayTest {
 			
 		}
 		
+	}
+
+	@Test public function testCompressUncompress() {
+		var data:ByteArray = new ByteArray();
+		var str:String = "Hello WorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorldWorld!";
+		data.writeUTFBytes(str);
+		
+		Assert.areEqual(str.length, data.length);
+
+		data.compress();
+
+		Assert.isTrue(data.length < str.length, "compressed data should be smaller");
+
+		data.uncompress();
+
+		Assert.areEqual(str.length, data.length);
 	}
 	
 	/*static private function serializeByteArray(ba:ByteArray):String {


### PR DESCRIPTION
openfl.utils.ByteArray extended haxe.io.Bytes and accessed private class field b. This is no longer possible with Haxe4 in some situations: https://github.com/HaxeFoundation/haxe/issues/6543#issuecomment-326502444

Therefore, this pull request changes openfl.utils.ByteArray to embed haxe.io.Bytes. It also avoids unwanted functions derived from haxe.io.Bytes and therefore improves compatability with Flash.