### PR TITLE
Fixes the htmltext getter

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1986,7 +1986,11 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 	
 	private function get_htmlText ():String {
 		
+		#if (js && html5)
+		return __isHTML ? __rawHtmlText : __text;
+		#else
 		return __text;
+		#end
 		
 	}
 	
@@ -2004,11 +2008,7 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 		__isHTML = true;
 		
 		#if (js && html5)
-		if (DisplayObject.__supportDOM) {
-			
-			__rawHtmlText = value;
-			
-		}
+		__rawHtmlText = value;
 		#end
 		
 		value = HTMLParser.parse(value, __textFormat, __textEngine.textFormatRanges);


### PR DESCRIPTION
Fixes the htmltext getter to return raw html. This is important if you edit html text like use it in expressions like ` tf.htmlText += someHtmlText`.