### PR TITLE
evenodd set as default winding rule for hitTest

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -269,7 +269,8 @@ class CanvasGraphics {
 	public static function hitTest (graphics:Graphics, x:Float, y:Float):Bool {
 		
 		#if (js && html5)
-		
+
+		var windingRule = CanvasWindingRule.EVENODD;
 		bounds = graphics.__bounds;
 		CanvasGraphics.graphics = graphics;
 		
@@ -359,7 +360,7 @@ class CanvasGraphics {
 						endFill ();
 						endStroke ();
 						
-						if (hasFill && context.isPointInPath (x, y)) {
+						if (hasFill && context.isPointInPath (x, y, windingRule)) {
 							
 							data.destroy ();
 							graphics.__canvas = cacheCanvas;
@@ -385,7 +386,7 @@ class CanvasGraphics {
 						endFill ();
 						endStroke ();
 						
-						if (hasFill && context.isPointInPath (x, y)) {
+						if (hasFill && context.isPointInPath (x, y, windingRule)) {
 							
 							data.destroy ();
 							graphics.__canvas = cacheCanvas;
@@ -469,7 +470,7 @@ class CanvasGraphics {
 			
 			data.destroy ();
 			
-			if (hasFill && context.isPointInPath (x, y)) {
+			if (hasFill && context.isPointInPath (x, y, windingRule)) {
 				
 				graphics.__canvas = cacheCanvas;
 				graphics.__context = cacheContext;


### PR DESCRIPTION
When we playCommands the default drawing rule is `evenodd`. Flash also have `evenodd` as default winding rule when hitTest(or handle mouse interaction) on Shapes/Graphics, therefore I set `evenodd` as a default winding rule for hitTest in openFL. 