### PR TITLE
DisplayObjectContainer/SimpleButton.__get*Bounds rework

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1390,6 +1390,17 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 	}
 	
+	private static inline function __calculateAbsoluteTransform (local:Matrix, parentTransform:Matrix, target:Matrix):Void {
+		
+		target.a = local.a * parentTransform.a + local.b * parentTransform.c;
+		target.b = local.a * parentTransform.b + local.b * parentTransform.d;
+		target.c = local.c * parentTransform.a + local.d * parentTransform.c;
+		target.d = local.c * parentTransform.b + local.d * parentTransform.d;
+		target.tx = local.tx * parentTransform.a + local.ty * parentTransform.c + parentTransform.tx;
+		target.ty = local.tx * parentTransform.b + local.ty * parentTransform.d + parentTransform.ty;
+		
+	}
+	
 	
 	private function __updateTransforms (overrideTransform:Matrix = null):Void {
 		
@@ -1409,18 +1420,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		}
 		
 		var renderParent = __renderParent != null ? __renderParent : parent;
-		var parentTransform;
 		
 		if (!overrided && parent != null) {
 			
-			parentTransform = parent.__worldTransform;
-			
-			__worldTransform.a = local.a * parentTransform.a + local.b * parentTransform.c;
-			__worldTransform.b = local.a * parentTransform.b + local.b * parentTransform.d;
-			__worldTransform.c = local.c * parentTransform.a + local.d * parentTransform.c;
-			__worldTransform.d = local.c * parentTransform.b + local.d * parentTransform.d;
-			__worldTransform.tx = local.tx * parentTransform.a + local.ty * parentTransform.c + parentTransform.tx;
-			__worldTransform.ty = local.tx * parentTransform.b + local.ty * parentTransform.d + parentTransform.ty;
+			__calculateAbsoluteTransform (local, parent.__worldTransform, __worldTransform);
 			
 		} else {
 			
@@ -1430,14 +1433,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (!overrided && renderParent != null) {
 			
-			parentTransform = renderParent.__renderTransform;
-			
-			__renderTransform.a = local.a * parentTransform.a + local.b * parentTransform.c;
-			__renderTransform.b = local.a * parentTransform.b + local.b * parentTransform.d;
-			__renderTransform.c = local.c * parentTransform.a + local.d * parentTransform.c;
-			__renderTransform.d = local.c * parentTransform.b + local.d * parentTransform.d;
-			__renderTransform.tx = local.tx * parentTransform.a + local.ty * parentTransform.c + parentTransform.tx;
-			__renderTransform.ty = local.tx * parentTransform.b + local.ty * parentTransform.d + parentTransform.ty;
+			__calculateAbsoluteTransform (local, renderParent.__renderTransform, __renderTransform);
 			
 		} else {
 			

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -408,6 +408,18 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	}
 	
 	
+	private static inline function __calculateAbsoluteTransform (local:Matrix, parentTransform:Matrix, target:Matrix):Void {
+		
+		target.a = local.a * parentTransform.a + local.b * parentTransform.c;
+		target.b = local.a * parentTransform.b + local.b * parentTransform.d;
+		target.c = local.c * parentTransform.a + local.d * parentTransform.c;
+		target.d = local.c * parentTransform.b + local.d * parentTransform.d;
+		target.tx = local.tx * parentTransform.a + local.ty * parentTransform.c + parentTransform.tx;
+		target.ty = local.tx * parentTransform.b + local.ty * parentTransform.d + parentTransform.ty;
+		
+	}
+	
+	
 	private function __cleanup ():Void {
 		
 		__cairo = null;
@@ -1387,17 +1399,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			__graphics.__getBounds (maskGraphics.__bounds, @:privateAccess Matrix.__identity);
 			
 		}
-		
-	}
-	
-	private static inline function __calculateAbsoluteTransform (local:Matrix, parentTransform:Matrix, target:Matrix):Void {
-		
-		target.a = local.a * parentTransform.a + local.b * parentTransform.c;
-		target.b = local.a * parentTransform.b + local.b * parentTransform.d;
-		target.c = local.c * parentTransform.a + local.d * parentTransform.c;
-		target.d = local.c * parentTransform.b + local.d * parentTransform.d;
-		target.tx = local.tx * parentTransform.a + local.ty * parentTransform.c + parentTransform.tx;
-		target.ty = local.tx * parentTransform.b + local.ty * parentTransform.d + parentTransform.ty;
 		
 	}
 	

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -24,6 +24,7 @@ import openfl.Vector;
 @:access(openfl.display.Graphics)
 @:access(openfl.errors.Error)
 @:access(openfl.geom.Point)
+@:access(openfl.geom.Matrix)
 @:access(openfl.geom.Rectangle)
 
 
