### PR TITLE
don't call __update in __updateCacheBitmap

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1176,9 +1176,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		
 		if (cacheAsBitmap || (renderer.__type != OPENGL && !colorTransform.__isDefault ())) {
 			
-			var matrix = null, rect = null;
-			
-			__update (false, true);
+			var rect = null;
 			
 			var needRender = (__cacheBitmap == null || (__renderDirty && (force || (__children != null && __children.length > 0) || (__graphics != null && __graphics.__dirty))) || opaqueBackground != __cacheBitmapBackground || (renderer.__type != OPENGL && !__cacheBitmapColorTransform.__equals (colorTransform)));
 			var updateTransform = (needRender || (renderer.__type == OPENGL && !__cacheBitmap.__worldTransform.equals (__worldTransform)));
@@ -1641,19 +1639,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 				
 			}
 			
-			if (updateTransform) {
-				
-				__update (false, true);
+			if (updateTransform || needRender) {
 				
 				Rectangle.__pool.release (rect);
 				
-				return true;
-				
-			} else {
-				
-				return false;
-				
 			}
+			
+			return updateTransform;
 			
 		} else if (__cacheBitmap != null) {
 			


### PR DESCRIPTION
> adapted from https://github.com/innogames/openfl/pull/10

since `__updateCacheBitmap` is always called from rendering functions, which are always called after the update, we don't need to traverse again

also, fix returning `rect` to the pool and remove now unused `matrix` var