### PR TITLE
don't do redundant child traversing in DisplayObjectContainer/SimpleButton.__getFilterBounds

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -83,7 +83,7 @@ class Bitmap extends DisplayObject {
 	}
 	
 	
-	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
+	private override function __getOwnBounds (rect:Rectangle, matrix:Matrix):Void {
 		
 		if (__bitmapData != null) {
 			

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -540,13 +540,20 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	}
 	
 	
-	private function __getBounds (rect:Rectangle, matrix:Matrix):Void {
+	private function __getOwnBounds (rect:Rectangle, matrix:Matrix):Void {
 		
 		if (__graphics != null) {
 			
 			__graphics.__getBounds (rect, matrix);
 			
 		}
+		
+	}
+	
+	
+	private function __getBounds (rect:Rectangle, matrix:Matrix):Void {
+		
+		__getOwnBounds (rect, matrix);
 		
 	}
 	
@@ -562,7 +569,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		// TODO: Should this be __getRenderBounds, to account for scrollRect?
 		
-		__getBounds (rect, matrix);
+		__getOwnBounds (rect, matrix);
 		
 		if (__filters != null && __filters.length > 0) {
 			
@@ -612,7 +619,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (__scrollRect == null) {
 			
-			__getBounds (rect, matrix);
+			__getOwnBounds (rect, matrix);
 			
 		} else {
 			

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -399,7 +399,7 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
 		
-		super.__getBounds (rect, matrix);
+		__getOwnBounds (rect, matrix);
 		
 		if (__children.length == 0) return;
 		
@@ -466,7 +466,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		} else {
 			
-			super.__getBounds (rect, matrix);
+			__getOwnBounds (rect, matrix);
 			
 		}
 		

--- a/src/openfl/display/SimpleButton.hx
+++ b/src/openfl/display/SimpleButton.hx
@@ -133,7 +133,7 @@ class SimpleButton extends InteractiveObject {
 	
 	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
 		
-		super.__getBounds (rect, matrix);
+		__getOwnBounds (rect, matrix);
 		
 		if (matrix != null) {
 			
@@ -163,7 +163,7 @@ class SimpleButton extends InteractiveObject {
 			
 		} else {
 			
-			super.__getBounds (rect, matrix);
+			__getOwnBounds (rect, matrix);
 			
 		}
 		

--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -299,7 +299,7 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	
 	
 	#if !flash
-	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
+	private override function __getOwnBounds (rect:Rectangle, matrix:Matrix):Void {
 		
 		var bounds = Rectangle.__pool.get ();
 		bounds.setTo (0, 0, __width, __height);

--- a/src/openfl/media/Video.hx
+++ b/src/openfl/media/Video.hx
@@ -115,7 +115,7 @@ class Video extends DisplayObject {
 	}
 	
 	
-	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
+	private override function __getOwnBounds (rect:Rectangle, matrix:Matrix):Void {
 		
 		var bounds = Rectangle.__pool.get ();
 		bounds.setTo (0, 0, __width, __height);

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1149,7 +1149,7 @@ class TextField extends InteractiveObject {
 	}
 	
 	
-	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
+	private override function __getOwnBounds (rect:Rectangle, matrix:Matrix):Void {
 		
 		__updateLayout ();
 		


### PR DESCRIPTION
This extracts the functionality to get actual graphics/bitmap boundaries from `__getBounds` into `__getOwnBounds` method.

It saves some CPU time when moving `cacheAsBitmap`'d sprites, because before `DisplayObjectContainer.__getFilterBounds` (called by `__updateCacheBitmap`) would call `__getBounds`, which is overriden to traverse all the children, and then traverse the children again to call `__getFilterBounds` on them. Now it just calls the `__getOwnBounds` to get rid of the first traversal.

PS I also changed `__getRenderBounds` in the same way, although I haven't found any actual usages of that function...