### PR TITLE
Set MovieClip children back to default playing state when removed and added

### DIFF
--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -365,6 +365,13 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 					
 					if (instance.displayObject == child) {
 						
+						//set MovieClips back to initial state
+						if (Std.is(child, MovieClip))
+						{
+							cast(child, MovieClip).gotoAndPlay(1);
+							instance = null;
+						}
+						
 						removeChild (child);
 						i--;
 						length--;


### PR DESCRIPTION
When a child of a  MovieClip is added in a frame and removed in a later frame, the next time the MovieClip completes a playing cycle and comes back to the frame where the child is added, the child should start playing again (if it is a MovieClip). This PR makes sure that frame children of MovieClips are set back to the initial "playing" state when they are removed.

Previously, the HTML5 target was not behaving like Flash because the MovieClip child only played once and would not start playing again if it was stopped by a script and then created again in the next cycle.