### PR TITLE
FIX: add __color = 0xFFFFFF; to Stage new function

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -660,7 +660,8 @@ class Stage extends DisplayObjectContainer implements IModule {
 		#end
 		
 		super ();
-		
+	
+		__color = 0xFFFFFF;
 		__colorSplit = [ 0xFF, 0xFF, 0xFF ];
 		__colorString = "#FFFFFF";
 		


### PR DESCRIPTION
Because __color is initialized as 0 (because its not set) but __colorSplit and __colorString are both initialized as '0xFFFFFF',
setting  a stageColor to 0x0 in window tag or using stage.color will fail because in set_color `(__color != value)` will eval to true.
So __color will still be 0 but __colorSplit and __colorString will be 0xFF . You will end up having a white background.
Using any other color will work , but just not black.

This has probably just been an accidental line delete ;)