### PR TITLE
fix for videos on mobile safari

### DIFF
--- a/openfl/net/NetStream.hx
+++ b/openfl/net/NetStream.hx
@@ -48,7 +48,10 @@ class NetStream extends EventDispatcher {
 		
 		#if (js && html5)
 		__video = cast Browser.document.createElement ("video");
-		
+
+		__video.setAttribute("playsinline", "");
+		__video.setAttribute("webkit-playsinline", "");
+
 		__video.addEventListener ("error", video_onError, false);
 		__video.addEventListener ("waiting", video_onWaiting, false);
 		__video.addEventListener ("ended", video_onEnd, false);


### PR DESCRIPTION
When a Video element is played on mobile safari, by default it will launch a new window to play that video in full screen. Need to use "playsinline" attribute to not do that.