### PR TITLE
HTML5: Improve Performance for colorTransform reset

### DIFF
--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -32,7 +32,7 @@ import hscript.Parser;
 #end
 
 @:access(openfl._internal.symbols.SWFSymbol)
-
+@:access(openfl.geom.ColorTransform)
 
 class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObject> #end {
 	
@@ -787,7 +787,7 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 			displayObject.transform.colorTransform = frameObject.colorTransform;
 			
 		}
-		else if (reset) {
+		else if (reset && !displayObject.transform.colorTransform.__isDefault()) {
 			
 			displayObject.transform.colorTransform = new ColorTransform();
 			

--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -18,6 +18,7 @@ import openfl.errors.ArgumentError;
 import openfl.events.Event;
 import openfl.events.MouseEvent;
 import openfl.filters.*;
+import openfl.geom.ColorTransform;
 import openfl.text.TextField;
 
 #if hscript
@@ -257,7 +258,7 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 							if (instance != null) {
 								
 								currentInstancesByFrameObjectID.set (frameObject.id, instance);
-								__updateDisplayObject (instance.displayObject, frameObject);
+								__updateDisplayObject (instance.displayObject, frameObject, true);
 								
 							}
 						
@@ -765,7 +766,7 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 	}
 	
 	
-	private function __updateDisplayObject (displayObject:DisplayObject, frameObject:FrameObject):Void {
+	private function __updateDisplayObject (displayObject:DisplayObject, frameObject:FrameObject, reset : Bool = false):Void {
 		
 		if (displayObject == null) return;
 		
@@ -784,6 +785,11 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 		if (frameObject.colorTransform != null) {
 			
 			displayObject.transform.colorTransform = frameObject.colorTransform;
+			
+		}
+		else if (reset) {
+			
+			displayObject.transform.colorTransform = new ColorTransform();
 			
 		}
 		

--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -365,6 +365,13 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 					
 					if (instance.displayObject == child) {
 						
+						//set MovieClips back to initial state
+						if (Std.is(child, MovieClip))
+						{
+							cast(child, MovieClip).gotoAndPlay(1);
+							instance = null;
+						}
+						
 						removeChild (child);
 						i--;
 						length--;

--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -365,11 +365,10 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 					
 					if (instance.displayObject == child) {
 						
-						//set MovieClips back to initial state
+						//set MovieClips back to initial state (autoplay)
 						if (Std.is(child, MovieClip))
 						{
 							cast(child, MovieClip).gotoAndPlay(1);
-							instance = null;
 						}
 						
 						removeChild (child);

--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -368,7 +368,8 @@ class MovieClip extends Sprite #if openfl_dynamic implements Dynamic<DisplayObje
 						//set MovieClips back to initial state (autoplay)
 						if (Std.is(child, MovieClip))
 						{
-							cast(child, MovieClip).gotoAndPlay(1);
+							var movie : MovieClip = cast child;
+							movie.gotoAndPlay(1);
 						}
 						
 						removeChild (child);


### PR DESCRIPTION
With my previous PR the colorTransform is now reset everytime the frameObject is created in the MovieClip. With this PR the colorTransform is only created again if the existing colorTransform is not already the default transform, i.e. this commit improves the performance by creating less objects.