### PR TITLE
HTML5: buttonMode sets correct frame labels in MovieClip (_up, _over, _down)

### DIFF
--- a/src/externs/core/openfl/openfl/Vector.hx
+++ b/src/externs/core/openfl/openfl/Vector.hx
@@ -7,7 +7,7 @@ import openfl.utils.ByteArray;
 @:multiType(T)
 
 
-abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
+abstract Vector<T>(IVector<T>) {
 	
 	
 	public var fixed (get, set):Bool;
@@ -19,139 +19,138 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public inline function concat (?a:Vector<T>):Vector<T> {
 		
-		var data:IVector<T> = cast (a != null ? (a:AbstractVector<T>).data : null);
-		return cast new AbstractVector<T> (this.data.concat (data));
+		return cast this.concat (cast a);
 		
 	}
 	
 	
 	public inline function copy ():Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.copy ());
+		return cast this.copy ();
 		
 	}
 	
 	
 	@:arrayAccess public inline function get (index:Int):T {
 		
-		return cast this.data.get (index);
+		return this.get (index);
 		
 	}
 	
 	
 	public inline function indexOf (x:T, ?from:Int = 0):Int {
 		
-		return this.data.indexOf (x, from);
+		return this.indexOf (x, from);
 		
 	}
 	
 	
 	public inline function insertAt (index:Int, element:T):Void {
 		
-		this.data.insertAt (index, element);
+		this.insertAt (index, element);
 		
 	}
 	
 	
 	public inline function iterator<T> ():Iterator<T> {
 		
-		return cast this.data.iterator ();
+		return this.iterator ();
 		
 	}
 	
 	
 	public inline function join (sep:String = ","):String {
 		
-		return this.data.join (sep);
+		return this.join (sep);
 		
 	}
 	
 	
 	public inline function lastIndexOf (x:T, ?from:Int = 0):Int {
 		
-		return this.data.lastIndexOf (x, from);
+		return this.lastIndexOf (x, from);
 		
 	}
 	
 	
 	public inline function pop ():Null<T> {
 		
-		return cast this.data.pop ();
+		return this.pop ();
 		
 	}
 	
 	
 	public inline function push (x:T):Int {
 		
-		return this.data.push (x);
+		return this.push (x);
 		
 	}
 	
 	
 	public inline function removeAt (index:Int):T {
 		
-		return cast this.data.removeAt (index);
+		return this.removeAt (index);
 		
 	}
 	
 	
 	public inline function reverse ():Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.reverse ());
+		return cast this.reverse ();
 		
 	}
 	
 	
 	@:arrayAccess public inline function set (index:Int, value:T):T {
 		
-		return cast this.data.set (index, value);
+		return this.set (index, value);
 		
 	}
 	
 	
 	public inline function shift ():Null<T> {
 		
-		return cast this.data.shift ();
+		return this.shift ();
 		
 	}
 	
 	
 	public inline function slice (?pos:Int, ?end:Int):Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.slice (pos, end));
+		return cast this.slice (pos, end);
 		
 	}
 	
 	
 	public inline function sort (f:T->T->Int):Void {
 		
-		this.data.sort (f);
+		this.sort (f);
 		
 	}
 	
 	
 	public inline function splice (pos:Int, len:Int):Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.splice (pos, len));
+		return cast this.splice (pos, len);
 		
 	}
 	
 	
 	public inline function toString ():String {
 		
-		return (this != null && this.data != null) ? this.data.toString () : null;
+		return this != null ? this.toString () : null;
 		
 	}
 	
 	
 	public inline function unshift (x:T):Void {
 		
-		this.data.unshift (x);
+		this.unshift (x);
 		
 	}
 	
 	
