### PR TITLE
remove unused leftover __updateMask method

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -290,31 +290,6 @@ class Bitmap extends DisplayObject {
 	}
 	
 	
-	public override function __updateMask (maskGraphics:Graphics):Void {
-		
-		if (__bitmapData == null) {
-			
-			return;
-			
-		}
-		
-		maskGraphics.__commands.overrideMatrix (this.__worldTransform);
-		maskGraphics.beginFill (0);
-		maskGraphics.drawRect (0, 0, __bitmapData.width, __bitmapData.height);
-		
-		if (maskGraphics.__bounds == null) {
-			
-			maskGraphics.__bounds = new Rectangle ();
-			
-		}
-		
-		__getBounds (maskGraphics.__bounds, @:privateAccess Matrix.__identity);
-		
-		super.__updateMask (maskGraphics);
-		
-	}
-	
-	
 	
 	
 	// Get & Set Methods

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -2105,13 +2105,6 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	private function __updateMask (maskGraphics:Graphics):Void {
-		
-		
-		
-	}
-	
-	
 	private function __updateTransforms (overrideTransform:Matrix = null):Void {
 		
 		if (overrideTransform == null) {

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1696,28 +1696,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 	}
 	
 	
-	private function __updateMask (maskGraphics:Graphics):Void {
-		
-		if (__graphics != null) {
-			
-			maskGraphics.__commands.overrideMatrix (this.__worldTransform);
-			maskGraphics.__commands.append (__graphics.__commands);
-			maskGraphics.__dirty = true;
-			maskGraphics.__visible = true;
-			
-			if (maskGraphics.__bounds == null) {
-				
-				maskGraphics.__bounds = new Rectangle();
-				
-			}
-			
-			__graphics.__getBounds (maskGraphics.__bounds, @:privateAccess Matrix.__identity);
-			
-		}
-		
-	}
-	
-	
 	private function __updateTransforms (overrideTransform:Matrix = null):Void {
 		
 		var overrided = overrideTransform != null;

--- a/src/openfl/display/IBitmapDrawable.hx
+++ b/src/openfl/display/IBitmapDrawable.hx
@@ -27,7 +27,6 @@ interface IBitmapDrawable {
 	private function __renderGLMask (renderer:OpenGLRenderer):Void;
 	private function __update (transformOnly:Bool, updateChildren:Bool):Void;
 	private function __updateChildren (transformOnly:Bool):Void;
-	private function __updateMask (maskGraphics:Graphics):Void;
 	private function __updateTransforms (?overrideTransform:Matrix = null):Void;
 	
 	private var __mask:DisplayObject;


### PR DESCRIPTION
The usage of this method was removed long ago, but the method itself wasn't removed for some reason, I assume it was just forgotten. This PR gets rid of it.