### PR TITLE
Fix completion for fields added by ShaderMacro

### DIFF
--- a/src/externs/core/openfl/openfl/display/Shader.hx
+++ b/src/externs/core/openfl/openfl/display/Shader.hx
@@ -3,6 +3,10 @@ package openfl.display; #if (display || !flash)
 
 import openfl.utils.ByteArray;
 
+#if !macro
+@:autoBuild(openfl._internal.macros.ShaderMacro.build())
+#end
+
 
 extern class Shader {
 	

--- a/src/externs/core/openfl/openfl/display/ShaderInput.hx
+++ b/src/externs/core/openfl/openfl/display/ShaderInput.hx
@@ -11,6 +11,7 @@ package openfl.display; #if (display || !flash)
 	public var height:Int;
 	public var index (default, null):Int;
 	public var input:T;
+	public var smoothing:Bool;
 	public var width:Int;
 	
 	

--- a/src/externs/extras/openfl/display/GraphicsShader.hx
+++ b/src/externs/extras/openfl/display/GraphicsShader.hx
@@ -1,8 +1,137 @@
 package openfl.display;
 
 
+import openfl.utils.ByteArray;
+
+
 extern class GraphicsShader extends Shader {
 	
+	@:glVertexHeader(
+		
+		"attribute float openfl_Alpha;
+		attribute vec4 openfl_ColorMultiplier;
+		attribute vec4 openfl_ColorOffset;
+		attribute vec4 openfl_Position;
+		attribute vec2 openfl_TexCoord;
+		
+		varying float openfl_vAlpha;
+		varying vec4 openfl_vColorMultiplier;
+		varying vec4 openfl_vColorOffset;
+		varying vec2 openfl_vTexCoord;
+		
+		uniform mat4 openfl_Matrix;
+		uniform bool openfl_HasColorTransform;"
+		
+	)
 	
+	
+	@:glVertexBody(
+		
+		"openfl_vAlpha = openfl_Alpha;
+		openfl_vTexCoord = openfl_TexCoord;
+		
+		if (openfl_HasColorTransform) {
+			
+			openfl_vColorMultiplier = openfl_ColorMultiplier;
+			openfl_vColorOffset = openfl_ColorOffset / 255.0;
+			
+		}
+		
+		gl_Position = openfl_Matrix * openfl_Position;"
+		
+	)
+	
+	
+	@:glVertexSource(
+		
+		"#pragma header
+		
+		void main(void) {
+			
+			#pragma body
+			
+		}"
+		
+	)
+	
+	
+	@:glFragmentHeader(
+		
+		"varying float openfl_vAlpha;
+		varying vec4 openfl_vColorMultiplier;
+		varying vec4 openfl_vColorOffset;
+		varying vec2 openfl_vTexCoord;
+		
+		uniform bool openfl_HasColorTransform;
+		uniform sampler2D bitmap;"
+		
+	)
+	
+	
+	@:glFragmentBody(
+		
+		"vec4 color = texture2D (bitmap, openfl_vTexCoord);
+		
+		if (color.a == 0.0) {
+			
+			gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0);
+			
+		} else if (openfl_HasColorTransform) {
+			
+			color = vec4 (color.rgb / color.a, color.a);
+			
+			mat4 colorMultiplier = mat4 (0);
+			colorMultiplier[0][0] = openfl_vColorMultiplier.x;
+			colorMultiplier[1][1] = openfl_vColorMultiplier.y;
+			colorMultiplier[2][2] = openfl_vColorMultiplier.z;
+			colorMultiplier[3][3] = openfl_vColorMultiplier.w;
+			
+			color = clamp (openfl_vColorOffset + (color * colorMultiplier), 0.0, 1.0);
+			
+			if (color.a > 0.0) {
+				
+				gl_FragColor = vec4 (color.rgb * color.a * openfl_vAlpha, color.a * openfl_vAlpha);
+				
+			} else {
+				
+				gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0);
+				
+			}
+			
+		} else {
+			
+			gl_FragColor = color * openfl_vAlpha;
+			
+		}"
+		
+	)
+	
+	
+	@:glFragmentSource(
+		
+		#if emscripten
+		"#pragma header
+		
+		void main(void) {
+			
+			#pragma body
+			
+			gl_FragColor = gl_FragColor.bgra;
+			
+		}"
+		#else
+		"#pragma header
+		
+		void main(void) {
+			
+			#pragma body
+			
+		}"
+		#end
+		
+	)
+
+	
+	public function new(code:ByteArray = null):Void;
 	
 }

--- a/src/openfl/_internal/macros/ShaderMacro.hx
+++ b/src/openfl/_internal/macros/ShaderMacro.hx
@@ -174,6 +174,7 @@ class ShaderMacro {
 				
 			}
 			
+			#if !display
 			for (field in fields) {
 				
 				switch (field.name) {
@@ -207,6 +208,7 @@ class ShaderMacro {
 				}
 				
 			}
+			#end
 			
 			fields = fields.concat (uniqueFields);
 			


### PR DESCRIPTION
The Shader extern needs to run ShaderMacro as well for this to work. Unfortunately, this currently requires duplicating all the shader sources. Would be helpful if both Shader.hx files could include the same external file instead.

According to --times, completion performance doesn't seem noticably impacted.