### PR TITLE
Enter/PASTE should dispatch text events

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2834,7 +2834,7 @@ class TextField extends InteractiveObject {
 					
 					dispatchEvent (te);
 					
-					if (!te.isDefaultPrevented()) {
+					if (!te.isDefaultPrevented ()) {
 						
 						__replaceSelectedText ("\n", true);
 						
@@ -3056,7 +3056,7 @@ class TextField extends InteractiveObject {
 						
 						dispatchEvent (te);
 						
-						if (!te.isDefaultPrevented()) {
+						if (!te.isDefaultPrevented ()) {
 							
 							__replaceSelectedText (Clipboard.text, true);
 							

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2830,9 +2830,17 @@ class TextField extends InteractiveObject {
 				
 				if (__textEngine.multiline) {
 					
-					__replaceSelectedText ("\n", true);
+					var te = new TextEvent (TextEvent.TEXT_INPUT, true, true, "\n");
 					
-					dispatchEvent (new Event (Event.CHANGE, true));
+					dispatchEvent (te);
+					
+					if (!te.isDefaultPrevented()) {
+						
+						__replaceSelectedText ("\n", true);
+						
+						dispatchEvent (new Event (Event.CHANGE, true));
+						
+					}
 					
 				}
 			
@@ -3042,12 +3050,25 @@ class TextField extends InteractiveObject {
 				
 				if (#if mac modifier.metaKey #else modifier.ctrlKey #end) {
 					
-					__replaceSelectedText (Clipboard.text, true);
+					if (Clipboard.text != null) {
+						
+						var te = new TextEvent (TextEvent.TEXT_INPUT, true, true, Clipboard.text);
+						
+						dispatchEvent (te);
+						
+						if (!te.isDefaultPrevented()) {
+							
+							__replaceSelectedText (Clipboard.text, true);
+							
+							dispatchEvent (new Event (Event.CHANGE, true));
+						}
+						
+					}
 					
-					dispatchEvent (new Event (Event.CHANGE, true));
 					
 				} else {
 					
+					// TODO: does this need to occur?
 					__textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end = __text.length;
 					
 				}


### PR DESCRIPTION
Adds `TEXT_INPUT` event dispatching for Enter and Ctrl+V, with proper `preventDefault` behavior.

Ctrl+V events do not occur if there is nothing on the Clipboard (`Clipboard.text == null`).