### PR TITLE
properly handle half-pixel coordinates for rectangle masks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "editor.trimAutoWhitespace": false,
+    "files.trimTrailingWhitespace": false,
     "editor.insertSpaces": false,
     "codedox": {
         "commentprefix": "    ",

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -927,14 +927,14 @@ class OpenGLRenderer extends DisplayObjectRenderer {
 			__gl.enable (__gl.SCISSOR_TEST);
 			
 			var x = Math.floor (clipRect.x);
-			var y = __flipped ? Math.floor (__height - clipRect.y - clipRect.height) : Math.floor (clipRect.y);
-			var width = Math.ceil (clipRect.width);
-			var height = Math.ceil (clipRect.height);
+			var y = Math.floor (clipRect.y);
+			var width = Math.ceil (clipRect.right) - x;
+			var height = Math.ceil (clipRect.bottom) - y;
 			
 			if (width < 0) width = 0;
 			if (height < 0) height = 0;
 			
-			__gl.scissor (x, y, width, height);
+			__gl.scissor (x, __flipped ? __height - y - height : y, width, height);
 			
 		} else {
 			


### PR DESCRIPTION
sometimes when rendering objects with a scrollrect (or tilemaps) at half-pixel coordinates, the width/height for `gl.scissor` wasn't correctly expanded and the object was missing one-pixel line from top or right, because the `__scissorRect` function didn't consider the position for calculating width/height. this PR fixes that

PS: another commit fixes the annoying whitespace trailing in vscode