### PR TITLE
Fixed event-bubbling of DisplayObject

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -417,7 +417,12 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	
 	private override function __dispatchEvent (event:Event):Bool {
-		
+		var tmpParent = null;
+
+		if (event.bubbles) {
+			tmpParent = parent;
+		}
+
 		var result = super.__dispatchEvent (event);
 		
 		if (event.__isCanceled) {
@@ -426,7 +431,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 		}
 		
-		if (event.bubbles && parent != null && parent != this) {
+		if (tmpParent != null && tmpParent != this) {
 			
 			event.eventPhase = EventPhase.BUBBLING_PHASE;
 			
@@ -436,7 +441,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 				
 			}
 			
-			parent.__dispatchEvent (event);
+			tmpParent.__dispatchEvent (event);
 			
 		}
 		


### PR DESCRIPTION
It may happen that 
`var result = super.__dispatchEvent (event);`
causes the parent to be removed.
By storing it temporarily we can continue bubbling, just as in flash.