### PR TITLE
Font metrics in html5

### DIFF
--- a/src/externs/core/openfl/openfl/text/Font.hx
+++ b/src/externs/core/openfl/openfl/text/Font.hx
@@ -76,6 +76,13 @@ extern class Font extends LimeFont {
 	public static function registerFont (font:Class<Dynamic>):Void;
 	
 	
+	/**
+	 * Registers a font instance in the global font list.
+	 *
+	 */
+	public static function registerFontInstance (instance:Font):Void;
+	
+	
 }
 
 

--- a/src/openfl/_internal/text/TextEngine.hx
+++ b/src/openfl/_internal/text/TextEngine.hx
@@ -194,7 +194,11 @@ class TextEngine {
 	
 	private static function findFont (name:String):Font {
 		
-		#if (lime_cffi)
+		#if (js && html5)
+		
+		return Font.__fontByName[name];
+		
+		#elseif (lime_cffi)
 		
 		for (registeredFont in Font.__registeredFonts) {
 			
@@ -234,6 +238,7 @@ class TextEngine {
 		var bold = format.bold;
 		var italic = format.italic;
 		
+		if (fontName == null) fontName = "_serif";
 		var fontNamePrefix = StringTools.replace (StringTools.replace (fontName, " Normal", ""), " Regular", "");
 		
 		if (bold && italic && Font.__fontByName.exists (fontNamePrefix + " Bold Italic")) {
@@ -269,25 +274,11 @@ class TextEngine {
 		
 		var ascent:Float, descent:Float, leading:Int;
 		
+		#if (js && html5 || lime_cffi)
+		
 		#if (js && html5)
-		
 		__context.font = getFont (format);
-
-		if (format.__ascent != null) {
-
-			ascent = format.size * format.__ascent;
-			descent = format.size * format.__descent;
-
-		} else {
-			
-			ascent = format.size;
-			descent = format.size * 0.185;
-			
-		}
-		
-		leading = format.leading;
-		
-		#elseif (lime_cffi)
+		#end
 		
 		var font = getFontInstance (format);
 		
@@ -296,7 +287,7 @@ class TextEngine {
 			ascent = format.size * format.__ascent;
 			descent = format.size * format.__descent;
 
-		} else if (font != null) {
+		} else if (font != null && font.unitsPerEM != null) { // font metrics might be missing in html5
 
 			ascent = (font.ascender / font.unitsPerEM) * format.size;
 			descent = Math.abs ((font.descender / font.unitsPerEM) * format.size);
@@ -386,7 +377,11 @@ class TextEngine {
 	
 	public static function getFontInstance (format:TextFormat):Font {
 		
-		#if (lime_cffi)
+		#if (js && html5)
+		
+		return findFontVariant (format);
+		
+		#elseif (lime_cffi)
 		
 		var instance = null;
 		var fontList = null;
@@ -1029,27 +1024,11 @@ class TextEngine {
 				formatRange = textFormatRanges[rangeIndex];
 				currentFormat.__merge (formatRange.format);
 				
+				#if (js && html5 || lime_cffi)
+				
 				#if (js && html5)
-				
 				__context.font = getFont (currentFormat);
-				
-				if (currentFormat.__ascent != null) {
-					
-					ascent = currentFormat.size * currentFormat.__ascent;
-					descent = currentFormat.size * currentFormat.__descent;
-					
-				} else {
-					
-					ascent = currentFormat.size;
-					descent = currentFormat.size * 0.185;
-					
-				}
-				
-				leading = currentFormat.leading;
-				
-				heightValue = ascent + descent + leading;
-				
-				#elseif (lime_cffi)
+				#end
 				
 				font = getFontInstance (currentFormat);
 				
@@ -1058,7 +1037,7 @@ class TextEngine {
 					ascent = currentFormat.size * currentFormat.__ascent;
 					descent = currentFormat.size * currentFormat.__descent;
 					
-				} else if (font != null) {
+				} else if (font != null && font.unitsPerEM != null) { // font metrics might be missing in html5
 					
 					ascent = (font.ascender / font.unitsPerEM) * currentFormat.size;
 					descent = Math.abs ((font.descender / font.unitsPerEM) * currentFormat.size);

--- a/src/openfl/text/Font.hx
+++ b/src/openfl/text/Font.hx
@@ -121,6 +121,12 @@ class Font extends LimeFont {
 	public static function registerFont (font:Class<Dynamic>) {
 		
 		var instance = cast (Type.createInstance (font, []), Font);
+		registerFontInstance(instance);
+		
+	}
+	
+	
+	public static function registerFontInstance (instance:Font) {
 		
 		if (instance != null) {
 			


### PR DESCRIPTION
The lack of font metrics in html5 is reponsible for at least two serious issues (#908, #1801). Unfortunately, there doesn't seem to be a reliable method to get font metrics in html5, especially if we want to support webfonts of any format added dynamically at runtime outside our control.

This PR mitigates this issue by:
 1. making font metrics automatically available for fonts known at build time
 2. allowing the developer to manually add font metrics for dynamically embedded fonts

In both cases, font metrics are used to solve both #908, #1801. If not available, the bahaviour stays the same as before. The changes also make it simple to add automated font metric computation in the future, if some reliable method is found.

Detailed summary of the changes (for both openfl and lime):

- font metric properties of `lime.text.font` are now writeable
- for fonts known at build time, font metrics are automatically made available by setting the properties in the generated `__ASSET__*` classes in `ManifestResources.hx`.

- added `openfl.text.Font.registerFontInstance`, allowing to manually add metrics for fonts not known at build time, as follows:  (also demonstrated in this [demo](http://chatziko.github.io/firefox-workaround/Export/html5/bin/))

      var font = new Font(fontName);
      font.ascender = 600;
      font.ascender = 500;
      font.unitsPerEM = 1000;
      Fonts.registerFontInstance(font);

- if font metrics are available:
  * `TextEngine` uses them to properly compute `textHeight` (fixes #908). As a bonus, this makes the corresponding methods quasi-identical for html5 and lime_cffi, so less `#if`s.

  * `CanvasTextField` uses them to correctly position text in Firefox (fixes #1801).

- if in the future we find a way to compute metrics automatically for web fonts, we can just add it to `lime.text.Font` and they'll be used automatically for the above purposes.

**Note:** the corresponding lime PR openfl/lime#1152 needs to be merged at the same time.




