### PR TITLE
Filter fix for colortransforms and resetting after changing MovieClip frame

### DIFF
--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1140,7 +1140,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 						lastBitmap = filter.__applyFilter (bitmapData2, bitmapData, sourceRect, destPoint);
 						
 						if (filter.__preserveObject) {
-							lastBitmap.draw (bitmapData3);
+							lastBitmap.draw (bitmapData3, null, transform.colorTransform);
 						}
 						filter.__renderDirty = false;
 						

--- a/openfl/display/MovieClip.hx
+++ b/openfl/display/MovieClip.hx
@@ -790,6 +790,10 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 			
 			displayObject.filters = filters;
 			
+		} else {
+
+			displayObject.filters = null;
+
 		}
 		
 		if (frameObject.visible != null) {


### PR DESCRIPTION
When colortransforms are applied to an object with a filter that has '__preserveObject' set, the colortransform needs to be included in the bitmapdata.draw. 

Fix to MovieClips when advancing to a frame that has no filters.