@@ -402,27 +403,20 @@ class DisplayObjectContainer extends InteractiveObject {
 		super.__getBounds (rect, matrix);
 		
 		if (__children.length == 0) return;
-		
-		if (matrix != null) {
 			
-			__updateTransforms (matrix);
-			__updateChildren (true);
-			
-		}
+		var childWorldTransform = Matrix.__pool.get();
 		
 		for (child in __children) {
 			
 			if (child.__scaleX == 0 || child.__scaleY == 0) continue;
-			child.__getBounds (rect, child.__worldTransform);
+			
+			DisplayObject.__calculateAbsoluteTransform (child.__transform, matrix, childWorldTransform);
+			
+			child.__getBounds (rect, childWorldTransform);
 			
 		}
 		
-		if (matrix != null) {
-			
-			__updateTransforms ();
-			__updateChildren (true);
-			
-		}
+		Matrix.__pool.release(childWorldTransform);
 		
 	}
 	
@@ -433,26 +427,19 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (__children.length == 0) return;
 		
-		if (matrix != null) {
-			
-			__updateTransforms (matrix);
-			__updateChildren (true);
-			
-		}
+		var childWorldTransform = Matrix.__pool.get();
 		
 		for (child in __children) {
 			
 			if (child.__scaleX == 0 || child.__scaleY == 0 || child.__isMask) continue;
-			child.__getFilterBounds (rect, child.__worldTransform);
+
+			DisplayObject.__calculateAbsoluteTransform (child.__transform, matrix, childWorldTransform);
+
+			child.__getFilterBounds (rect, childWorldTransform);
 			
 		}
 		
-		if (matrix != null) {
-			
-			__updateTransforms ();
-			__updateChildren (true);
-			
-		}
+		Matrix.__pool.release(childWorldTransform);
 		
 	}
 	
@@ -472,26 +459,19 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (__children.length == 0) return;
 		
-		if (matrix != null) {
-			
-			__updateTransforms (matrix);
-			__updateChildren (true);
-			
-		}
+		var childWorldTransform = Matrix.__pool.get();
 		
 		for (child in __children) {
 			
 			if (child.__scaleX == 0 || child.__scaleY == 0 || child.__isMask) continue;
-			child.__getRenderBounds (rect, child.__worldTransform);
+			
+			DisplayObject.__calculateAbsoluteTransform (child.__transform, matrix, childWorldTransform);
+			
+			child.__getRenderBounds (rect, childWorldTransform);
 			
 		}
 		
-		if (matrix != null) {
-			
-			__updateTransforms ();
-			__updateChildren (true);
-			
-		}
+		Matrix.__pool.release(childWorldTransform);
 		
 	}
 	

--- a/src/openfl/display/SimpleButton.hx
+++ b/src/openfl/display/SimpleButton.hx
@@ -135,21 +135,13 @@ class SimpleButton extends InteractiveObject {
 		
 		super.__getBounds (rect, matrix);
 		
-		if (matrix != null) {
-			
-			__updateTransforms (matrix);
-			__updateChildren (true);
-			
-		}
+		var childWorldTransform = Matrix.__pool.get();
 		
-		__currentState.__getBounds (rect, __currentState.__worldTransform);
+		DisplayObject.__calculateAbsoluteTransform (__currentState.__transform, matrix, childWorldTransform);
 		
-		if (matrix != null) {
-			
-			__updateTransforms ();
-			__updateChildren (true);
-			
-		}
+		__currentState.__getBounds (rect, childWorldTransform);
+		
+		Matrix.__pool.release(childWorldTransform);
 		
 	}
 	
@@ -167,21 +159,13 @@ class SimpleButton extends InteractiveObject {
 			
 		}
 		
-		if (matrix != null) {
-			
-			__updateTransforms (matrix);
-			__updateChildren (true);
-			
-		}
+		var childWorldTransform = Matrix.__pool.get();
 		
-		__currentState.__getRenderBounds (rect, __currentState.__worldTransform);
+		DisplayObject.__calculateAbsoluteTransform (__currentState.__transform, matrix, childWorldTransform);
 		
-		if (matrix != null) {
-			
-			__updateTransforms ();
-			__updateChildren (true);
-			
-		}
+		__currentState.__getRenderBounds (rect, childWorldTransform);
+		
+		Matrix.__pool.release(childWorldTransform);
 		
 	}
 	


### PR DESCRIPTION
This is another take on optimizing `DisplayObjectContainer`'s `__getFilterBounds` (used by `__updateCacheBitmap`), as well as the normal `__getBounds` (which are basically the same).

Before, the `get*Bounds` function would temporarily set current object's `__worldTransform` to the given matrix and recursively update its children, and then reset everything back, recalculating the transform and traversing the children again, which is again done by the children.

Now we calculate the child world transform matrix locally and pass it to recursive `__get*Bounds` calls without modifying any state and doing excessive traversal. This saves quite some CPU time, for example, when moving complex `cacheAsBitmap`d objects.