-	public inline static function ofArray<T> (a:Array<T>):Vector<T> {
+	@:generic public inline static function ofArray<T> (a:Array<T>):Vector<T> {
 		
 		var vector = new Vector<T> ();
 		
@@ -166,46 +165,83 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	}
 	
 	
-	public inline static function convert<T,U> (v:AbstractVector<T>):AbstractVector<U> {
+	public inline static function convert<T,U> (v:IVector<T>):IVector<U> {
 		
 		return cast v;
 		
 	}
 	
 	
-	@:to static #if (!js && !flash) inline #end function toBoolVector<T:Bool> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toBoolVector<T:Bool> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):BoolVector {
 		
-		return new AbstractVector<T> (cast new BoolVector (length, fixed), array);
-		
-	}
-	
-	
-	@:to static #if (!js && !flash) inline #end function toIntVector<T:Int> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
-		
-		return new AbstractVector<T> (cast new IntVector (length, fixed), array);
+		return new BoolVector (length, fixed, cast array);
 		
 	}
 	
 	
-	@:to static #if (!js && !flash) inline #end function toFloatVector<T:Float> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toIntVector<T:Int> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):IntVector {
 		
-		return new AbstractVector<T> (cast new FloatVector (length, fixed), array);
+		return new IntVector (length, fixed, cast array);
+		
+	}
+	
+	
+	@:to static #if (!js && !flash) inline #end function toFloatVector<T:Float> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):FloatVector {
+		
+		return new FloatVector (length, fixed, cast array);
 		
 	}
 	
 	
 	#if !cs
-	@:to static #if (!js && !flash) inline #end function toFunctionVector<T:Function> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toFunctionVector<T:Function> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):FunctionVector {
 		
-		return new AbstractVector<T> (cast new FunctionVector (length, fixed), array);
+		return new FunctionVector (length, fixed, cast array);
 		
 	}
 	#end
 	
 	
-	@:to static #if (!js && !flash) inline #end function toObjectVector<T> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toObjectVector<T:{}> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):ObjectVector<T> {
 		
