### PR TITLE
fix offset bug when colorTransform is used on MovieClip that contains…

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1701,13 +1701,6 @@ class TextField extends InteractiveObject {
 		
 		if (super.__updateCacheBitmap (renderer, force || __dirty)) {
 			
-			if (__cacheBitmap != null) {
-				
-				__cacheBitmap.__renderTransform.tx -= __offsetX;
-				__cacheBitmap.__renderTransform.ty -= __offsetY;
-				
-			}
-			
 			return true;
 			
 		}


### PR DESCRIPTION
Hello,

we were seeing a problem with TextFields in HTML5 canvas mode where the TextFields were incorrectly placed with a little offset when a colorTransform was applied to the parent MovieClip. I investigated the behavior and I think the problem originates from TextField.hx method __updateCacheBitmap:

    if (__cacheBitmap != null) {
        __cacheBitmap.__renderTransform.tx -= __offsetX;
        __cacheBitmap.__renderTransform.ty -= __offsetY;
				
    }
If these lines are commented out, everything works as expected. I think the offset is actually applied twice at the moment, __updateTransforms() also applies the offset, which is called from within DisplayObject.__updateCacheBitmap via __update(). 

So far the fix seems to have no other side effects in our project, but let me know in case I missed something.