### PR TITLE
Allow drawing rectangles with negative size

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -607,10 +607,13 @@ import js.html.CanvasRenderingContext2D;
 	
 	public function drawRect (x:Float, y:Float, width:Float, height:Float):Void {
 		
-		if (width <= 0 || height <= 0) return;
+		if(width == 0 && height == 0) return;
 		
-		__inflateBounds (x - __strokePadding, y - __strokePadding);
-		__inflateBounds (x + width + __strokePadding, y + height + __strokePadding);
+		var xSign = width < 0 ? -1 : 1;
+		var ySign = height < 0 ? -1 : 1;
+		
+		__inflateBounds (x - __strokePadding * xSign, y - __strokePadding * ySign);
+		__inflateBounds (x + width + __strokePadding * xSign, y + height + __strokePadding * ySign);
 		
 		__commands.drawRect (x, y, width, height);
 		
@@ -621,10 +624,13 @@ import js.html.CanvasRenderingContext2D;
 	
 	public function drawRoundRect (x:Float, y:Float, width:Float, height:Float, ellipseWidth:Float, ellipseHeight:Null<Float> = null):Void {
 		
-		if (width <= 0 || height <= 0) return;
+		if(width == 0 && height == 0) return;
 		
-		__inflateBounds (x - __strokePadding, y - __strokePadding);
-		__inflateBounds (x + width + __strokePadding, y + height + __strokePadding);
+		var xSign = width < 0 ? -1 : 1;
+		var ySign = height < 0 ? -1 : 1;
+		
+		__inflateBounds (x - __strokePadding * xSign, y - __strokePadding * ySign);
+		__inflateBounds (x + width + __strokePadding * xSign, y + height + __strokePadding * ySign);
 		
 		__commands.drawRoundRect (x, y, width, height, ellipseWidth, ellipseHeight);
 		
@@ -635,7 +641,7 @@ import js.html.CanvasRenderingContext2D;
 	
 	public function drawRoundRectComplex (x:Float, y:Float, width:Float, height:Float, topLeftRadius:Float, topRightRadius:Float, bottomLeftRadius:Float, bottomRightRadius:Float):Void {
 		
-		if (width <= 0 || height <= 0) return;
+		if(width <= 0 || height <= 0) return;
 		
 		__inflateBounds (x - __strokePadding, y - __strokePadding);
 		__inflateBounds (x + width + __strokePadding, y + height + __strokePadding);


### PR DESCRIPTION
Flash works this way. The only time nothing is drawn is when both width and height are equal to zero.

Drawing with positive x and y, negative x and y, and a mix of the two all have the same behavior for flash, cairo, and canvas.

drawRoundRectComplex has its own kind of odd behavior when negative dimensions are used, and even seems to ignore the additional arguments when that happens. I've left it alone.