### PR TITLE
Fix: Sometimes the index could be a wrong value throwing a null error.

### DIFF
--- a/openfl/_internal/text/TextLayoutGroup.hx
+++ b/openfl/_internal/text/TextLayoutGroup.hx
@@ -48,7 +48,7 @@ class TextLayoutGroup {
 		#if (js && html5)
 		return positions[index];
 		#else
-		return positions[index].advance.x;
+		return (index >= 0 && index < positions.length) ? positions[index].advance.x : 0;
 		#end
 		
 	}


### PR DESCRIPTION
I have experimented some troubles with my app with the new versions 6.2.x. 

This PR fixes part of the problem.

Some traces:

```
Called from openfl.display.DisplayObjectContainer::__renderGL openfl/display/DisplayObjectContainer.hx line 842
Called from openfl.text.TextField::__renderGL openfl/text/TextField.hx line 1420
Called from openfl._internal.renderer.cairo.CairoTextField::render openfl/_internal/renderer/cairo/CairoTextField.hx line 340
Called from openfl.text.TextField::getCharBoundaries openfl/text/TextField.hx line 191
```

```
Called from openfl.text.TextField::get_textWidth openfl/text/TextField.hx line 2212
Called from openfl.text.TextField::__updateLayout openfl/text/TextField.hx line 1497
Called from openfl._internal.text.TextEngine::update openfl/_internal/text/TextEngine.hx line 1582
Called from openfl._internal.text.TextEngine::getLayoutGroups openfl/_internal/text/TextEngine.hx line 1233
```