### PR TITLE
Only call update on dirty display objects

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -123,6 +123,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	private var __scrollRect:Rectangle;
 	private var __transform:Matrix;
 	private var __transformDirty:Bool;
+	private var __updateDirty:Bool;
+	private var __updateTraverse:Bool;
 	private var __visible:Bool;
 	private var __worldAlpha:Float;
 	private var __worldAlphaChanged:Bool;
@@ -922,6 +924,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 		}
 		
+		__setUpdateDirty();
+		
 	}
 	
 	
@@ -943,8 +947,39 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 		}
 		
+		__setUpdateDirty();
+		
 	}
 	
+	
+	private inline function __setUpdateDirty ():Void {
+		
+		if (!__updateDirty) {
+			
+			__updateDirty = true;
+			
+			// As this DisplayObject needs to be updated, we need to flag all parents to be traversed
+			__setParentUpdateTraverse ();
+			
+		}
+		
+	}	
+	
+	
+	private function __setParentUpdateTraverse ():Void {
+		
+		var renderParent = __renderParent != null ? __renderParent : parent;
+		
+		// Relying on __updateTraverse always being set, is currently too risky and would only bring small performance gain
+		// Therefore setting it always to true up to the root objects
+		if (renderParent != null/* && !renderParent.__updateTraverse*/) {
+			
+			renderParent.__updateTraverse = true;
+			renderParent.__setParentUpdateTraverse ();
+		
+		}
+		
+	}
 	
 	private function __setWorldTransformInvalid ():Void {
 		
@@ -959,8 +994,20 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 	}
 	
+	private function __traverse ():Void {
+		
+		if (__updateDirty) {
+			
+			__update (false, true);
+			
+		}
+		
+	}
+	
 	
 	public function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null):Void {
+		
+		__updateDirty = false;
 		
 		var renderParent = __renderParent != null ? __renderParent : parent;
 		if (__isMask && renderParent == null) renderParent = __maskTarget;

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -982,6 +982,27 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 	}
 	
+	private override function __traverse ():Void {
+		
+		if (__updateDirty) {
+			
+			__update (false, true);
+			
+		} else if (__updateTraverse) {
+			
+			for (child in __children) {
+				
+				child.__traverse ();
+				
+			}
+			
+		}
+		
+		// This container has been traversed, therefore reset flag
+		__updateTraverse = false;
+			
+	}
+	
 	
 	public override function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null):Void {
 		

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1114,7 +1114,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 			
 			__enterFrame (__deltaTime);
 			__deltaTime = 0;
-			__update (false, true);
+			__traverse ();
 			
 			if (__renderer != null #if !openfl_always_render && __renderDirty #end) {
 				


### PR DESCRIPTION
In big scenes the scene traversal via DisplayObjectContainer.__update can have significant performance impact, even though most of the scene did not change. This change only traverses the parent objects of changed objects (to reach them) and only calls __update on the changed objects and their children.

This pull requests increases performance by around 30% in my benchmark.