### PR TITLE
Fix to setting sampler values other than defaults

### DIFF
--- a/src/openfl/_internal/stage3D/opengl/GLContext3D.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLContext3D.hx
@@ -481,7 +481,7 @@ class GLContext3D {
 			
 			for (i in 0...Context3D.MAX_SAMPLERS) {
 				
-				context.__samplerStates[i].copyFrom (context.__program.__getSamplerState (i));
+				context.__samplerStates[i] = context.__program.__getSamplerState (i);
 				
 			}
 			
@@ -881,7 +881,7 @@ class GLContext3D {
 				
 				if (context.__supportsAnisotropicFiltering) {
 					
-					state.maxAniso = (context.__maxAnisotropyTexture2D < 16 ? context.__maxAnisotropyTexture2D : 16);
+					state.maxAniso = (context.__maxAnisotropyTexture2D < 16 ? context.__maxAnisotropyTexture2D : 0);
 					
 				}
 			


### PR DESCRIPTION
Using the original copyFrom implementation always triggers a dirty sampler and can trigger regeneration of mipmaps each time the texture is used when the setting hasn't changed. Also due to int conversion maxAnsio of 16X sampling is 0 - stops bouncing between 16 & 0, again causing the sampler to be marked as dirty.