### PR TITLE
Graphics: fix beginShaderFill() extern signature

### DIFF
--- a/src/externs/core/openfl/openfl/display/Graphics.hx
+++ b/src/externs/core/openfl/openfl/display/Graphics.hx
@@ -149,7 +149,7 @@ import openfl.Vector;
 	public function beginGradientFill (type:GradientType, colors:Array<UInt>, alphas:Array<Float>, ratios:Array<Int>, matrix:Matrix = null, ?spreadMethod:SpreadMethod, ?interpolationMethod:InterpolationMethod, ?focalPointRatio:Float):Void;
 	
 	
-	public function beginShaderFill (shader:Shader, matrix:Matrix = null):Void;
+	public function beginShaderFill (shader:GraphicsShader, matrix:Matrix = null):Void;
 	
 	
 	/**


### PR DESCRIPTION
The extern suggests that a regular Shader can be passed, but this results in a compiler error:

```haxe
new openfl.display.Sprite().graphics.beginShaderFill(new openfl.display.Shader());
```

>openfl.display.Shader should be openfl.display.GraphicsShader