### PR TITLE
Removed setting MovieClip child objects' parent and stage properties on creation

### DIFF
--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -611,8 +611,6 @@ class MovieClip extends Sprite #if (openfl_dynamic && haxe_ver < "4.0.0") implem
 							
 							if (displayObject != null) {
 								
-								displayObject.parent = this;
-								displayObject.stage = stage;
 								instance = new FrameSymbolInstance (frame, frameObject.id, frameObject.symbol, frameObject.depth, displayObject, frameObject.clipDepth);
 								
 							}


### PR DESCRIPTION
Setting parent and stage properties immediately (rather than being set in the DisplayObjectContainer.addChildAt method) prevented the Event.ADDED_TO_STAGE event from being fired.