-		return cast new AbstractVector<T> (cast new ObjectVector<T> (length, fixed), array);
+		return new ObjectVector<T> (length, fixed, cast array);
+		
+	}
+	
+	
+	@:from static inline function fromBoolVector<T> (vector:BoolVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	
+	
+	@:from static inline function fromIntVector<T> (vector:IntVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	
+	
+	@:from static inline function fromFloatVector<T> (vector:FloatVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	
+	
+	#if !cs
+	@:from static inline function fromFunctionVector<T:Function> (vector:FunctionVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	#end
+	
+	
+	@:from static inline function fromObjectVector<T> (vector:ObjectVector<T>):Vector<T> {
+		
+		return cast vector;
 		
 	}
 	
@@ -219,78 +255,28 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	@:noCompletion private inline function get_fixed ():Bool {
 		
-		return this.data.fixed;
+		return this.fixed;
 		
 	}
 	
 	
 	@:noCompletion private inline function set_fixed (value:Bool):Bool {
 		
-		return this.data.fixed = value;
+		return this.fixed = value;
 		
 	}
 	
 	
 	@:noCompletion private inline function get_length ():Int {
 		
-		return this.data.length;
+		return this.length;
 		
 	}
 	
 	
 	@:noCompletion private inline function set_length (value:Int):Int {
 		
-		return this.data.length = value;
-		
-	}
-	
-	
-}
-
-
-
-
-#if !openfl_debug
-@:fileXml('tags="haxe,release"')
-@:noDebug
-#end
-
-
-// Wrap sub-types in a common wrapper to allow
-// for Vector<T> to Vector<Dynamic> conversion
-// while retaining the underlying type
-
-@:dox(hide) private class AbstractVector<T> {
-	
-	
-	public var data:IVector<T>;
-	
-	
-	public function new (data:IVector<T>, ?array:Array<T>) {
-		
-		this.data = data;
-		
-		if (array != null) {
-			
-			var cacheFixed = data.fixed;
-			data.fixed = false;
-			
-			for (i in 0...array.length) {
-				
-				data.set (i, cast array[i]);
-				
-			}
-			
-			data.fixed = cacheFixed;
-			
-		}
-		
-	}
-	
-	
-	@:noCompletion @:keep private function toJSON () {
-		
-		return @:privateAccess data.toJSON ();
+		return this.length = value;
 		
 	}
 	
@@ -317,15 +303,10 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public function new (?length:Int, ?fixed:Bool, ?array:Array<Bool>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Bool> ();
-			
-		}
-		
+		if (array == null) array = new Array ();
 		__array = array;
 		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -642,17 +623,12 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	private var __array:Array<Float>;
 	
 	
-	public function new (?length:Int, ?fixed:Bool, ?array:Array<Float>):Void {
+	public function new (?length:Int, ?fixed:Bool, ?array:Array<Dynamic>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Float> ();
-			
-		}
+		__array = new Array ();
+		if (array != null) for (i in 0...array.length) __array[i] = array[i];
 		
-		__array = array;
-		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -964,15 +940,10 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public function new (?length:Int, ?fixed:Bool, ?array:Array<Function>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Function> ();
-			
-		}
-		
+		if (array == null) array = new Array ();
 		__array = array;
 		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -1292,15 +1263,10 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public function new (?length:Int, ?fixed:Bool, ?array:Array<Int>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Int> ();
-			
-		}
-		
+		if (array == null) array = new Array ();
 		__array = array;
 		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -1609,17 +1575,12 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	private var __array:Array<T>;
 	
 	
-	public function new (?length:Int, ?fixed:Bool, ?array:Array<T>):Void {
+	public function new (?length:Int, ?fixed:Bool, ?array:Array<Dynamic>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<T> ();
-			
-		}
+		__array = new Array ();
+		if (array != null) for (i in 0...array.length) __array[i] = array[i];
 		
-		__array = array;
-		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -1937,8 +1898,6 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	public function splice (pos:Int, len:Int):IVector<T>;
 	public function toString ():String;
 	public function unshift (x:T):Void;
-	
-	@:noCompletion private function toJSON ():Dynamic;
 	
 }
 

--- a/src/openfl/Vector.hx
+++ b/src/openfl/Vector.hx
@@ -7,7 +7,7 @@ import openfl.utils.ByteArray;
 @:multiType(T)
 
 
-abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
+abstract Vector<T>(IVector<T>) {
 	
 	
 	public var fixed (get, set):Bool;
@@ -19,139 +19,138 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public inline function concat (?a:Vector<T>):Vector<T> {
 		
-		var data:IVector<T> = cast (a != null ? (a:AbstractVector<T>).data : null);
-		return cast new AbstractVector<T> (this.data.concat (data));
+		return cast this.concat (cast a);
 		
 	}
 	
 	
 	public inline function copy ():Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.copy ());
+		return cast this.copy ();
 		
 	}
 	
 	
 	@:arrayAccess public inline function get (index:Int):T {
 		
-		return cast this.data.get (index);
+		return this.get (index);
 		
 	}
 	
 	
 	public inline function indexOf (x:T, ?from:Int = 0):Int {
 		
-		return this.data.indexOf (x, from);
+		return this.indexOf (x, from);
 		
 	}
 	
 	
 	public inline function insertAt (index:Int, element:T):Void {
 		
-		this.data.insertAt (index, element);
+		this.insertAt (index, element);
 		
 	}
 	
 	
 	public inline function iterator<T> ():Iterator<T> {
 		
-		return cast this.data.iterator ();
+		return this.iterator ();
 		
 	}
 	
 	
 	public inline function join (sep:String = ","):String {
 		
-		return this.data.join (sep);
+		return this.join (sep);
 		
 	}
 	
 	
 	public inline function lastIndexOf (x:T, ?from:Int = 0):Int {
 		
-		return this.data.lastIndexOf (x, from);
+		return this.lastIndexOf (x, from);
 		
 	}
 	
 	
 	public inline function pop ():Null<T> {
 		
-		return cast this.data.pop ();
+		return this.pop ();
 		
 	}
 	
 	
 	public inline function push (x:T):Int {
 		
-		return this.data.push (x);
+		return this.push (x);
 		
 	}
 	
 	
 	public inline function removeAt (index:Int):T {
 		
-		return cast this.data.removeAt (index);
+		return this.removeAt (index);
 		
 	}
 	
 	
 	public inline function reverse ():Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.reverse ());
+		return cast this.reverse ();
 		
 	}
 	
 	
 	@:arrayAccess public inline function set (index:Int, value:T):T {
 		
-		return cast this.data.set (index, value);
+		return this.set (index, value);
 		
 	}
 	
 	
 	public inline function shift ():Null<T> {
 		
-		return cast this.data.shift ();
+		return this.shift ();
 		
 	}
 	
 	
 	public inline function slice (?pos:Int, ?end:Int):Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.slice (pos, end));
+		return cast this.slice (pos, end);
 		
 	}
 	
 	
 	public inline function sort (f:T->T->Int):Void {
 		
-		this.data.sort (f);
+		this.sort (f);
 		
 	}
 	
 	
 	public inline function splice (pos:Int, len:Int):Vector<T> {
 		
-		return cast new AbstractVector<T> (this.data.splice (pos, len));
+		return cast this.splice (pos, len);
 		
 	}
 	
 	
 	public inline function toString ():String {
 		
-		return (this != null && this.data != null) ? this.data.toString () : null;
+		return this != null ? this.toString () : null;
 		
 	}
 	
 	
 	public inline function unshift (x:T):Void {
 		
-		this.data.unshift (x);
+		this.unshift (x);
 		
 	}
 	
 	
