### PR TITLE
Use highp floats for GLES shaders

### DIFF
--- a/assets/templates/swf/MovieClip.mtt
+++ b/assets/templates/swf/MovieClip.mtt
@@ -1,7 +1,7 @@
 package ::PACKAGE_NAME::; #if !flash
 
 
-import openfl._internal.swf.SWFLite;
+import openfl._internal.formats.swf.SWFLite;
 import openfl.display.MovieClip;
 import openfl.Assets;
 

--- a/assets/templates/swf/SimpleButton.mtt
+++ b/assets/templates/swf/SimpleButton.mtt
@@ -1,7 +1,7 @@
 package ::PACKAGE_NAME::; #if !flash
 
 
-import openfl._internal.swf.SWFLite;
+import openfl._internal.formats.swf.SWFLite;
 import openfl.display.SimpleButton;
 import openfl.Assets;
 

--- a/lib-esm/openfl/utils/AssetLibrary.js
+++ b/lib-esm/openfl/utils/AssetLibrary.js
@@ -1,8 +1,8 @@
 export { default } from "./../../_gen/openfl/utils/AssetLibrary";
 
-import { default as FilterType } from "../../_gen/openfl/_internal/swf/FilterType";
-import { default as ShapeCommand } from "../../_gen/openfl/_internal/swf/ShapeCommand";
-import { default as SWFLiteLibrary } from "../../_gen/openfl/_internal/swf/SWFLiteLibrary";
+import { default as FilterType } from "../../_gen/openfl/_internal/formats/swf/FilterType";
+import { default as ShapeCommand } from "../../_gen/openfl/_internal/formats/swf/ShapeCommand";
+import { default as SWFLiteLibrary } from "../../_gen/openfl/_internal/formats/swf/SWFLiteLibrary";
 import { default as BitmapSymbol } from "../../_gen/openfl/_internal/symbols/BitmapSymbol";
 import { default as ButtonSymbol } from "../../_gen/openfl/_internal/symbols/ButtonSymbol";
 import { default as DynamicTextSymbol } from "../../_gen/openfl/_internal/symbols/DynamicTextSymbol";
@@ -12,9 +12,9 @@ import { default as SpriteSymbol } from "../../_gen/openfl/_internal/symbols/Spr
 import { default as StaticTextRecord } from "../../_gen/openfl/_internal/symbols/StaticTextRecord";
 import { default as StaticTextSymbol } from "../../_gen/openfl/_internal/symbols/StaticTextSymbol";
 import { default as SWFSymbol } from "../../_gen/openfl/_internal/symbols/SWFSymbol";
-import { default as Frame } from "../../_gen/openfl/_internal/timeline/Frame";
-import { default as FrameObject } from "../../_gen/openfl/_internal/timeline/FrameObject";
-import { default as FrameObjectType } from "../../_gen/openfl/_internal/timeline/FrameObjectType";
+import { default as Frame } from "../../_gen/openfl/_internal/symbols/timeline/Frame";
+import { default as FrameObject } from "../../_gen/openfl/_internal/symbols/timeline/FrameObject";
+import { default as FrameObjectType } from "../../_gen/openfl/_internal/symbols/timeline/FrameObjectType";
 
 // Apart from adding this file to the sideEffects array in package.json, we also need 
 // to list each class out here so that it is included in the webpack bundle

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -377,8 +377,12 @@ class Shader {
 			var prefix = 
 				
 				"#ifdef GL_ES
-				precision " + (precisionHint == FULL ? "mediump" : "lowp") + " float;
-				#endif
+					#ifdef GL_FRAGMENT_PRECISION_HIGH
+					precision highp float;
+					#else
+					precision " + (precisionHint == FULL ? "mediump" : "lowp") + " float;
+					#endif // GL_FRAGMENT_PRECISION_HIGH
+				#endif // GL_ES
 				";
 			
 			var vertex = prefix + glVertexSource;


### PR DESCRIPTION
This fix eliminates visible shearing on rotation and disappearing on very small scale of display objects on certain devices.
By using high precision floats for vertex shader fixes this issue completely.
Check if device supports fragment precision floats to avoid crashing on devices that don't support it.
Thanks to @justin-espedal for finding this problem.