### PR TITLE
Restore binding to non-default framebuffer

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -2455,11 +2455,12 @@ class BitmapData implements IBitmapDrawable {
 		
 		var gl = renderer.__gl;
 		
+		@:privateAccess var oldFramebuffer = renderer.__framebuffers[gl.FRAMEBUFFER];
 		renderer.bindFramebuffer (gl.FRAMEBUFFER, __getFramebuffer (renderer, true));
 		
 		renderer.__render (source);
 		
-		renderer.bindFramebuffer (gl.FRAMEBUFFER, null);
+		renderer.bindFramebuffer (gl.FRAMEBUFFER, oldFramebuffer);
 		
 	}
 	
@@ -2481,7 +2482,7 @@ class BitmapData implements IBitmapDrawable {
 			var color:ARGB = (color:ARGB);
 			var useScissor = !this.rect.equals (rect);
 			
-			renderer.bindFramebuffer (gl.FRAMEBUFFER, __framebuffer);
+			var oldFramebuffer = renderer.bindFramebuffer (gl.FRAMEBUFFER, __framebuffer);
 			
 			if (useScissor) {
 				
@@ -2499,7 +2500,7 @@ class BitmapData implements IBitmapDrawable {
 				
 			}
 			
-			renderer.bindFramebuffer (gl.FRAMEBUFFER, null);
+			renderer.bindFramebuffer (gl.FRAMEBUFFER, oldFramebuffer);
 			
 		} else if (readable) {
 			

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -385,14 +385,17 @@ class OpenGLRenderer extends DisplayObjectRenderer {
 	}
 	
 	
-	public function bindFramebuffer (target:Int, framebuffer:GLFramebuffer):Void {
+	public function bindFramebuffer (target:Int, framebuffer:GLFramebuffer):GLFramebuffer {
 		
-		if (__framebuffers[target] != framebuffer) {
+		var old = __framebuffers[target];
+		
+		if (old != framebuffer) {
 			
 			__framebuffers[target] = framebuffer;
 			__gl.bindFramebuffer (target, framebuffer);
-			
 		}
+		
+		return old;
 		
 	}
 	
@@ -1254,6 +1257,7 @@ class OpenGLRenderer extends DisplayObjectRenderer {
 		if (source == null || shader == null) return;
 		if (__defaultRenderTarget == null) return;
 		
+		var oldFramebuffer = __framebuffers[__gl.FRAMEBUFFER];
 		bindFramebuffer (__gl.FRAMEBUFFER, __defaultRenderTarget.__getFramebuffer (this, false));
 		
 		if (clear) {
@@ -1276,7 +1280,7 @@ class OpenGLRenderer extends DisplayObjectRenderer {
 		if (shader.__textureCoord != null) __gl.vertexAttribPointer (shader.__textureCoord.index, 2, __gl.FLOAT, false, 14 * Float32Array.BYTES_PER_ELEMENT, 3 * Float32Array.BYTES_PER_ELEMENT);
 		__gl.drawArrays (__gl.TRIANGLE_STRIP, 0, 4);
 		
-		bindFramebuffer (__gl.FRAMEBUFFER, null);
+		bindFramebuffer (__gl.FRAMEBUFFER, oldFramebuffer);
 		
 		__clearShader ();
 		


### PR DESCRIPTION
Allow a framebuffer other than the default to be restored to after temporarily binding other framebuffers.

This approach remembers and restores the previous buffer, whatever it was.