### PR TITLE
Static init functions code need to be attribuable to their class

### DIFF
--- a/src/externs/core/openfl/openfl/Vector.hx
+++ b/src/externs/core/openfl/openfl/Vector.hx
@@ -2114,6 +2114,12 @@ abstract Vector<T>(VectorData<T>) from VectorData<T> {
 	
 	private static function __init__ () {
 		
+		__stub__();
+		
+	}
+	
+	private static function __stub__() {
+		
 		untyped __js__ ("var prefix = (typeof openfl_VectorData !== 'undefined');
 		var ref = (prefix ? openfl_VectorData : VectorData);
 		var p = ref.prototype;

--- a/src/openfl/Vector.hx
+++ b/src/openfl/Vector.hx
@@ -2114,6 +2114,12 @@ abstract Vector<T>(VectorData<T>) from VectorData<T> {
 	
 	private static function __init__ () {
 		
+		__stub__();
+		
+	}
+	
+	private static function __stub__() {
+		
 		untyped __js__ ("var prefix = (typeof openfl_VectorData !== 'undefined');
 		var ref = (prefix ? openfl_VectorData : VectorData);
 		var p = ref.prototype;

--- a/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -66,13 +66,9 @@ class CanvasGraphics {
 	
 	#if (js && html5)
 	private static function __init__ ():Void {
-		
-		if (Browser.supported) {
 			
-			hitTestCanvas = cast Browser.document.createElement ("canvas");
-			hitTestContext = hitTestCanvas.getContext ("2d");
-			
-		}
+		hitTestCanvas = Browser.supported ? cast Browser.document.createElement ("canvas") : null;
+		hitTestContext = Browser.supported ? hitTestCanvas.getContext ("2d") : null;
 		
 	}
 	#end


### PR DESCRIPTION
Once generated to JS, code from `__init__` needs to look like:
```
com_Foo.staticProp = initialValue;
com_Foo.doStaticInit();
if (Array.prototype.indexOf == undefined) {
   // some init code attributed to Array
}
```
Code analysis is broken by `__init__` code like:
```
if (typeof window != "undefined") {
   // one or more lines of static init logic
}
var foo = [1,2,3];
com_Foo.staticProp = foo;
```