### PR TITLE
small filter check refactoring 

### DIFF
--- a/src/openfl/_internal/renderer/cairo/CairoTextField.hx
+++ b/src/openfl/_internal/renderer/cairo/CairoTextField.hx
@@ -224,7 +224,7 @@ class CairoTextField {
 					
 					var usedHack = false;
 					
-					if (textField.__filters != null && textField.__filters.length > 0) {
+					if (textField.__hasFilters ()) {
 						
 						// Hack, force outline
 						

--- a/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -215,7 +215,7 @@ class CanvasTextField {
 							
 						}
 						
-						if (textField.__filters != null && textField.__filters.length > 0) {
+						if (textField.__hasFilters ()) {
 							
 							// Hack, force outline
 							

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -316,7 +316,7 @@ class Bitmap extends DisplayObject {
 		
 		__setRenderDirty ();
 		
-		if (__filters != null && __filters.length > 0) {
+		if (__hasFilters ()) {
 			
 			//__updateFilters = true;
 			

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -264,7 +264,7 @@ class Bitmap extends DisplayObject {
 	
 	private override function __updateCacheBitmap (renderer:DisplayObjectRenderer, force:Bool):Bool {
 		
-		if (__filters == null) return false;
+		if (!__hasFilters ()) return false;
 		return super.__updateCacheBitmap (renderer, force);
 		
 	}

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -583,7 +583,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		__getBounds (rect, matrix);
 		
-		if (__filters != null && __filters.length > 0) {
+		if (__hasFilters ()) {
 			
 			var extension = Rectangle.__pool.get ();
 			
@@ -710,6 +710,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		}
 		
 		return local;
+		
+	}
+	
+	
+	private inline function __hasFilters ():Bool {
+		
+		return __filters != null && __filters.length > 0;
 		
 	}
 	
@@ -1157,7 +1164,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 			var needRender = (__cacheBitmap == null || (__renderDirty && (force || (__children != null && __children.length > 0) || (__graphics != null && __graphics.__dirty))) || opaqueBackground != __cacheBitmapBackground || !__cacheBitmapColorTransform.__equals (__worldColorTransform));
 			var updateTransform = (needRender || (!__cacheBitmap.__worldTransform.equals (__worldTransform)));
-			var hasFilters = (__filters != null && __filters.length > 0);
+			var hasFilters = __hasFilters ();
 			
 			if (hasFilters && !needRender) {
 				

--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -469,7 +469,7 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	
 	private override function __updateCacheBitmap (renderer:DisplayObjectRenderer, force:Bool):Bool {
 		
-		if (__filters == null) return false;
+		if (!__hasFilters ()) return false;
 		return super.__updateCacheBitmap (renderer, force);
 		
 	}


### PR DESCRIPTION
Originally I was fixing the usage of `filters` getter in `__updateCacheBitmap` in our OpenFL branch, but I see it's already also fixed in d2d85a526ada0120c66f749b5fb122bd97ae7959.

Although I also did some refactoring that extracts null+length check into a `__hasFilters` inline function instead of duplicating it all over the code, which might be useful. I also use that new function in `__updateCacheBitmap`s instead of just checking for null, which is more consistent with other places. And if we don't want the length check, we can now simply change this function, so I think it makes sense.