### PR TITLE
SampleDataEvent

### DIFF
--- a/externs/core/flash/flash/media/Sound.hx
+++ b/externs/core/flash/flash/media/Sound.hx
@@ -29,6 +29,13 @@ extern class Sound extends EventDispatcher {
 	public var length (default, never):Float;
 	public var url (default, never):String;
 	
+	#if flash
+	public var sampleRate (get, never):Int;
+	
+	private inline function get_sampleRate ():Int { return 44100; }
+	#end
+	
+	
 	public function new (stream:URLRequest = null, context:SoundLoaderContext = null);
 	public function close ():Void;
 	

--- a/externs/core/openfl/openfl/media/Sound.hx
+++ b/externs/core/openfl/openfl/media/Sound.hx
@@ -135,6 +135,12 @@ extern class Sound extends EventDispatcher {
 	#if flash
 	@:noCompletion @:dox(hide) @:require(flash10_1) public var isURLInaccessible (default, null):Bool;
 	#end
+
+	/**
+	 * Returns the samplerate which is always 44100 hz for flash but can be different 
+	 * on HTML5.
+	 */
+	public var sampleRate (get, never):Int;	
 	
 	/**
 	 * The length of the current sound in milliseconds.

--- a/openfl/events/SampleDataEvent.hx
+++ b/openfl/events/SampleDataEvent.hx
@@ -1,9 +1,20 @@
 package openfl.events;
 
 
+
 import openfl.utils.ByteArray;
 import openfl.utils.Endian;
 
+#if (js && html5)
+	import js.html.audio.AudioProcessingEvent;
+	import haxe.io.Float32Array;
+	import js.html.audio.AudioBuffer;
+	import openfl.errors.Error;
+#end
+#if lime_openal
+	import openfl.errors.Error;
+	import haxe.io.Bytes;
+#end
 
 class SampleDataEvent extends Event {
 	
@@ -14,6 +25,15 @@ class SampleDataEvent extends Event {
 	public var position:Float;
 	
 	
+	#if (js && html5)	
+		private var tempBuffer:Float32Array;
+		private var leftChannel:js.html.Float32Array;
+		private var rightChannel:js.html.Float32Array;
+	#end	
+	#if lime_openal
+		private var leftChannel:Int;
+		private var rightChannel:Int;
+	#end
 	public function new (type:String, bubbles:Bool = false, cancelable:Bool = false) {
 		
 		super (type, bubbles, cancelable);
@@ -43,4 +63,61 @@ class SampleDataEvent extends Event {
 	}
 	
 	
+#if lime_openal
+	private function getBufferSize():Int {
+		var bufferSize:Int = Std.int(data.length / 4 / 2);
+			if (bufferSize >= 2048 && bufferSize <= 8192) {
+				return bufferSize;
+			} else {
+				throw new Error("To be consistent with flash the listener function registered to SampleDataEvent has to provide between 2048 and 8192 samples.");
+			}		
+		return bufferSize;
+	}	
+	
+	private function getSamples(outputBuffer:ByteArray):Void {
+		var bytesLength:Int = data.length;
+		var tempFloat:Float;
+		data.position = 0;
+		outputBuffer.position = 0;
+		while (data.position < bytesLength)
+		{
+			tempFloat = data.readFloat();
+			leftChannel = Std.int(tempFloat * 32768);
+			outputBuffer.writeShort(leftChannel);
+			tempFloat = data.readFloat();
+			rightChannel = Std.int(tempFloat * 32768);
+			outputBuffer.writeShort(rightChannel);
+		}
+
+		data.position = 0;
+	}	
+	#end
+	#if (js && html5)
+	private function getBufferSize():Int {
+		var bufferSize:Int = Std.int(data.length/4/2);
+		if (bufferSize > 0) {
+			if ((bufferSize != 0) && ((bufferSize & (bufferSize - 1)) == 0) && bufferSize >= 2048 && bufferSize <= 8192) {
+				tempBuffer = new haxe.io.Float32Array(bufferSize * 2);
+				return bufferSize;
+			} else {
+				throw new Error("To be consistent with flash the listener function registered to SampleDataEvent has to provide 2048, 4096 or 8192 samples if targeting HTML5.");
+			}
+		}
+		return 0;
+	}
+
+private function getSamples(event:js.html.audio.AudioProcessingEvent):Void {
+		data.position = 0;
+		tempBuffer=Float32Array.fromBytes(data);
+
+		leftChannel = event.outputBuffer.getChannelData(0);
+		rightChannel = event.outputBuffer.getChannelData(1);
+		var pos:Int = 0;
+		var bufferLength:Int = Std.int(data.length / 2);
+		for (i in 0...bufferLength) {
+			leftChannel[i] = tempBuffer[pos++];
+			rightChannel[i] = tempBuffer[pos++];
+		}		
+	}
+	#end	
 }


### PR DESCRIPTION
Implementation of Flash's SampleDataEvent using WebAudio on HTML5 and OpenAL on Windows/Neko.
Though untested it should work on other targets using on OpenAL.

**Example of use:**

```haxe
package;

import openfl.display.Sprite;
import openfl.media.Sound;
import openfl.events.SampleDataEvent;
import openfl.utils.ByteArray;

class Main extends Sprite 
{
    private var sampleRate:Int;
    private var bufferSize:Int = 8192;
    private var bpm:Int = 90;
    private var numberOfRows:Int = 48; // 48=3/4 time | 64=4/4 time
    private var currentRow:Int = 0;
    private var quarterNoteLength:Float;
    private var sixteenthNoteLength:Float;
    private var numOctaves:Int = 8;
    private var patterns:Array<Dynamic>= new Array();
    private var currentPattern:Int=0;
    private var songOrder:Array<Int> = [0, 1];
    private var notes:Array<String>= ["c-", "c#", "d-", "d#", "e-", "f-", "f#", "g-", "g#", "a-", "a#", "b-"];
    private var frequencies:Array<Dynamic> = new Array();
    private var samplePosition:Int = 0;
    private var position:Int = 0;
    private var channel1:Dynamic = {volume: .05, waveForm: "", frequency: [], noteTriggered: false, envelopePos: 0};
    private var envelope:Array<Float>= new Array();
    private var echoBytes:ByteArray = new ByteArray();
    private var maxEchoBytes:UInt = 8192 * 256;
    private var echoing:Bool = true;
    private var echoDelay:Float;
    private var echoPosition:UInt=0;
	
    public function new() 
    {
        super();
		
        var sound:Sound = new Sound();
	sampleRate = sound.sampleRate;
		
        quarterNoteLength = sampleRate * 60 / bpm;
        sixteenthNoteLength = quarterNoteLength / 2 / 2;
        echoDelay = sixteenthNoteLength * 4;
        for (a in 0...numOctaves)
        {
            for (b in 0...notes.length)
            {
                frequencies.push([notes[b % notes.length] + a, 16.35 * Math.pow(2, frequencies.length / 12)]);
            }
        }
		patterns.push(["g-2|g-4", "", "", "a-4", "a#4", "", "d-2|a-4", "", "g-4", "", "f-4", "", "g-2|g-4", "", "d-4", "", "", "", "", "", "", "", "d-4", "", "g-2|g-4", "", "", "a-4", "a#4", "", "c-2|c-5", "", "a#4", "", "c-5", "", "d-2|d-5", "", "", "", "", "", "", "", "", "", "d-5", ""]);
		patterns.push(["g-2|d-5","","","d#5","d-5","","f-2|c-5","","a#4","","a-4","","d#2|a#4","","c-5","","a#4","","d-2|a-4","","","","d-4","","g-2|g-4","","","a-4","g-4","","d-2|f-4","","d-4","","f-4","","g-2|g-4","","","","","","","","","","",""]);
        Reflect.setProperty(channel1, "waveForm", "sawtooth");

        for (c in 0...Std.int(quarterNoteLength))
        {
            if (c < sixteenthNoteLength * 1)
            {
                envelope.push(1.0);
            }
            else
            {
                if (c < sixteenthNoteLength * 3)
                {
                    envelope.push(.4);
                }
                else
                {
                    envelope.push(0.0);
                }
            }
        }
        
        updateRow();
        
        sound.addEventListener(SampleDataEvent.SAMPLE_DATA, onSampleData);
        sound.play(); 
    }
    
private function updateRow():Void
    {
        var tempNote:String = patterns[songOrder[currentPattern]][currentRow];
        if (tempNote != "")
        {
            var tempArray:Array<Float> = new Array();
            Reflect.setProperty(channel1, "frequency", []);
            if (tempNote.indexOf("|") == -1)
            {
                // single note
                tempArray.push(findFrequency(tempNote));
            }
            else
            {
                // chord
                var tempNotes:Array<String> = tempNote.split("|");
                for (a in 0...tempNotes.length)
                {
                    tempArray.push(findFrequency(tempNotes[a]));
                }
            }
            Reflect.setProperty(channel1, "noteTriggered", true);
            Reflect.setProperty(channel1, "frequency", tempArray);
        }    
    }
        
    private function onSampleData(event:SampleDataEvent):Void
    {
        var tempArray:Array<Float>;
        var addDataL:Float = 0.0;
        var addDataR:Float = 0.0;
        var volumeModifier:Float= 0.0;
        var sampleData:Float = 0.0;
        for (i in 0...bufferSize)            
        {
            if (++samplePosition == sixteenthNoteLength)
            {
                if (++currentRow == numberOfRows)
                {
                    currentRow = 0;
                    if (++currentPattern == songOrder.length)
                    {
                        currentPattern = 0;
                    }
                }
                updateRow();
                samplePosition = 0;
            }
            if (Reflect.field(channel1, "noteTriggered"))
            {
                Reflect.setProperty(channel1, "envelopePos", 0);
                Reflect.setProperty(channel1, "noteTriggered", false);    
            }
            if (Reflect.field(channel1, "envelopePos")+ 1 < envelope.length)
            {
                var tempInt:Int = Reflect.field(channel1, "envelopePos") + 1;
                Reflect.setProperty(channel1, "envelopePos", tempInt);
            }
            volumeModifier = envelope[Reflect.field(channel1, "envelopePos")];
            tempArray = Reflect.field(channel1, "frequency");
            if (tempArray.length == 1)
            {
                sampleData = generate(Reflect.field(channel1, "waveForm"), position, tempArray[0] , Reflect.field(channel1, "volume") * volumeModifier);
            }
            else
            {
                sampleData = generate(Reflect.field(channel1, "waveForm"), position, tempArray[0] , Reflect.field(channel1, "volume") * volumeModifier);
                sampleData += generate(Reflect.field(channel1, "waveForm"), position, tempArray[1] , Reflect.field(channel1, "volume") * volumeModifier);
            }
                
            if (echoing)
            {
                if (position > echoDelay)
                {
                    var oldPos:UInt = echoBytes.position;
                    echoBytes.position = echoPosition;
                    addDataL = echoBytes.readFloat() / 4;
                    addDataR = echoBytes.readFloat() / 4;
                    
                    if (echoPosition + 8 < maxEchoBytes)
                    {
                        echoPosition += 8;
                    }
                    else
                    {
                        echoPosition = 0;
                    }
                    echoBytes.position = oldPos;
                }
            }                
            
            event.data.writeFloat(sampleData + addDataL);
            event.data.writeFloat(sampleData + addDataR);
            echoBytes.writeFloat(sampleData);
            echoBytes.writeFloat(sampleData);
            if (echoBytes.position == maxEchoBytes)
            {
                echoBytes.position = 0;
            }                
            position++;
        }
    }
            
    private function findFrequency(inpNote:String):Float
    {
        var retVal:Float=0.0;
        for (a in 0...frequencies.length)
        {
            if (frequencies[a][0] == inpNote)
            {
                retVal = frequencies[a][1];
                break;
            }
        }
        return retVal;
    }        
        
    private function generate(waveForm:String, pos:Int, frequency:Float, volume:Float):Float
    {
        var retVal:Float = 0.0;
        switch (waveForm)
        {
            case "square": 
                retVal = Math.sin((pos) * Math.PI * 2 / sampleRate * frequency) > 0 ? volume : -volume;
            case "sine": 
                retVal = Math.sin((pos) * Math.PI * 2 / sampleRate * frequency * 2) * volume;
            case "sawtooth": 
                retVal = (2 * (pos % (sampleRate / frequency)) / (sampleRate / frequency) - 1) * volume;
        }
        return retVal;
    }
}
```