### PR TITLE
feature/ifdef-conditional, conditional compilation with webpack

### DIFF
--- a/scripts/build.hxml
+++ b/scripts/build.hxml
@@ -9,6 +9,8 @@ ImportAll
 -cp ../node_modules/hxgenjs/src
 -cp ../node_modules/tink_macro/src
 -cp ../node_modules/tink_core/src
+-cp custom
+--macro CustomHxGenJSSetup.setup()
 --macro genjs.Generator.use()
 # -D hxextern
 # -D tsextern

--- a/scripts/custom/CustomClassGenerator.hx
+++ b/scripts/custom/CustomClassGenerator.hx
@@ -1,0 +1,224 @@
+package;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import haxe.macro.Type;
+import genjs.processor.*;
+import genjs.generator.*;
+
+#if tink_macro
+using tink.MacroApi;
+#end
+using haxe.io.Path;
+using StringTools;
+using genjs.template.CodeTools;
+
+
+class CustomClassGenerator implements IClassGenerator {
+	public function new() {}
+
+	public function generate(api:JSGenApi, c:ProcessedClass) {
+
+		function superClassName(c:ClassType) 
+			return switch c.superClass {
+				case null: null;
+				case {t: sc}:
+					var sc = ClassProcessor.process(api, sc.toString(), sc.get());
+					return sc.id.asAccessName(sc.externType);
+			}		
+		
+		if(c.type.isExtern)
+			return None;
+		
+		var filepath = c.id.asFilePath() + '.js';
+		var name = c.type.name;
+		
+		var data = {};
+		Reflect.setField(data, 'className', name);
+		Reflect.setField(data, c.id.asTemplateHolder(), name);
+		for(dependency in c.dependencies) switch dependency {
+			case DType(TypeProcessor.process(api, _) => Some(PClass(c))):
+				Reflect.setField(data, c.id.asTemplateHolder(), c.id.asAccessName(c.externType));
+			
+			case DType(TypeProcessor.process(api, _) => Some(PEnum(e))): 
+				Reflect.setField(data, e.id.asTemplateHolder(), e.id.asAccessName());
+				
+			default:
+		}
+		// HACK: Runtime type values from Std
+		Reflect.setField(data, 'Date', 'Date');
+		Reflect.setField(data, 'Int', '$$hxClasses["Int"]');
+		Reflect.setField(data, 'Dynamic', '$$hxClasses["Dynamic"]');
+		Reflect.setField(data, 'Float', '$$hxClasses["Float"]');
+		Reflect.setField(data, 'Bool', '$$hxClasses["Bool"]');
+		Reflect.setField(data, 'Class', '$$hxClasses["Class"]');
+		Reflect.setField(data, 'Enum', '$$hxClasses["Enum"]');
+		Reflect.setField(data, 'Void', '$$hxClasses["Void"]');
+		
+		var requireStatements = new RequireGenerator().generate(api, filepath.directory(), c.dependencies);
+		
+		var ctor = 'var $name = ' + switch c.constructor {
+			case null | {template: null}: 'function(){}';
+			case {template: template}: template.execute(data);
+		}
+		#if (js_es==6)
+			switch ctor.indexOf('function(') {
+				case -1: throw 'assert';
+				case v: //DO NOT DO THIS AT HOME!!!!
+					ctor = {
+						var ctor = 'constructor' + ctor.substr(v + 'function'.length);
+						var cls = 
+							'class $name ' + switch superClassName(c.type) {
+								case null: '{\n${ctor.indent(1)}';
+								case v: 
+									var superCall = '$v.call(this';
+									switch ctor.indexOf(superCall) {
+										case -1: 
+											if (c.constructor == null)
+												ctor = '';
+											else {
+												if (c.type.superClass.t.get().constructor == null) {
+													switch ctor.indexOf('{') {
+														case -1: throw 'assert';
+														case v: 
+															ctor = [
+																ctor.substr(0, v+1),
+																"super()".indent(1),
+																ctor.substr(v + 1),
+															].join('\n');
+													}
+												}
+												else
+													c.constructor.field.pos.error('Could not find super call'); 
+											}
+										case v:
+										    var pretext = ctor.substr(0, v);
+											if (~/this[^a-zA-Z0-9_\$]/.match(pretext)) 
+												c.constructor.field.pos.warning('cannot access `this` before calling `super`');
+									}
+									ctor = 
+										ctor
+											.replace('$v.call(this,', 'super(')
+											.replace('$v.call(this', 'super(');
+									'extends $v {\n${ctor.indent(1)}';
+							}
+						cls + '\n';
+					}
+		  	}
+		#end
+		// Fields
+		#if (js_es >= 6) 
+			var statics = [];
+			ctor += [for (f in c.fields) 
+				if (f.template != null)
+					switch f.template.execute(data) {
+						case method if (method.startsWith('function(')):
+							(if (f.isStatic) 'static ' else '') 
+							+ f.field.name 
+							+ method.substr('function'.length);
+						case v:
+							if (f.isStatic) {
+								var name = f.field.name;
+								statics.push('var $name = $v;');
+								[
+									'static get $name() { return $name; }',
+									'static set $name(value) { $name = value; }',
+								].join('\n');
+							} 
+							else f.field.pos.error('field impossible to generate on ES6');
+							//c.type.pos.warning(v);
+							//v;
+					}
+			].join('\n').indent(1) + '\n}\n';
+			var statics = statics.join('\n');
+		#else 
+			var fields = [];
+			for(field in c.fields.filter(function(f) return !f.isStatic)) {
+				switch new FieldGenerator().generate(api, field, data) {
+					case Some(v): fields.push(v);
+					case None:
+				}
+			}		
+			var fields = '{\n' + fields.join(',\n').indent(1) + '\n}';
+			// Statics
+			var staticFunctions = [];
+			var staticVariables = [];
+			for(field in c.fields.filter(function(f) return f.isStatic)) {
+				switch new FieldGenerator().generate(api, field, data) {
+					case Some(v): (field.isFunction ? staticFunctions : staticVariables).push(v);
+					case None:
+				}
+			}
+			
+			var statics = staticFunctions.join('\n') + '\n' + staticVariables.join('\n');
+		#end
+		// Meta
+		var cname = c.id.split('.').map(api.quoteString).join(',');
+		var meta = ['$name.__name__ = [$cname];'];
+		
+		switch c.type.interfaces {
+			case null | []: // do nothing;
+			case v:
+				var inames = [for(i in v) ClassProcessor.process(api, i.t.toString(), i.t.get()).id.asAccessName()];
+				meta.push('$name.__interfaces__ = [${inames.join(',')}];');
+		}
+		
+		#if (js_es < 6)
+		switch superClassName(c.type) {
+			case null:
+				meta.push('$name.prototype = $fields;');
+			case scname:
+				meta.push('$name.__super__ = $scname;');
+				meta.push('$name.prototype = $$extend($scname.prototype, $fields);');
+		}
+		#end
+		meta.push('$name.prototype.__class__ = $$hxClasses["${c.id}"] = $name;');
+		// __init__
+		var init = 
+			if(c.init != null) c.init.template.execute(data) + ';';
+			else '';
+		
+		
+		// var code = '';
+		// for(field in c.fields) if(field.template != null) code += '\n' + field.template.execute({});
+		// for(field in c.statics) if(field.template != null) code += '\n' + field.template.execute({});
+		// if(code != '') {
+		// 	trace(filepath);
+		// 	trace(code);
+		// }
+		var re = ~/\/\/\/\s*#(if|endif)\s*(.*);\s*?(\r\n|\r|\n)/g;
+		var metaContent = meta.join('\n');
+		if (metaContent.indexOf('///') > -1) {
+			// Purpose of this replace call is to remove the trailing semicolon 
+			// from triple slash lines like: /// #if debug;
+      metaContent = re.replace(metaContent, '/// #$1 $2$3');
+		}
+		if (init.indexOf('///') > -1) {
+			init = re.replace(init, '/// #$1 $2$3');
+		}
+		if (ctor.indexOf('///') > -1) {
+			ctor = re.replace(ctor, '/// #$1 $2$3');
+		}
+		if (statics.indexOf('///') > -1) {
+			statics = re.replace(statics, '/// #$1 $2$3');
+		}
+		return Some([
+			'// Class: ${c.id}',
+			'var $$global = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this',
+			'$$global.Object.defineProperty(exports, "__esModule", {value: true});',
+			'var __map_reserved = {};', // TODO: add only if needed
+			'// Imports',
+			requireStatements,
+			'// Constructor',
+			ctor,
+			'// Meta',
+			metaContent,
+			'// Init',
+			init,
+			'// Statics',
+			statics,
+			'// Export',
+			'exports.default = $name;',
+		].join('\n\n'));
+	}
+}

