### PR TITLE
orphan display objects cleanup fixes

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1213,6 +1213,20 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 			
 		}
 		
+		if (__cacheBitmap != null) {
+			
+			__cacheBitmap.__cleanup();
+			__cacheBitmap = null;
+			
+		}
+		
+		if (__cacheBitmapData != null) {
+			
+			__cacheBitmapData.dispose();
+			__cacheBitmapData = null;
+			
+		}
+		
 	}
 	
 	

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -995,6 +995,8 @@ class DisplayObjectContainer extends InteractiveObject {
 	@:noCompletion private override function __renderCairoMask (renderer:CairoRenderer):Void {
 		
 		#if lime_cairo
+		__cleanupRemovedChildren ();
+		
 		if (__graphics != null) {
 			
 			CairoGraphics.renderMask (__graphics, renderer);
@@ -1054,6 +1056,8 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	
 	@:noCompletion private override function __renderCanvasMask (renderer:CanvasRenderer):Void {
+		
+		__cleanupRemovedChildren ();
 		
 		if (__graphics != null) {
 			

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -676,6 +676,23 @@ class DisplayObjectContainer extends InteractiveObject {
 	}
 	
 	
+	inline function __cleanupRemovedChildren () {
+		
+		for (orphan in __removedChildren) {
+			
+			if (orphan.stage == null) {
+				
+				orphan.__cleanup ();
+				
+			}
+			
+		}
+		
+		__removedChildren.length = 0;
+		
+	}
+	
+	
 	@:noCompletion private override function __dispatchChildren (event:Event):Void {
 		
 		if (__children != null) {
@@ -952,17 +969,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		for (orphan in __removedChildren) {
-			
-			if (orphan.stage == null) {
-				
-				orphan.__cleanup ();
-				
-			}
-			
-		}
-		
-		__removedChildren.length = 0;
+		__cleanupRemovedChildren ();
 		
 		renderer.__popMaskObject (this);
 		#end
@@ -1022,17 +1029,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		for (orphan in __removedChildren) {
-			
-			if (orphan.stage == null) {
-				
-				orphan.__cleanup ();
-				
-			}
-			
-		}
-		
-		__removedChildren.length = 0;
+		__cleanupRemovedChildren ();
 		
 		renderer.__popMaskObject (this);
 		
@@ -1087,17 +1084,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		for (orphan in __removedChildren) {
-			
-			if (orphan.stage == null) {
-				
-				orphan.__renderDOM (renderer);
-				
-			}
-			
-		}
-		
-		__removedChildren.length = 0;
+		__cleanupRemovedChildren ();
 		
 		renderer.__popMaskObject (this);
 		
@@ -1110,11 +1097,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			child.__renderDOMClear (renderer);
 		}
 		
-		for (orphan in __removedChildren) {
-			if (orphan.stage == null) {
-				orphan.__renderDOMClear (renderer);
-			}
-		}
+		__cleanupRemovedChildren ();
 		
 	}
 	
@@ -1155,17 +1138,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		for (orphan in __removedChildren) {
-			
-			if (orphan.stage == null) {
-				
-				orphan.__cleanup ();
-				
-			}
-			
-		}
-		
-		__removedChildren.length = 0;
+		__cleanupRemovedChildren ();
 		
 		if (__children.length > 0) {
 			
@@ -1191,6 +1164,8 @@ class DisplayObjectContainer extends InteractiveObject {
 			child.__renderGLMask (renderer);
 			
 		}
+		
+		__cleanupRemovedChildren ();
 		
 	}
 	

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -676,6 +676,21 @@ class DisplayObjectContainer extends InteractiveObject {
 	}
 	
 	
+	override function __cleanup ():Void {
+		
+		super.__cleanup ();
+		
+		for (child in __children) {
+			
+			child.__cleanup ();
+			
+		}
+		
+		__cleanupRemovedChildren ();
+		
+	}
+	
+	
 	inline function __cleanupRemovedChildren () {
 		
 		for (orphan in __removedChildren) {

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -955,6 +955,8 @@ class DisplayObjectContainer extends InteractiveObject {
 	@:noCompletion private override function __renderCairo (renderer:CairoRenderer):Void {
 		
 		#if lime_cairo
+		__cleanupRemovedChildren ();
+		
 		if (!__renderable || __worldAlpha <= 0) return;
 		
 		super.__renderCairo (renderer);
@@ -984,8 +986,6 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		__cleanupRemovedChildren ();
-		
 		renderer.__popMaskObject (this);
 		#end
 		
@@ -1012,6 +1012,8 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	
 	@:noCompletion private override function __renderCanvas (renderer:CanvasRenderer):Void {
+		
+		__cleanupRemovedChildren ();
 		
 		if (!__renderable || __worldAlpha <= 0 || (mask != null && (mask.width <= 0 || mask.height <= 0))) return;
 		
@@ -1044,8 +1046,6 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		__cleanupRemovedChildren ();
-		
 		renderer.__popMaskObject (this);
 		
 		#end
@@ -1071,6 +1071,8 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	
 	@:noCompletion private override function __renderDOM (renderer:DOMRenderer):Void {
+		
+		__cleanupRemovedChildren ();
 		
 		super.__renderDOM (renderer);
 		
@@ -1099,8 +1101,6 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		__cleanupRemovedChildren ();
-		
 		renderer.__popMaskObject (this);
 		
 	}
@@ -1108,16 +1108,18 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	@:noCompletion private override function __renderDOMClear (renderer:DOMRenderer):Void {
 		
+		__cleanupRemovedChildren ();
+		
 		for (child in __children) {
 			child.__renderDOMClear (renderer);
 		}
-		
-		__cleanupRemovedChildren ();
 		
 	}
 	
 	
 	@:noCompletion private override function __renderGL (renderer:OpenGLRenderer):Void {
+		
+		__cleanupRemovedChildren ();
 		
 		if (!__renderable || __worldAlpha <= 0) return;
 		
@@ -1153,8 +1155,6 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 		}
 		
-		__cleanupRemovedChildren ();
-		
 		if (__children.length > 0) {
 			
 			// renderer.filterManager.popObject (this);
@@ -1166,6 +1166,8 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	
 	@:noCompletion private override function __renderGLMask (renderer:OpenGLRenderer):Void {
+		
+		__cleanupRemovedChildren ();
 		
 		if (__graphics != null) {
 			
@@ -1179,8 +1181,6 @@ class DisplayObjectContainer extends InteractiveObject {
 			child.__renderGLMask (renderer);
 			
 		}
-		
-		__cleanupRemovedChildren ();
 		
 	}
 	


### PR DESCRIPTION
> from https://github.com/innogames/openfl/pull/57

- cleanup and dispose cache bitmap
- cleanup child display objects recursively
- always cleanup removed children even if we return early and don't actually do the rendering

---

this will properly (and timely) dispose cache bitmaps and their textures in the GPU. this greatly minimizes the impact of small-ish memory leaks, where the object is removed from the stage, but the reference to it is still hanging somewhere. we just had a nasty case with a minor event listener we forgot to remove retained a display object with huge cacheAsBitmap textures that were never cleaned up and took a lot of GPU space