### PR TITLE
HTMLParser: workaround for Haxe 4 compatibility

### DIFF
--- a/src/openfl/_internal/text/HTMLParser.hx
+++ b/src/openfl/_internal/text/HTMLParser.hx
@@ -133,7 +133,8 @@ class HTMLParser {
 								
 								if (__regexAlign.match (segment)) {
 									
-									format.align = __getAttributeMatch (__regexAlign).toLowerCase ();
+									var align = __getAttributeMatch (__regexAlign).toLowerCase ();
+									format.align = align;
 									
 								}
 							


### PR DESCRIPTION
This applies the workaround mentioned in HaxeFoundation/haxe#6656 to restore Haxe 4 compatibility.