-	public inline static function ofArray<T> (a:Array<T>):Vector<T> {
+	@:generic public inline static function ofArray<T> (a:Array<T>):Vector<T> {
 		
 		var vector = new Vector<T> ();
 		
@@ -166,46 +165,83 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	}
 	
 	
-	public inline static function convert<T,U> (v:AbstractVector<T>):AbstractVector<U> {
+	public inline static function convert<T,U> (v:IVector<T>):IVector<U> {
 		
 		return cast v;
 		
 	}
 	
 	
-	@:to static #if (!js && !flash) inline #end function toBoolVector<T:Bool> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toBoolVector<T:Bool> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):BoolVector {
 		
-		return new AbstractVector<T> (cast new BoolVector (length, fixed), array);
-		
-	}
-	
-	
-	@:to static #if (!js && !flash) inline #end function toIntVector<T:Int> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
-		
-		return new AbstractVector<T> (cast new IntVector (length, fixed), array);
+		return new BoolVector (length, fixed, cast array);
 		
 	}
 	
 	
-	@:to static #if (!js && !flash) inline #end function toFloatVector<T:Float> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toIntVector<T:Int> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):IntVector {
 		
-		return new AbstractVector<T> (cast new FloatVector (length, fixed), array);
+		return new IntVector (length, fixed, cast array);
+		
+	}
+	
+	
+	@:to static #if (!js && !flash) inline #end function toFloatVector<T:Float> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):FloatVector {
+		
+		return new FloatVector (length, fixed, cast array);
 		
 	}
 	
 	
 	#if !cs
-	@:to static #if (!js && !flash) inline #end function toFunctionVector<T:Function> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toFunctionVector<T:Function> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):FunctionVector {
 		
-		return new AbstractVector<T> (cast new FunctionVector (length, fixed), array);
+		return new FunctionVector (length, fixed, cast array);
 		
 	}
 	#end
 	
 	
-	@:to static #if (!js && !flash) inline #end function toObjectVector<T> (t:AbstractVector<T>, length:Int, fixed:Bool, array:Array<T>):AbstractVector<T> {
+	@:to static #if (!js && !flash) inline #end function toObjectVector<T:{}> (t:IVector<T>, length:Int, fixed:Bool, array:Array<T>):ObjectVector<T> {
 		
