### PR TITLE
Fix colorTransform not being reset to default in first frame of MovieClip animation

### DIFF
--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -18,6 +18,7 @@ import openfl.errors.ArgumentError;
 import openfl.events.Event;
 import openfl.events.MouseEvent;
 import openfl.filters.*;
+import openfl.geom.ColorTransform;
 import openfl.text.TextField;
 
 #if hscript
@@ -257,7 +258,7 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 							if (instance != null) {
 								
 								currentInstancesByFrameObjectID.set (frameObject.id, instance);
-								__updateDisplayObject (instance.displayObject, frameObject);
+								__updateDisplayObject (instance.displayObject, frameObject, true);
 								
 							}
 						
@@ -765,7 +766,7 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 	}
 	
 	
-	private function __updateDisplayObject (displayObject:DisplayObject, frameObject:FrameObject):Void {
+	private function __updateDisplayObject (displayObject:DisplayObject, frameObject:FrameObject, reset : Bool = false):Void {
 		
 		if (displayObject == null) return;
 		
@@ -784,6 +785,11 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 		if (frameObject.colorTransform != null) {
 			
 			displayObject.transform.colorTransform = frameObject.colorTransform;
+			
+		}
+		else if (reset) {
+			
+			displayObject.transform.colorTransform = new ColorTransform();
 			
 		}
 		


### PR DESCRIPTION
As promised the pull request for the fix of the bug discussed here: http://community.openfl.org/t/html5-develop-possible-fix-for-movieclip-gotoandstop-colortransform-bug/10378/6

The fix turned out to be simpler than what I expected because the behavior was a bit different to what I thought I observed. The colorTransform is null both for the first frame where the object is created, as well as for any other frame after a colorTransform was set but did not change. That means a check for colorTransform == null would not work because there is no difference whether it means this is a default colorTransform, or the colorTransform that was introduced in an earlier frame.

So instead I introduced a reset parameter in the __updateDisplayObject function that is true only when an object is created, because when an object is created, all properties should be reset to default unless a different behavior is specified. This might possibly also be used for matrix, etc., but this is currently not something we have a test case for so I did not change that behavior.