--- a/scripts/custom/CustomClassGenerator.hx
+++ b/scripts/custom/CustomClassGenerator.hx
@@ -191,7 +191,7 @@ class CustomClassGenerator implements IClassGenerator {
 		if (metaContent.indexOf('///') > -1) {
 			// Purpose of this replace call is to remove the trailing semicolon 
 			// from triple slash lines like: /// #if debug;
-      metaContent = re.replace(metaContent, '/// #$1 $2$3');
+			metaContent = re.replace(metaContent, '/// #$1 $2$3');
 		}
 		if (init.indexOf('///') > -1) {
 			init = re.replace(init, '/// #$1 $2$3');

--- a/scripts/custom/CustomHxGenJSSetup.hx
+++ b/scripts/custom/CustomHxGenJSSetup.hx
@@ -1,0 +1,42 @@
+import genjs.generator.*;
+
+class CustomHxGenJSSetup {
+	
+	/*
+	Called in the build.hxml script.
+	
+	We supply our own custom ClassGenerator which overrides the one 
+	used by the hxgenjs library. We use our own in order to remove the 
+	trailing semicolons from the triple slash lines such as:
+	
+	/// #if debug; 
+	/// #endif;
+	
+	Which are generated in the lib/_gen/ javascript files by the haxe 
+	compiler whenever it encounters these lines in the haxe source.
+	
+	untyped __js__("/// #if debug");
+	
+	Note: If the haxe compiler wasn't adding semicolons to the end of these 
+	lines, we wouldn't need this custom generator in the first place!
+	
+	We can then use the ifdef-loader webpack loader to conditionally 
+	include or exclude lines of javascript from the javascript bundle.
+	See src/openfl/display/MovieClip.hx for usage.
+	*/
+	public static function setup() {
+		
+		#if (!genjs || genjs != "no")
+		var customConfig:genjs.Generator.Config = {
+			mainGenerator: new MainGenerator(),
+			classGenerator: new CustomClassGenerator(),
+			enumGenerator: new EnumGenerator(),
+			fileExtension: '.js',
+			stubs: true,
+		};
+		
+		genjs.Generator.generators.push(customConfig);
+		#end
+	}
+}
+

--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -70,8 +70,15 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 	
 	
 	#if openfljs
+	private static var __parent_fps:Bool;
 	private static function __init__ () {
 		
+		#if openfljs
+		__parent_fps = true;
+		untyped __js__("/// #if (typeof swf_parent_fps === 'undefined' || !swf_parent_fps) && (typeof swflite_parent_fps === 'undefined' || !swflite_parent_fps)");
+		__parent_fps = false;
+		untyped __js__("/// #endif");
+		#end
 		untyped Object.defineProperties (MovieClip.prototype, {
 			"currentFrame": { get: untyped __js__ ("function () { return this.get_currentFrame (); }") },
 			"currentFrameLabel": { get: untyped __js__ ("function () { return this.get_currentFrameLabel (); }") },
@@ -164,9 +171,19 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 		
 		__playing = true;
 		
-		#if (!swflite_parent_fps && !swf_parent_fps)
+		#if (openfljs || (!swflite_parent_fps && !swf_parent_fps))
+		
+		#if openfljs
+		if (!__parent_fps) {
+		#end
+		
 		__frameTime = Std.int (1000 / __swf.frameRate);
 		__timeElapsed = 0;
+		
+		#if openfljs
+		}
+		#end
+		
 		#end
 		
 	}
@@ -687,19 +704,34 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 	
 	private function __getNextFrame (deltaTime:Int):Int {
 		
-		#if (!swflite_parent_fps && !swf_parent_fps)
+		var nextFrame:Int = 0;
+		#if openfljs
+		if (!__parent_fps) {
+		#end
+		
+		#if (openfljs || (!swflite_parent_fps && !swf_parent_fps))
 		
 		__timeElapsed += deltaTime;
-		var nextFrame = __currentFrame + Math.floor (__timeElapsed / __frameTime);
+		nextFrame = __currentFrame + Math.floor (__timeElapsed / __frameTime);
 		if (nextFrame < 1) nextFrame = 1;
 		if (nextFrame > __totalFrames) nextFrame = Math.floor ((nextFrame - 1) % __totalFrames) + 1;
 		__timeElapsed = (__timeElapsed % __frameTime);
 		
-		#else
+		#end
 		
-		var nextFrame = __currentFrame + 1;
+		#if openfljs
+		} else {
+		#end
+		
+		#if (openfljs || swflite_parent_fps || swf_parent_fps)
+		
+		nextFrame = __currentFrame + 1;
 		if (nextFrame > __totalFrames) nextFrame = 1;
 		
+		#end
+		
+		#if openfljs
+		}
 		#end
 		
 		return nextFrame;

--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -73,12 +73,11 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 	private static var __parent_fps:Bool;
 	private static function __init__ () {
 		
-		#if openfljs
 		__parent_fps = true;
 		untyped __js__("/// #if (typeof swf_parent_fps === 'undefined' || !swf_parent_fps) && (typeof swflite_parent_fps === 'undefined' || !swflite_parent_fps)");
 		__parent_fps = false;
 		untyped __js__("/// #endif");
-		#end
+		
 		untyped Object.defineProperties (MovieClip.prototype, {
 			"currentFrame": { get: untyped __js__ ("function () { return this.get_currentFrame (); }") },
 			"currentFrameLabel": { get: untyped __js__ ("function () { return this.get_currentFrameLabel (); }") },


### PR DESCRIPTION
Allows us to add triple slash conditionals to the generated npm javascript classes that almost mirrors the functionality of the haxe conditional compilation. You need to add the ifdef-loader to a project's webpack loader list. So here's the updated lib/_gen/openfl/display/MovieClip.js init closure that includes the conditional.

```
{
  MovieClip.__parent_fps = true;
  /// #if (typeof swf_parent_fps === 'undefined' || !swf_parent_fps) && (typeof swflite_parent_fps === 'undefined' || !swflite_parent_fps)
  MovieClip.__parent_fps = false;
  /// #endif 
}
```


webpack.common.js

```
module: {
  rules: [
    {
      test: /\.js$/,
      use: [
        { loader: "ifdef-loader", options: {swflite_parent_fps: true} }
      ]
    },
    {
      test: /\.tsx?$/,
      use: [
      { loader: 'ts-loader' }
      ]
    }
   ]
}
```

A slightly modified hxgenjs ClassGenerator is required for the sole purpose of removing the trailing semicolons that the Haxe compiler adds to the end of any `__js__("...")` output. ifdef-loader errors out if it encounters these semicolons. So short of fixing this in the Haxe compiler, this can be dealt with using  hxgenjs.

```
untyped __js__("/// #endif") 

haxe outputs in the js:
/// #endif;
```

The modifications in CustomClassGenerator  are from line 189 to 204.