### PR TITLE
- normalized vector js stringify

### DIFF
--- a/openfl/Vector.hx
+++ b/openfl/Vector.hx
@@ -280,7 +280,7 @@ abstract Vector<T>(IVector<T>) {
 		
 	}
 	
-	
+
 }
 
 
@@ -535,15 +535,21 @@ abstract Vector<T>(IVector<T>) {
 		}
 		
 	}
-	
-	
-	
-	
+
+
+	#if js
+	@:noCompletion @:keep private function toJSON(): Array<Bool> {
+		return __array;
+	}
+	#end
+
+
+
 	// Getters & Setters
 	
 	
-	
-	
+
+
 	@:noCompletion private function get_length ():Int {
 		
 		return __array.length;
@@ -837,8 +843,13 @@ abstract Vector<T>(IVector<T>) {
 		}
 		
 	}
-	
-	
+
+
+	#if js
+	@:noCompletion @:keep private function toJSON(): Array<Float> {
+		return __array;
+	}
+	#end
 	
 	
 	// Getters & Setters
@@ -1451,10 +1462,15 @@ abstract Vector<T>(IVector<T>) {
 		}
 		
 	}
-	
-	
-	
-	
+
+
+	#if js
+	@:noCompletion @:keep private function toJSON(): Array<Int> {
+		return __array;
+	}
+	#end
+
+
 	// Getters & Setters
 	
 	
@@ -1753,9 +1769,15 @@ abstract Vector<T>(IVector<T>) {
 		}
 		
 	}
-	
-	
-	
+
+
+	#if js
+	@:noCompletion @:keep private function toJSON(): Array<T> {
+		return __array;
+	}
+	#end
+
+
 	
 	// Getters & Setters
 	
@@ -1808,7 +1830,7 @@ abstract Vector<T>(IVector<T>) {
 		
 	}
 	
-	
+
 }
 
 

--- a/tests/unit/test/openfl/VectorTest.hx
+++ b/tests/unit/test/openfl/VectorTest.hx
@@ -1,6 +1,7 @@
 package openfl;
 
 
+import openfl.errors.Error;
 import massive.munit.Assert;
 
 
@@ -439,6 +440,76 @@ class VectorTest {
 		Assert.areEqual (100, vector[0]);
 		
 	}
-	
+
+
+	#if (!html5 && !flash) @Ignore #end @Test public function intVectorStringify () {
+		// Testing if we have the same stringify behavior in JS and flash
+		var expected: String = "[1,2]";
+		var stringyfied: String = null;
+		var vector: Vector<Int> = new Vector<Int> ();
+
+		vector.push(1);
+		vector.push(2);
+
+		stringyfied = haxe.Json.stringify(vector);
+
+		Assert.areEqual (expected, stringyfied);
+	}
+
+	#if (!html5 && !flash) @Ignore #end @Test public function boolVectorStringify () {
+		// Testing if we have the same stringify behavior in JS and flash
+		var expected: String = "[false,true]";
+		var stringyfied: String = null;
+		var vector: Vector<Bool> = new Vector<Bool> ();
+
+		vector.push(false);
+		vector.push(true);
+
+		stringyfied = haxe.Json.stringify(vector);
+
+		Assert.areEqual (expected, stringyfied);
+	}
+
+	#if (!html5 && !flash) @Ignore #end @Test public function floatVectorStringify () {
+		// Testing if we have the same stringify behavior in JS and flash
+		var expected: String = "[1.1,2.2]";
+		var stringyfied: String = null;
+		var vector: Vector<Float> = new Vector<Float> ();
+
+		vector.push(1.1);
+		vector.push(2.2);
+
+		stringyfied = haxe.Json.stringify(vector);
+
+		Assert.areEqual (expected, stringyfied);
+	}
+
+	#if (!html5 && !flash) @Ignore #end @Test public function objectVectorStringify () {
+		// Testing if we have the same stringify behavior in JS and flash
+		var expected: String = null;
+		var stringyfied: String = null;
+		var obj: Error = new Error("Message", 1);
+		var strObj: String = haxe.Json.stringify(obj);
+		var vector: Vector<Error> = new Vector<Error> ();
+
+		vector.push(obj);
+
+		stringyfied = haxe.Json.stringify(vector);
+		expected = "[" + strObj + "]";
+
+		Assert.areEqual (expected, stringyfied);
+
+		// Testing stringify inside object
+		var obj: Dynamic = {id: 5, errors: vector};
+
+		stringyfied = haxe.Json.stringify(obj);
+
+		// Testing if stringify inside object is still the same as outside
+		Assert.isTrue (stringyfied.indexOf(expected) != -1);
+
+		// Check lengh and __array aren't stringified
+		Assert.areEqual(stringyfied.indexOf("length"), -1);
+		Assert.areEqual(stringyfied.indexOf("__array"), -1);
+	}
 	
 }


### PR DESCRIPTION
This changes makes Vector stringify behave the same way as flash. 
In as3 when we stringify a vector we get the same as array: `{[Obj1, Obj2...]}`
Without this changes, instead of that we get `{__length: 2, __array: [Obj1, Obj2]}`.
It affects only `js` in `BoolVector`, `FloatVector`, `IntVector` and `ObjectVector`. 
Tests for it was added as well 