### PR TITLE
Fix TextFormatRange management

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2228,7 +2228,30 @@ class TextField extends InteractiveObject {
 			if (range.start <= beginIndex && range.end >= endIndex) {
 				
 				range.end += offset;
-				i++;
+				
+				if (range.start == range.end) {
+					
+					__textEngine.textFormatRanges.splice (i, 1);
+					
+				} else {
+					
+					i++;
+					
+				}
+				
+			} else if (range.start <= beginIndex && range.end < endIndex && range.end > beginIndex) {
+				
+				range.end = beginIndex + newText.length;
+				
+				if (range.start == range.end) {
+					
+					__textEngine.textFormatRanges.splice (i, 1);
+					
+				} else {
+					
+					i++;
+					
+				}
 				
 			} else if (range.start >= beginIndex && range.end <= endIndex) {
 				
@@ -2244,11 +2267,17 @@ class TextField extends InteractiveObject {
 					
 				}
 				
-				offset -= (range.end - range.start);
+			} else if (range.start >= beginIndex && range.end > endIndex && endIndex > range.start) {
 				
-			} else if (range.start > beginIndex && range.start <= endIndex) {
+				range.start = beginIndex;
+				range.end += offset;
+				i++;
+			
+			} else if (range.start >= endIndex) {
 				
 				range.start += offset;
+				range.end += offset;
+				
 				i++;
 				
 			} else {


### PR DESCRIPTION
TextFormatRanges were not handled properly for each possible case. The issues were most obvious with input text, where adding or deleting text would cause the formats to "move" relative to the text.

Let me know if there are issues, I didn't extensively test it.