### PR TITLE
WorldTransform not being updated - fixed

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -128,6 +128,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	private var __worldTransform:Matrix;
 	private var __worldVisible:Bool;
 	private var __worldVisibleChanged:Bool;
+	private var __worldTransformInvalidated:Bool;
 	private var __worldZ:Int;
 	
 	#if (js && html5)
@@ -605,16 +606,17 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	
 	private function __getWorldTransform ():Matrix {
-		
-		if (__transformDirty) {
-			
+
+		var transformDirty = __transformDirty || __worldTransformInvalidated;
+
+		if (transformDirty) {
+
 			var list = [];
 			var current = this;
-			var transformDirty = __transformDirty;
-			
+
 			if (parent == null) {
 				
-				if (transformDirty) __update (true, false);
+				__update (true, false);
 				
 			} else {
 				
@@ -624,28 +626,20 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 					current = current.parent;
 					
 					if (current == null) break;
-					
-					if (current != stage && current.__transformDirty) {
-						
-						transformDirty = true;
-						
-					}
-					
 				}
 				
 			}
 			
-			if (transformDirty) {
-				
-				var i = list.length;
-				while (--i >= 0) {
-					
-					list[i].__update (true, false);
-					
-				}
-				
+			var i = list.length;
+			while (--i >= 0) {
+
+				current = list[i];
+				current.__update (true, false);
+				current.__worldTransformInvalidated = false;
+
 			}
-			
+				
+
 		}
 		
 		return __worldTransform;
@@ -876,6 +870,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		if (!__transformDirty) {
 			
 			__transformDirty = true;
+			__worldTransformInvalidated = true;
 			__setParentRenderDirty ();
 			
 		}


### PR DESCRIPTION
There is a special sequence of steps that could lead to an issue where child's world position is not gonna be updated. This PR provides the fix.

`package;


import flash.geom.Point;
import openfl.display.Sprite;


class Main extends Sprite {
	
	
	public function new () {
		
		super ();
		

		var _grandParent: Sprite = new Sprite();
		var _parent: Sprite = new Sprite();
		var _child: Sprite = new Sprite();
		addChild(_grandParent);

		_grandParent.addChild(_parent);
		_parent.addChild(_child);

		_child.x = _child.y = 100;
		_parent.x = _parent.y = 100;
		_grandParent.x = _grandParent.y = 100;

		_child.graphics.beginFill(0xFF0000, .1);
		_child.graphics.drawRect(0, 0, 200, 200);
		_child.graphics.endFill();

		_parent.graphics.beginFill(0xFF0000, .1);
		_parent.graphics.drawRect(0, 0, 200, 200);
		_parent.graphics.endFill();

		_grandParent.graphics.beginFill(0xFF0000, .1);
		_grandParent.graphics.drawRect(0, 0, 200, 200);
		_grandParent.graphics.endFill();

		//step 0. ask for global child position
		var p = _child.localToGlobal(new Point());
		trace("Child global position before " + p);

		var offsetX = 100;
		// step 1. change a grand parent's transform
		_grandParent.x += offsetX;
		trace("grandParent moved " + offsetX + "px on the right");
		// step 2. ask for width/height any parent between _child and _grandParent in the hierarchy
		_parent.width;
		// step 3. ask for global position of the _child. The global child position won't be changed, it will be the
		// same as in step 0.
		var newp = _child.localToGlobal(new Point());

		p.x += offsetX;
		trace("Child global position after " + newp + " <= should be " + p);

		// Rationale
		/**
		*  Step 2. Recalculates the _child's __worldTransform only relative to _parent, not considering _grandParent and
		*  resets _child's __transformDirty to false. At this point the _child's __worldTransform is incorrect
		*  because _grandParent has been moved.
		*  Next time when a _child is asked for localToGlobal or getBounds it won't calculate the correct value since
		*  __transformDirty is false and __getWorldTransform will return the cached __worldTransform which is wrong.
		**/


	}
	
	
}`