### PR TITLE
minor fix to SWFLiteLibrary bytesTotal

### DIFF
--- a/src/openfl/_internal/swf/SWFLiteLibrary.hx
+++ b/src/openfl/_internal/swf/SWFLiteLibrary.hx
@@ -322,6 +322,14 @@ import openfl.utils.ByteArray;
 		rootPath = manifest.rootPath;
 		super.__fromManifest (manifest);
 		
+		bytesTotal = 0;
+		
+		for (id in paths.keys ()) {
+			
+			bytesTotal += sizes.get (id);
+			
+		}
+		
 	}
 	
 	


### PR DESCRIPTION
When using Assets.loadLibrary to load a swf library, the onProgress callback always returns 0 as the total of bytes to load.  I tried to understand how SWFLiteLibrary works to fix it the correct way without breaking anything else. Thought there are probably several ways to fix/refactor it so feel free to make changes or let me know if I should change something. 

SWFLiteLibrary seems to load every assets contained in `paths`. This PR sets the value of `bytesTotal` using `paths` after it has been initialized from the manifest.