### PR TITLE
Non-blocking socket connection

### DIFF
--- a/src/openfl/net/Socket.hx
+++ b/src/openfl/net/Socket.hx
@@ -162,8 +162,8 @@ class Socket extends EventDispatcher implements IDataInput implements IDataOutpu
 		
 		try {
 			
-			__socket.connect (h, port);
 			__socket.setBlocking (false);
+			__socket.connect (h, port);
 			__socket.setFastSend (true);
 			
 		} catch (e:Dynamic) {}


### PR DESCRIPTION
Set socket to non-blocking before attempting to connect to prevent the application from freezing while waiting for an unsuccessful connection attempt to terminate.