### PR TITLE
[FIX] Typescript syntax errors

### DIFF
--- a/lib/openfl/filters/ConvolutionFilter.d.ts
+++ b/lib/openfl/filters/ConvolutionFilter.d.ts
@@ -22,7 +22,7 @@ declare namespace openfl.filters {
 		public matrixY:number;
 		public preserveAlpha:boolean;
 		
-		public constructor (matrixX?:number, matrixY?:number, matrix?:Array<Float>, divisor?:number, bias?:number, preserveAlpha?:boolean, clamp?:boolean, color?:number, alpha?:number):Void;
+		public constructor (matrixX?:number, matrixY?:number, matrix?:Array<number>, divisor?:number, bias?:number, preserveAlpha?:boolean, clamp?:boolean, color?:number, alpha?:number);
 		
 	}
 	

--- a/lib/openfl/utils/AssetCache.d.ts
+++ b/lib/openfl/utils/AssetCache.d.ts
@@ -7,7 +7,7 @@ import Font from "./../text/Font";
 declare namespace openfl.utils {
 	
 	
-	/*@:dox(hide)*/ export class AssetCache implements IAssetCache {
+	/*@:dox(hide)*/ export class AssetCache extends IAssetCache {
 	
 	
 		public enabled:boolean;

--- a/lib/openfl/utils/setTimeout.d.ts
+++ b/lib/openfl/utils/setTimeout.d.ts
@@ -1,6 +1,6 @@
 declare namespace openfl.utils {
 	
-	export function setTimeout (func:any, delay?:number, ...params?:Array<any>):number;
+	export function setTimeout (func:any, delay?:number, ...params:Array<any>):number;
 	
 }
 


### PR DESCRIPTION
There were some syntax errors in the typescript types that probably happend during the automatic conversion of the .hx files.

This would be a temporarily fix that worked for us to get typescript to transpile without errors but its best to find out what exactly went wrong during conversion (if it was done automatically and not by hand)