### PR TITLE
dispose texture+buffer in BitmapData.disposeImage, call disposeImage when re-rendering Graphics/TextField, delete previous buffer when recreating one for BitmapData

### DIFF
--- a/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -1253,6 +1253,10 @@ class CanvasGraphics {
 			
 			var width = graphics.__width;
 			var height = graphics.__height;
+
+			if (graphics.__bitmap != null) {
+				graphics.__bitmap.disposeImage ();
+			}
 			
 			if (!graphics.__visible || graphics.__commands.length == 0 || bounds == null || width < 1 || height < 1) {
 				

--- a/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -68,6 +68,10 @@ class CanvasTextField {
 			var width = graphics.__width;
 			var height = graphics.__height;
 			
+			if (graphics.__bitmap != null) {
+				graphics.__bitmap.disposeImage ();
+			}
+			
 			if (((textEngine.text == null || textEngine.text == "") && !textEngine.background && !textEngine.border && !textEngine.__hasFocus && (textEngine.type != INPUT || !textEngine.selectable)) || ((textEngine.width <= 0 || textEngine.height <= 0) && textEngine.autoSize != TextFieldAutoSize.NONE)) {
 				
 				textField.__graphics.__canvas = null;

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -505,6 +505,17 @@ class BitmapData implements IBitmapDrawable {
 		
 		readable = false;
 		
+		if (__texture != null) {
+			__textureContext.deleteTexture (__texture);
+			__texture = null;
+			__textureContext = null;
+		}
+		
+		if (__buffer != null) {
+			__bufferContext.deleteBuffer (__buffer);
+			__buffer = null;
+			__bufferContext = null;
+		}
 	}
 	
 	
@@ -916,6 +927,11 @@ class BitmapData implements IBitmapDrawable {
 			
 			// __bufferAlpha = alpha;
 			// __bufferColorTransform = colorTransform != null ? colorTransform.__clone () : null;
+			
+			if (__buffer != null) {
+				__bufferContext.deleteBuffer (__buffer);
+			}
+			
 			__bufferContext = gl;
 			__buffer = gl.createBuffer ();
 			


### PR DESCRIPTION
This will properly delete buffer/texture when re-rending TextField and Graphics, and will also dispose the old buffer when BitmapData buffer is re-created. This is good, because I don't think we can rely on GL resources being auto-freed on GC collection.