### PR TITLE
fix canvas colorTransform

### DIFF
--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -11,6 +11,7 @@ import openfl.errors.RangeError;
 import openfl.errors.TypeError;
 import openfl.events.Event;
 import openfl.events.EventPhase;
+import openfl.geom.ColorTransform;
 import openfl.geom.Matrix;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
@@ -678,11 +679,19 @@ class DisplayObjectContainer extends InteractiveObject {
 	}
 	
 	
+	@:access(openfl.geom.ColorTransform)
 	private override function __renderCanvas (renderer:CanvasRenderer):Void {
 		
 		if (!__renderable || __worldAlpha <= 0 || (mask != null && (mask.width <= 0 || mask.height <= 0))) return;
 		
 		#if !neko
+		
+		var needRender = __objectTransform != null && !__objectTransform.colorTransform.__isDefault();
+		
+		if (needRender) 
+		{
+			__renderDirty = true;
+		}
 		
 		super.__renderCanvas (renderer);
 		
@@ -695,7 +704,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			for (child in __children) {
 				
 				child.__renderCanvas (renderer);
-				child.__renderDirty = false;
+				child.__renderDirty = needRender;
 				
 			}
 			


### PR DESCRIPTION
When compiling with -Dcanvas, the children are not well displayed when there is a colorTransform applied. This PR try to fix it.

I tested it with the following project (c.f. [TFColorEffect.zip](https://github.com/openfl/openfl/files/2176294/TFColorEffect.zip)):

```haxe
class Main extends Sprite {

	public function new () {
		
		super();
		
		var _mc = Assets.getMovieClip("mylib:Button");
		
		addChild(_mc);
		
		_mc.alpha = 0;
		
		haxe.Timer.delay(function () { _mc.alpha = .4; }, 200);
		haxe.Timer.delay(function () { _mc.alpha = 1; }, 500);
		
	}
}
```
`mylib:Button` is a MovieClip containing a MovieClip with a brightness effect containing a TextField. At run-time the TextField is visible in webgl but not in canvas.

I didn't test it in dom but it would be interesting to try.

Maybe it is not the right way to fix this as I don't have a deep understanding of what is happening here. In the meantime it does fix some of our buttons in game.
