### PR TITLE
Fix null-pointer exception in unload()

### DIFF
--- a/openfl/_internal/swf/SWFLiteLibrary.hx
+++ b/openfl/_internal/swf/SWFLiteLibrary.hx
@@ -282,6 +282,8 @@ import openfl.utils.ByteArray;
 	
 	public override function unload ():Void {
 		
+		if (swf == null) return;
+		
 		var bitmap:BitmapSymbol;
 		
 		for (symbol in swf.symbols) {


### PR DESCRIPTION
Simple test for null before trying to iterate over symbols a SWFLite library to stop exceptions occurring