-		return cast new AbstractVector<T> (cast new ObjectVector<T> (length, fixed), array);
+		return new ObjectVector<T> (length, fixed, cast array);
+		
+	}
+	
+	
+	@:from static inline function fromBoolVector<T> (vector:BoolVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	
+	
+	@:from static inline function fromIntVector<T> (vector:IntVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	
+	
+	@:from static inline function fromFloatVector<T> (vector:FloatVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	
+	
+	#if !cs
+	@:from static inline function fromFunctionVector<T:Function> (vector:FunctionVector):Vector<T> {
+		
+		return cast vector;
+		
+	}
+	#end
+	
+	
+	@:from static inline function fromObjectVector<T> (vector:ObjectVector<T>):Vector<T> {
+		
+		return cast vector;
 		
 	}
 	
@@ -219,78 +255,28 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	@:noCompletion private inline function get_fixed ():Bool {
 		
-		return this.data.fixed;
+		return this.fixed;
 		
 	}
 	
 	
 	@:noCompletion private inline function set_fixed (value:Bool):Bool {
 		
-		return this.data.fixed = value;
+		return this.fixed = value;
 		
 	}
 	
 	
 	@:noCompletion private inline function get_length ():Int {
 		
-		return this.data.length;
+		return this.length;
 		
 	}
 	
 	
 	@:noCompletion private inline function set_length (value:Int):Int {
 		
-		return this.data.length = value;
-		
-	}
-	
-	
-}
-
-
-
-
-#if !openfl_debug
-@:fileXml('tags="haxe,release"')
-@:noDebug
-#end
-
-
-// Wrap sub-types in a common wrapper to allow
-// for Vector<T> to Vector<Dynamic> conversion
-// while retaining the underlying type
-
-@:dox(hide) private class AbstractVector<T> {
-	
-	
-	public var data:IVector<T>;
-	
-	
-	public function new (data:IVector<T>, ?array:Array<T>) {
-		
-		this.data = data;
-		
-		if (array != null) {
-			
-			var cacheFixed = data.fixed;
-			data.fixed = false;
-			
-			for (i in 0...array.length) {
-				
-				data.set (i, cast array[i]);
-				
-			}
-			
-			data.fixed = cacheFixed;
-			
-		}
-		
-	}
-	
-	
-	@:noCompletion @:keep private function toJSON () {
-		
-		return @:privateAccess data.toJSON ();
+		return this.length = value;
 		
 	}
 	
@@ -317,15 +303,10 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public function new (?length:Int, ?fixed:Bool, ?array:Array<Bool>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Bool> ();
-			
-		}
-		
+		if (array == null) array = new Array ();
 		__array = array;
 		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -642,17 +623,12 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	private var __array:Array<Float>;
 	
 	
-	public function new (?length:Int, ?fixed:Bool, ?array:Array<Float>):Void {
+	public function new (?length:Int, ?fixed:Bool, ?array:Array<Dynamic>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Float> ();
-			
-		}
+		__array = new Array ();
+		if (array != null) for (i in 0...array.length) __array[i] = array[i];
 		
-		__array = array;
-		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -964,15 +940,10 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public function new (?length:Int, ?fixed:Bool, ?array:Array<Function>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Function> ();
-			
-		}
-		
+		if (array == null) array = new Array ();
 		__array = array;
 		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -1292,15 +1263,10 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	
 	public function new (?length:Int, ?fixed:Bool, ?array:Array<Int>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<Int> ();
-			
-		}
-		
+		if (array == null) array = new Array ();
 		__array = array;
 		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -1609,17 +1575,12 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	private var __array:Array<T>;
 	
 	
-	public function new (?length:Int, ?fixed:Bool, ?array:Array<T>):Void {
+	public function new (?length:Int, ?fixed:Bool, ?array:Array<Dynamic>):Void {
 		
-		if (array == null) {
-			
-			array = new Array<T> ();
-			
-		}
+		__array = new Array ();
+		if (array != null) for (i in 0...array.length) __array[i] = array[i];
 		
-		__array = array;
-		
-		if (length != null) {
+		if (length != null && length > 0) {
 			
 			this.length = length;
 			
@@ -1937,8 +1898,6 @@ abstract Vector<T>(AbstractVector<T>) from AbstractVector<T> {
 	public function splice (pos:Int, len:Int):IVector<T>;
 	public function toString ():String;
 	public function unshift (x:T):Void;
-	
-	@:noCompletion private function toJSON ():Dynamic;
 	
 }
 


### PR DESCRIPTION
I added a behavior in HTML5 to copy the behavior of Flash to show the correct frame labels when buttonMode is enabled. (_up, _over, _down)

I also tried to copy your code style and annotations, furthermore the code complexity only increases when the user sets buttonMode to true, projects that don't use the setting should not be affected at all.