### PR TITLE
TextEngine.hx fix for textfield wordwrap=true & size<4 causing an endless loop

### DIFF
--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -1260,7 +1260,7 @@ class TextEngine {
 							
 						}
 						
-						breakLongWords(endIndex);
+						if (width > 0) breakLongWords(endIndex);
 						
 						nextLayoutGroup (textIndex, endIndex);
 						
@@ -1373,7 +1373,7 @@ class TextEngine {
 					
 				} else if (textIndex < formatRange.end || textIndex == text.length) {
 					
-					if (wordWrap) {
+					if (wordWrap && width > 0) {
 						
 						breakLongWords(formatRange.end);
 						

--- a/openfl/_internal/text/TextEngine.hx
+++ b/openfl/_internal/text/TextEngine.hx
@@ -1073,7 +1073,7 @@ class TextEngine {
 				
 				if (textIndex <= breakIndex) {
 					
-					if (wordWrap && previousSpaceIndex <= textIndex) {
+					if (wordWrap && previousSpaceIndex <= textIndex && width >= 4) {
 						
 						breakLongWords(breakIndex);
 						
@@ -1260,7 +1260,7 @@ class TextEngine {
 							
 						}
 						
-						if (width > 0) breakLongWords(endIndex);
+						if (width >= 4) breakLongWords(endIndex);
 						
 						nextLayoutGroup (textIndex, endIndex);
 						
@@ -1373,7 +1373,7 @@ class TextEngine {
 					
 				} else if (textIndex < formatRange.end || textIndex == text.length) {
 					
-					if (wordWrap && width > 0) {
+					if (wordWrap && width >= 4) {
 						
 						breakLongWords(formatRange.end);
 						


### PR DESCRIPTION
This PR fixes the edge case where a Textfield has size<4 and wordwrap=true causes an endless bug in  breakLongWords inline method.
This is a common case in HaxeUI in the process to pre-setup the layout, or in our case for Textfield sizes generated from code for charts.

Steps to reproduce bug:

var tf: TextField = new TextField();
tf.width = 3;
tf.height = 200;
tf.wordWrap = true;
tf.text = "THIS IS A TEST";
this.addChild(tf);
