### PR TITLE
Docker hub : When building `openfl/openfl:develop` inherit from `openfl/lime:develop`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG LIME_VERSION=latest
+ARG LIME_VERSION=develop
 
 FROM openfl/lime:${LIME_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG LIME_VERSION=develop
+ARG LIME_VERSION=latest
 
 FROM openfl/lime:${LIME_VERSION}
 

--- a/hooks/build
+++ b/hooks/build
@@ -4,7 +4,14 @@
 # $IMAGE_NAME var is injected into the build so the tag is correct.
 
 echo "Build hook running"
+
+if [ "$DOCKER_TAG" == "develop" ]; then
+    LIME_VERSION="develop"
+else
+    LIME_VERSION="latest"
+fi
+
 docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
              --build-arg VCS_REF=`git rev-parse --short HEAD` \
-             --build-arg LIME_VERSION=$DOCKER_TAG \
+             --build-arg LIME_VERSION=$LIME_VERSION \
              -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Build hook for docker hub.
+# $IMAGE_NAME var is injected into the build so the tag is correct.
+
+echo "Build hook running"
+docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+             --build-arg VCS_REF=`git rev-parse --short HEAD` \
+             --build-arg LIME_VERSION=$DOCKER_TAG \
+             -t $IMAGE_NAME .


### PR DESCRIPTION
When building `openfl/openfl` on docker hub, we need to inherit `FROM openfl/lime:develop` if we're on the `develop` branch, otherwise from `latest`