### PR TITLE
TextEngine.hx fix for textfield wordwrap=true & size=0 causing an endless loop

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -1260,7 +1260,7 @@ class TextEngine {
 							
 						}
 						
-						breakLongWords(endIndex);
+						if (width > 0) breakLongWords(endIndex);
 						
 						nextLayoutGroup (textIndex, endIndex);
 						
@@ -1373,7 +1373,7 @@ class TextEngine {
 					
 				} else if (textIndex < formatRange.end || textIndex == text.length) {
 					
-					if (wordWrap) {
+					if (wordWrap && width > 0) {
 						
 						breakLongWords(formatRange.end);
 						


### PR DESCRIPTION
This PR fixes the edge case where a Textfield has size=0 and wordwrap=true causes an endless bug.
This is a common case in HaxeUI in the process to pre-setup the layout.
Steps to reproduce:

var tf: TextField = new TextField();
tf.width = 0;
tf.wordWrap = true;
tf.text = "|";
this.addChild(tf);
