### PR TITLE
Click-through fix for non-interactive Sprite

### DIFF
--- a/src/openfl/display/Sprite.hx
+++ b/src/openfl/display/Sprite.hx
@@ -80,6 +80,7 @@ class Sprite extends DisplayObjectContainer {
 	
 	private override function __hitTest (x:Float, y:Float, shapeFlag:Bool, stack:Array<DisplayObject>, interactiveOnly:Bool, hitObject:DisplayObject):Bool {
 		
+		if (interactiveOnly && !mouseEnabled && !mouseChildren) return false;
 		if (!hitObject.visible || __isMask) return __hitTestHitArea (x, y, shapeFlag, stack, interactiveOnly, hitObject);
 		if (mask != null && !mask.__hitTestMask (x, y)) return __hitTestHitArea (x, y, shapeFlag, stack, interactiveOnly, hitObject);
 		


### PR DESCRIPTION
Clicking overlapping squares in center on Flash gives "child1 is clicked". Other platforms (tested on js / cpp) are giving "parentSprite is clicked" which is wrong.

Possibly related: #1745, #1777

```
package;

import openfl.display.Sprite;
import openfl.events.Event;
import openfl.events.MouseEvent;

class Main extends Sprite {
	
	public function new () {
		
		super ();
		
		if (stage != null){
			init();
		} else {
			addEventListener(Event.ADDED_TO_STAGE, init);
		}
		
	}
	
	private function init(?evt:Event) {
	
		removeEventListener(Event.ADDED_TO_STAGE, init);
		
		var parentSprite:Sprite = new Sprite();
		
		parentSprite.graphics.beginFill(0xF1A783, 1);
		parentSprite.graphics.lineTo(200, 0);
		parentSprite.graphics.lineTo(200, 200);
		parentSprite.graphics.lineTo(0, 200);
		parentSprite.graphics.lineTo(0, 0);
		parentSprite.graphics.endFill();
		
		parentSprite.x = 100;
		parentSprite.y = 100;
		
		parentSprite.name = 'parentSprite';
		
		parentSprite.addEventListener(MouseEvent.CLICK, onClick );
		
		var child1:Sprite = new Sprite();
		
		child1.graphics.beginFill(0x7BF995, 0.5);
		child1.graphics.lineTo(100, 0);
		child1.graphics.lineTo(100, 100);
		child1.graphics.lineTo(0, 100);
		child1.graphics.lineTo(0, 0);
		child1.graphics.endFill();
		
		child1.x = 25;
		child1.y = 25;
		
		child1.name = 'child1';
		
		var child2:Sprite = new Sprite();
		
		child2.graphics.beginFill(0x84BAF0, 0.5);
		child2.graphics.lineTo(100, 0);
		child2.graphics.lineTo(100, 100);
		child2.graphics.lineTo(0, 100);
		child2.graphics.lineTo(0, 0);
		child2.graphics.endFill();
		
		child2.x = 75;
		child2.y = 75;
		
		child2.name = 'child2';
		
		child2.mouseEnabled = child2.mouseChildren = false;

		parentSprite.addChild(child1);
		parentSprite.addChild(child2);
		addChild(parentSprite);
		
	}
	
	function onClick(evt:MouseEvent) {
		
		trace('${cast(evt.target, Sprite).name} is clicked');
		
	}
	
}
```