### PR TITLE
Copy colorTransform instead if setting it.

### DIFF
--- a/src/openfl/geom/Transform.hx
+++ b/src/openfl/geom/Transform.hx
@@ -72,7 +72,7 @@ class Transform {
 		
 		if (!__colorTransform.__equals (value)) {
 			
-			__colorTransform = value;
+			__colorTransform.__copyFrom (value);
 			
 			if (value != null) {
 				


### PR DESCRIPTION
Copy colorTransform instead if setting it. By setting it by reference, when changed outside and set again, `__displayObject` won't get dirty since `__colorTransform` and the `value` refer to the same object and `!__colorTransform.__equals (value)` will never be true. 

An example: Try to use Actuate's transform tween to tween a colors.