### PR TITLE
reset the __worldTransformInvalid flag on __update

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -664,7 +664,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 
 				current = list[i];
 				current.__update (true, false);
-				current.__worldTransformInvalid = false;
 
 			}
 				
@@ -1011,6 +1010,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 		//}
 		
+		__worldTransformInvalid = false;
+
 		if (!transformOnly) {
 			
 			if (__supportDOM) {


### PR DESCRIPTION
this can e.g. save some milliseconds in `__hitTest` when dragging stuff, because before `__update` would update all the transforms without resetting the flag, so `__getWorldTransform` would call `__update` again