### PR TITLE
Fix wrong movieclip being created

### DIFF
--- a/openfl/_internal/symbols/SpriteSymbol.hx
+++ b/openfl/_internal/symbols/SpriteSymbol.hx
@@ -31,11 +31,6 @@ class SpriteSymbol extends SWFSymbol {
 	
 	private override function __createObject (swf:SWFLite):MovieClip {
 		
-		#if !macro
-		MovieClip.__initSWF = swf;
-		MovieClip.__initSymbol = this;
-		#end
-		
 		var symbolType = null;
 		
 		if (className != null) {
@@ -72,6 +67,8 @@ class SpriteSymbol extends SWFSymbol {
 			movieClip = new MovieClip ();
 			
 		}
+		
+		movieClip.__fromSymbol(swf, this);
 		
 		return movieClip;
 		


### PR DESCRIPTION
On android we hit a very weird issue where sometimes the movieclip would be empty (or have the wrong number of children), digging and digging we couldn't figure out why, it didn't makes sense. Turns out that while debugging, I notice that the wrong symbol was used during the movieclip creation but the parent definitely had the correct symbol when it tried to create the child. 

Somehow we must have one of our extension that use thread on android, a callback is called, some movieclip get created at the same time and that static variable get changed.

I think it's much simpler like that and less error prone, was there a reason why it was using static variable?