### PR TITLE
Immediately blink the caret when position changes

### DIFF
--- a/openfl/text/TextField.hx
+++ b/openfl/text/TextField.hx
@@ -587,7 +587,9 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 		
 		__selectionIndex = beginIndex;
 		__caretIndex = endIndex;
-		
+		__stopCursorTimer ();
+		__startCursorTimer ();
+
 	}
 	
 	


### PR DESCRIPTION
When the cursor position changes in a TextField ensure the caret blink starts immediately to give immediate feedback on the new position. 