### PR TITLE
Fix masking when mask and or masked cache as bitmap

### DIFF
--- a/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
+++ b/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
@@ -48,7 +48,7 @@ class CanvasMaskManager extends AbstractMaskManager {
 			
 		}
 		
-		if (object.__mask != null) {
+		if (!object.__cacheBitmapRender && object.__mask != null) {
 			
 			pushMask (object.__mask);
 			

--- a/openfl/_internal/renderer/opengl/GLMaskManager.hx
+++ b/openfl/_internal/renderer/opengl/GLMaskManager.hx
@@ -137,7 +137,7 @@ class GLMaskManager extends AbstractMaskManager {
 		
 		if (stencilReference == 0) return;
 		
-		if (stencilReference > 10) {
+		if (stencilReference > 1) {
 			
 			gl.stencilOp (gl.KEEP, gl.KEEP, gl.DECR);
 			gl.stencilFunc (gl.EQUAL, stencilReference, 0xFF);

--- a/openfl/display/BitmapData.hx
+++ b/openfl/display/BitmapData.hx
@@ -1705,7 +1705,16 @@ class BitmapData implements IBitmapDrawable {
 			var matrixCache = source.__worldTransform;
 			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
+			
+			var oldRenderable = untyped source.__renderable;
+			if (untyped source.__isMask) {
+				
+				untyped source.__renderable = true;
+				
+			}
+			
 			source.__renderCanvas (renderSession);
+			untyped source.__renderable = oldRenderable;
 			source.__updateTransforms (matrixCache);
 			source.__updateChildren (true);
 			

--- a/openfl/display/DisplayObject.hx
+++ b/openfl/display/DisplayObject.hx
@@ -1123,6 +1123,12 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 				
 			}
 			
+			if (__mask != null && __cacheBitmap.mask != __mask) {
+				
+				__cacheBitmap.mask = __mask;
+				
+			}
+			
 			__cacheBitmap.smoothing = renderSession.allowSmoothing;
 			__cacheBitmap.__renderable = __renderable;
 			__cacheBitmap.__worldAlpha = __worldAlpha;
@@ -1519,6 +1525,12 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 			value.__isMask = true;
 			value.__maskTarget = this;
+			
+		}
+		
+		if (__cacheBitmap != null && __cacheBitmap.mask != value) {
+			
+			__cacheBitmap.mask = value;
 			
 		}
 		


### PR DESCRIPTION
This is a fix of a broken masking when masked and/or mask is/are cached as bitmap. The changes include:
1. Don't apply mask while rendering `__cacheBitmap`
2. Set the mask as well to `__cacheBitmap` if masked is cached as bitmap
3. Cached as bitmap mask won't be drawn due to `__renderable = false`. Set temporary `__renderable` to `true` to draw the mask then reset it to original value.