### PR TITLE
Fix BitmapData.draw() with mask for native

### DIFF
--- a/src/openfl/_internal/renderer/cairo/CairoGraphics.hx
+++ b/src/openfl/_internal/renderer/cairo/CairoGraphics.hx
@@ -1582,7 +1582,7 @@ class CairoGraphics {
 		
 		if (graphics.__commands.length != 0) {
 			
-			var cairo = renderer.cairo;
+			cairo = renderer.cairo;
 			
 			var positionX = 0.0;
 			var positionY = 0.0;
@@ -1603,7 +1603,7 @@ class CairoGraphics {
 						var c = data.readCubicCurveTo ();
 						cairo.curveTo (c.controlX1 - offsetX, c.controlY1 - offsetY, c.controlX2 - offsetX, c.controlY2 - offsetY, c.anchorX - offsetX, c.anchorY - offsetY);
 						positionX = c.anchorX;
-						positionY = c.anchorX;
+						positionY = c.anchorY;
 					
 					case CURVE_TO:
 						


### PR DESCRIPTION
Cairo variable was assigned as local variable so calling external functions from renderMask() like quadraticCurveTo() and drawRoundRect() weren't working as trying to access another renderer.
Fix typo in renderMask() CUBIC_CURVE_TO
resolves #1821