### PR TITLE
Make tabIndex getters and setters overridable like in Flash

### DIFF
--- a/openfl/display/InteractiveObject.hx
+++ b/openfl/display/InteractiveObject.hx
@@ -19,9 +19,10 @@ class InteractiveObject extends DisplayObject {
 	
 	public var softKeyboardInputAreaOfInterest:Rectangle;
 	public var tabEnabled (get, set):Bool;
-	public var tabIndex:Int;
+	public var tabIndex (get, set):Int;
 	
 	private var __tabEnabled:Null<Bool>;
+	private var __tabIndex:Int;
 	
 	
 	public function new () {
@@ -32,7 +33,7 @@ class InteractiveObject extends DisplayObject {
 		mouseEnabled = true;
 		needsSoftKeyboard = false;
 		__tabEnabled = null;
-		tabIndex = -1;
+		__tabIndex = -1;
 		
 	}
 	
@@ -97,6 +98,20 @@ class InteractiveObject extends DisplayObject {
 	private function set_tabEnabled (value:Bool):Bool {
 		
 		return __tabEnabled = value;
+		
+	}
+	
+	
+	private function get_tabIndex ():Int {
+		
+		return __tabIndex;
+		
+	}
+	
+	
+	private function set_tabIndex (value:Int):Int {
+		
+		return __tabIndex = value;
 		
 	}
 	


### PR DESCRIPTION
This allows the tabIndex property to be overridden (getter/setter) when extending InteractiveObject based classes