### PR TITLE
remove the TextField+GlowFilter hack

### DIFF
--- a/src/openfl/_internal/renderer/cairo/CairoTextField.hx
+++ b/src/openfl/_internal/renderer/cairo/CairoTextField.hx
@@ -14,7 +14,6 @@ import openfl._internal.text.TextEngine;
 import openfl.display.BitmapData;
 import openfl.display.CairoRenderer;
 import openfl.display.Graphics;
-import openfl.filters.GlowFilter;
 import openfl.geom.Matrix;
 import openfl.geom.Rectangle;
 import openfl.text.TextField;
@@ -247,70 +246,31 @@ class CairoTextField {
 					cairo.setFontSize (size);
 					
 					cairo.moveTo (group.offsetX + scrollX - bounds.x, group.offsetY + group.ascent + scrollY - bounds.y);
-					
-					var usedHack = false;
-					
-					if (textField.__filters != null) {
 						
-						// Hack, force outline
+					#if openfl_cairo_show_text
+					cairo.showText (text.substring (group.startIndex, group.endIndex));
+					#else
+					
+					// TODO: Improve performance
+					
+					cairo.translate (0, 0);
+					
+					var glyphs = [];
+					var x:Float = group.offsetX + scrollX - bounds.x;
+					var y:Float = group.offsetY + group.ascent + scrollY - bounds.y;
+					var j = 0;
+					
+					for (position in group.positions) {
 						
-						if (Std.is (textField.__filters[0], GlowFilter)) {
-							
-							cairo.textPath (text.substring (group.startIndex, group.endIndex));
-							
-							var glowFilter:GlowFilter = cast textField.__filters[0];
-							
-							color = glowFilter.color;
-							r = ((color & 0xFF0000) >>> 16) / 0xFF;
-							g = ((color & 0x00FF00) >>> 8) / 0xFF;
-							b = (color & 0x0000FF) / 0xFF;
-							
-							cairo.setSourceRGBA (r, g, b, glowFilter.alpha);
-							cairo.lineWidth = Math.max (glowFilter.blurX, glowFilter.blurY);
-							cairo.strokePreserve ();
-							
-							color = group.format.color;
-							r = ((color & 0xFF0000) >>> 16) / 0xFF;
-							g = ((color & 0x00FF00) >>> 8) / 0xFF;
-							b = (color & 0x0000FF) / 0xFF;
-							
-							cairo.setSourceRGB (r, g, b);
-							
-							cairo.fillPreserve ();
-							usedHack = true;
-							
-						}
+						if (position == null || position.glyph == 0) continue;
+						glyphs.push (new CairoGlyph (position.glyph, x + position.offset.x + 0.5, y - position.offset.y + 0.5));
+						x += position.advance.x;
+						y -= position.advance.y;
 						
 					}
 					
-					if (!usedHack) {
-						
-						#if openfl_cairo_show_text
-						cairo.showText (text.substring (group.startIndex, group.endIndex));
-						#else
-						
-						// TODO: Improve performance
-						
-						cairo.translate (0, 0);
-						
-						var glyphs = [];
-						var x:Float = group.offsetX + scrollX - bounds.x;
-						var y:Float = group.offsetY + group.ascent + scrollY - bounds.y;
-						var j = 0;
-						
-						for (position in group.positions) {
-							
-							if (position == null || position.glyph == 0) continue;
-							glyphs.push (new CairoGlyph (position.glyph, x + position.offset.x + 0.5, y - position.offset.y + 0.5));
-							x += position.advance.x;
-							y -= position.advance.y;
-							
-						}
-						
-						cairo.showGlyphs (glyphs);
-						#end
-						
-					}
+					cairo.showGlyphs (glyphs);
+					#end
 					
 					if (textField.__caretIndex > -1 && textEngine.selectable) {
 						

--- a/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -9,7 +9,6 @@ import openfl.display.BitmapDataChannel;
 import openfl.display.CanvasRenderer;
 import openfl.display.Graphics;
 import openfl.events.Event;
-import openfl.filters.GlowFilter;
 import openfl.geom.Matrix;
 import openfl.geom.Rectangle;
 import openfl.text.TextField;
@@ -212,28 +211,6 @@ class CanvasTextField {
 						if (applyHack) {
 							
 							offsetY = group.format.size * 0.185;
-							
-						}
-						
-						if (textField.__filters != null) {
-							
-							// Hack, force outline
-							
-							if (Std.is (textField.__filters[0], GlowFilter)) {
-								
-								var glowFilter:GlowFilter = cast textField.__filters[0];
-								
-								var cacheAlpha = context.globalAlpha;
-								context.globalAlpha = cacheAlpha * glowFilter.alpha;
-								
-								context.strokeStyle = "#" + StringTools.hex (glowFilter.color & 0xFFFFFF, 6);
-								context.lineWidth = Math.max (glowFilter.blurX, glowFilter.blurY);
-								context.strokeText (text.substring (group.startIndex, group.endIndex), group.offsetX + scrollX - bounds.x, group.offsetY + offsetY + scrollY - bounds.y);
-								
-								context.strokeStyle = null;
-								context.globalAlpha = cacheAlpha;
-								
-							}
 							
 						}
 						

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -40,7 +40,6 @@ import openfl.events.FocusEvent;
 import openfl.events.KeyboardEvent;
 import openfl.events.MouseEvent;
 import openfl.events.TextEvent;
-import openfl.filters.GlowFilter;
 import openfl.geom.Matrix;
 import openfl.geom.Rectangle;
 import openfl.net.URLRequest;
@@ -2015,15 +2014,6 @@ class TextField extends InteractiveObject {
 		__updateLayout ();
 		
 		return __textEngine.bottomScrollV;
-		
-	}
-	
-	
-	private override function get_cacheAsBitmap ():Bool {
-		
-		// HACK
-		if (__filters != null && __filters.length == 1 && Std.is (__filters[0], GlowFilter)) return false;
-		return super.get_cacheAsBitmap ();
 		
 	}
 	


### PR DESCRIPTION
This gets rid of the text stroking when `GlowFilter` is used. This was super unexpected and producing weird results, not at all like in Flash, with ugly spikes.

Now, together with https://github.com/openfl/lime/pull/1209 and https://github.com/openfl/openfl/pull/1948, GlowFilter on texts looks exactly the same as in Flash.