### PR TITLE
Allow a transparent background for main HTML canvas when using color-…

### DIFF
--- a/openfl/display/Stage.hx
+++ b/openfl/display/Stage.hx
@@ -159,7 +159,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 		this.application = window.application;
 		this.window = window;
 		
-		if (color == null) {
+		if (color == null || window.config.colorDepth > 16) {
 			
 			__transparent = true;
 			this.color = 0x000000;


### PR DESCRIPTION
…depth = 32 for integrating with the rest of the web page.

This allows OpenFL  (HTML canvas) to have a transparent background, show dom elements behind content. It requires the background-color CSS of the index.html template to be removed too for it to work. but that can be done through a new template specified in the project.xml template tag.