### PR TITLE
improving TextField cacheAsBitmap behavior

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1082,8 +1082,10 @@ class TextField extends InteractiveObject {
 		
 		var bounds = Rectangle.__pool.get ();
 		bounds.copyFrom (__textEngine.bounds);
-		bounds.x += __offsetX;
-		bounds.y += __offsetY;
+		
+		matrix.tx += __offsetX;
+		matrix.ty += __offsetY;
+		
 		bounds.__transform (bounds, matrix);
 		
 		rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
@@ -1701,6 +1703,13 @@ class TextField extends InteractiveObject {
 		
 		if (super.__updateCacheBitmap (renderer, force || __dirty)) {
 			
+			if (__cacheBitmap != null) {
+				
+				__cacheBitmap.__renderTransform.tx -= __offsetX;
+				__cacheBitmap.__renderTransform.ty -= __offsetY;
+				
+			}
+
 			return true;
 			
 		}


### PR DESCRIPTION
During my tests I found that my initial change correctly fixed the positioning of the TextField, however the size of the Bitmap was too small in some cases. It seems that the __getBounds logic was changed and does not work correctly anymore.

By adjusting the matrix instead of the bounds rectangle in __getBounds(), the size of the Bitmap is corrected as well as the positioning of the matrix in regards of the TextField offset values. Therefore my previous change has to be undone. The positioning is still fixed, but now also the size of the rectangle seems to be correct.