### PR TITLE
Don't try to "sync" BitmapData's Image before uploading it as a texture.

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -1051,10 +1051,6 @@ class BitmapData implements IBitmapDrawable {
 			
 		}
 		
-		#if (js && html5)
-		ImageCanvasUtil.sync (image, false);
-		#end
-		
 		if (image != null && image.version > __textureVersion) {
 			
 			var internalFormat, format;
@@ -1998,15 +1994,6 @@ class BitmapData implements IBitmapDrawable {
 			#end
 			
 		}
-		
-	}
-	
-	
-	private function __sync ():Void {
-		
-		#if (js && html5)
-		ImageCanvasUtil.sync (image, false);
-		#end
 		
 	}
 	


### PR DESCRIPTION
This would cause it to be drawn to a freshly-created Canvas which is heavy (esp. on MS Edge) and unnecessary because texImage2D supports uploading directly from Image elements.

PS also remove the unused `__sync` method.