### PR TITLE
fix font name matching in assets

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -1005,7 +1005,7 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 		
 		if (!found) {
 			
-			var alpha = ~/[^a-zA-Z]+/;
+			var alpha = ~/[^a-zA-Z]+/g;
 			
 			for (font in Font.enumerateFonts ()) {
 				


### PR DESCRIPTION
fix for font matching not finding font names with multiple non-alphabetic characters in asset library from symbols (regex global flag is needed to find multiple e.g. dashes and spaces)