### PR TITLE
handle alpha properly for GlowFilter and DropShadowFilter

### DIFF
--- a/src/openfl/filters/DropShadowFilter.hx
+++ b/src/openfl/filters/DropShadowFilter.hx
@@ -113,11 +113,10 @@ import lime.graphics.utils.ImageDataUtil;
 		
 		// TODO: Support knockout, inner
 		
-		var a = (__color >> 24) & 0xFF;
 		var r = (__color >> 16) & 0xFF;
 		var g = (__color >> 8) & 0xFF;
 		var b = __color & 0xFF;
-		sourceBitmapData.colorTransform (sourceBitmapData.rect, new ColorTransform (0, 0, 0, 1, r, g, b, a));
+		sourceBitmapData.colorTransform (sourceBitmapData.rect, new ColorTransform (0, 0, 0, __alpha, r, g, b, 0));
 		
 		destPoint.x += __offsetX;
 		destPoint.y += __offsetY;

--- a/src/openfl/filters/GlowFilter.hx
+++ b/src/openfl/filters/GlowFilter.hx
@@ -101,7 +101,7 @@ import lime.graphics.utils.ImageDataUtil;
 		var r = (__color >> 16) & 0xFF;
 		var g = (__color >> 8) & 0xFF;
 		var b = __color & 0xFF;
-		sourceBitmapData.colorTransform (sourceBitmapData.rect, new ColorTransform (0, 0, 0, 1, r, g, b, __alpha * 0xFF));
+		sourceBitmapData.colorTransform (sourceBitmapData.rect, new ColorTransform (0, 0, 0, __alpha, r, g, b, 0));
 		
 		var finalImage = ImageDataUtil.gaussianBlur (bitmapData.image, sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), __blurX, __blurY, __quality, __strength);
 		


### PR DESCRIPTION
> from https://github.com/innogames/openfl/pull/39

I _think_ this is the correct way the `alpha` parameter should be treated.

What was there before:
 - For `DropShadowFilter`, the `__alpha` value wasn't used at all, and instead it tried to get the alpha from the color and then add it to the image. But since the color is just `RGB`, the `a` value would always end up being `0`, so no effect at all.
 - For `GlowFilter`, the `__alpha` value was added to the image, so if we e.g. have `0.5` alpha in the filter and `0.5` alpha in the image, the resulting pixel would be fully opaque.

What is there now:
 - Both filters use `__alpha` for actually multiplying the alpha value from the image, so e.g. if we have a source alpha of `0.75` and the filter alpha of `0.5`, the resulting pixel will have alpha value of `0.375`.

This sounds correct to me and seems to fix our glow filter issues.