### PR TITLE
Multi-format word fixes, round 3

### DIFF
--- a/src/openfl/_internal/text/TextEngine.hx
+++ b/src/openfl/_internal/text/TextEngine.hx
@@ -893,7 +893,7 @@ class TextEngine {
 					
 					var advance;
 					
-					if (i < text.length-1) {
+					if (i < text.length - 1) {
 						
 						// Advance can be less for certain letter combinations, e.g. 'Yo' vs. 'Do'
 						var nextWidth = __context.measureText (text.charAt (i + 1)).width;
@@ -1025,42 +1025,28 @@ class TextEngine {
 			
 		}
 		
-		#if !js inline #end function nextFormatRange ():Void {
+		#if !js inline #end function setLineMetrics ():Void {
 			
-			if (rangeIndex < textFormatRanges.length - 1) {
+			if (currentFormat.__ascent != null) {
 				
-				rangeIndex++;
-				formatRange = textFormatRanges[rangeIndex];
-				currentFormat.__merge (formatRange.format);
+				ascent = currentFormat.size * currentFormat.__ascent;
+				descent = currentFormat.size * currentFormat.__descent;
 				
-				#if (js && html5)
-				__context.font = getFont (currentFormat);
-				#end
+			} else if (font != null && font.unitsPerEM != 0) {
 				
-				font = getFontInstance (currentFormat);
+				ascent = (font.ascender / font.unitsPerEM) * currentFormat.size;
+				descent = Math.abs ((font.descender / font.unitsPerEM) * currentFormat.size);
 				
-				if (currentFormat.__ascent != null) {
-					
-					ascent = currentFormat.size * currentFormat.__ascent;
-					descent = currentFormat.size * currentFormat.__descent;
-					
-				} else if (font != null && font.unitsPerEM != 0) {
-					
-					ascent = (font.ascender / font.unitsPerEM) * currentFormat.size;
-					descent = Math.abs ((font.descender / font.unitsPerEM) * currentFormat.size);
-					
-				} else {
-					
-					ascent = currentFormat.size;
-					descent = currentFormat.size * 0.185;
-					
-				}
+			} else {
 				
-				leading = currentFormat.leading;
-				
-				heightValue = ascent + descent + leading;
+				ascent = currentFormat.size;
+				descent = currentFormat.size * 0.185;
 				
 			}
+			
+			leading = currentFormat.leading;
+			
+			heightValue = ascent + descent + leading;
 			
 			if (heightValue > maxHeightValue) {
 				
@@ -1076,21 +1062,147 @@ class TextEngine {
 			
 		}
 		
+		#if !js inline #end function nextFormatRange ():Void {
+			
+			if (rangeIndex < textFormatRanges.length - 1) {
+				
+				rangeIndex++;
+				formatRange = textFormatRanges[rangeIndex];
+				currentFormat.__merge (formatRange.format);
+				
+				#if (js && html5)
+				__context.font = getFont (currentFormat);
+				#end
+				
+				font = getFontInstance (currentFormat);
+				
+			}
+			
+		}
+		
+		#if !js inline #end function setFormattedPositions (startIndex:Int, endIndex:Int) {
+			// sets the positions of the text from start to end, including format changes if there are any
+			
+			if (endIndex <= formatRange.end) {
+				
+				positions = getPositions (text, startIndex, endIndex);
+				widthValue = getPositionsWidth (positions);
+				
+			} else {
+				
+				var tempIndex = startIndex;
+				var tempRangeEnd = formatRange.end;
+				var countRanges = 0;
+				
+				positions = [];
+				widthValue = 0;
+				
+				while (true) {
+					
+					var tempPositions = getPositions (text, tempIndex, tempRangeEnd);
+					
+					positions = positions.concat(tempPositions);
+					
+					widthValue += getPositionsWidth (positions);
+					
+					if (tempRangeEnd != endIndex) {
+						
+						nextFormatRange ();
+						
+						tempIndex = tempRangeEnd;
+						tempRangeEnd = endIndex < formatRange.end ? endIndex : formatRange.end;
+						
+						countRanges++;
+						
+					}
+					
+					else break;
+					
+				}
+				
+				rangeIndex -= countRanges + 1;
+				nextFormatRange (); // get back to the formatRange and font
+				
+			}
+			
+		}
+		
+		#if !js inline #end function placeFormattedText (endIndex:Int):Void {
+			
+			if (endIndex <= formatRange.end) {
+				// don't worry about placing multiple formats if a space or break happens first
+				
+				positions = getPositions (text, textIndex, endIndex);
+				widthValue = getPositionsWidth (positions);
+				
+				nextLayoutGroup (textIndex, endIndex);
+				
+				layoutGroup.positions = positions;
+				layoutGroup.offsetX = offsetX;
+				layoutGroup.ascent = ascent;
+				layoutGroup.descent = descent;
+				layoutGroup.leading = leading;
+				layoutGroup.lineIndex = lineIndex;
+				layoutGroup.offsetY = offsetY;
+				layoutGroup.width = widthValue;
+				layoutGroup.height = heightValue;
+				
+				offsetX += widthValue;
+				
+				if (endIndex == formatRange.end) {
+					
+					layoutGroup = null;
+					nextFormatRange ();
+					setLineMetrics ();
+					
+				}
+				
+			} else {
+			
+				// fill in all text from start to end, including any format changes
+				
+				while (true) {
+					
+					var tempRangeEnd = endIndex < formatRange.end ? endIndex : formatRange.end;
+					
+					positions = getPositions (text, textIndex, tempRangeEnd);
+					widthValue = getPositionsWidth (positions);
+					
+					nextLayoutGroup (textIndex, tempRangeEnd);
+					
+					layoutGroup.positions = positions;
+					layoutGroup.offsetX = offsetX;
+					layoutGroup.ascent = ascent;
+					layoutGroup.descent = descent;
+					layoutGroup.leading = leading;
+					layoutGroup.lineIndex = lineIndex;
+					layoutGroup.offsetY = offsetY;
+					layoutGroup.width = widthValue;
+					layoutGroup.height = heightValue;
+					
+					offsetX += widthValue;
+					
+					textIndex = tempRangeEnd;
+					
+					if (tempRangeEnd == formatRange.end) layoutGroup = null;
+					
+					if (tempRangeEnd == endIndex) break;
+					
+					nextFormatRange ();
+					setLineMetrics ();
+					
+				}
+				
+			}
+			
+			textIndex = endIndex;
+			
+		}
+		
 		#if !js inline #end function alignBaseline ():Void {
 			// aligns the baselines of all characters in a single line
 			
-			// since nextFormatRange may not have been called, have to update these manually
-			if (ascent > maxAscent) {
-				
-				maxAscent = ascent;
-				
-			}
-			
-			if (heightValue > maxHeightValue) {
-				
-				maxHeightValue = heightValue;
-				
-			}
+			setLineMetrics ();
 			
 			var i = layoutGroups.length;
 			
@@ -1117,77 +1229,104 @@ class TextEngine {
 		}
 		
 		#if !js inline #end function breakLongWords (endIndex:Int):Void {
+			// breaks up words that are too long to fit in a single line
 			
-			var tempWidth = getTextWidth (text.substring (textIndex, endIndex));
+			var remainingPositions = positions;
+			var i, positionWidth;
+			var currentPosition, tempPositions;
+			
+			var tempWidth = getPositionsWidth (remainingPositions);
 			
 			while (offsetX + tempWidth > width - 2) {
 				
-				var i = 1;
+				i = 0;
+				positionWidth = 0.0;
 				
-				while (textIndex + i < endIndex + 1) {
+				while (offsetX + positionWidth < width - 2) {
 					
-					tempWidth = getTextWidth (text.substr (textIndex, i));
+					currentPosition = remainingPositions[i];
 					
-					if (offsetX + tempWidth > width - 2) {
+					if (#if (js && html5) currentPosition #else currentPosition.advance.x #end == 0.0) {
 						
-						i--;
-						break;
+						// skip Unicode character buffer positions
+						i++;
 						
 					}
 					
-					i++;
+					else {
+						
+						positionWidth += #if (js && html5) currentPosition #else currentPosition.advance.x #end;
+						i++;
+						
+					}
 					
 				}
 				
-				if (i == 0 && tempWidth > width - 4) {
-					// if the textfield is smaller than a single character
+				if (i < 2 && positionWidth > width - 4) {
+					// if the textfield is smaller than the first character in a line, automatically wrap the next character
 					
-					i = text.length;
-					
-				}
-				
-				if (i == 0) {
-					// if a single character in a new format made the line too long
-					
-					offsetX = 2;
-					offsetY += layoutGroup.height;
-					++lineIndex;
-					
-					break;
+					// unless it's the last line of the long word
+					if (textIndex + i == endIndex) {
+						
+						break;
+						
+					}
 					
 				}
 				
 				else {
 					
-					nextLayoutGroup (textIndex, textIndex + i);
-					layoutGroup.positions = getPositions (text, textIndex, textIndex + i);
-					layoutGroup.offsetX = offsetX;
-					layoutGroup.ascent = ascent;
-					layoutGroup.descent = descent;
-					layoutGroup.leading = leading;
-					layoutGroup.lineIndex = lineIndex;
-					layoutGroup.offsetY = offsetY;
-					layoutGroup.width = getPositionsWidth (layoutGroup.positions);
-					layoutGroup.height = heightValue;
+					// remove characters until the text fits one line
+					// because of combining letters potentially being broken up now, we have to redo the formatted positions each time
+					while (offsetX + positionWidth > width - 2) {
 					
-					layoutGroup = null;
-					
-					alignBaseline ();
-					
-					textIndex += i;
-					
-					positions = getPositions (text, textIndex, endIndex);
-					widthValue = getPositionsWidth (positions);
-					
-					tempWidth = widthValue;
+						i--;
+						
+						if (i > 0) {
+							
+							setFormattedPositions (textIndex, textIndex + i);
+							positionWidth = widthValue;
+							
+						}
+						
+						else {
+							
+							i = 1;
+							
+						}
+						
+					}
 					
 				}
 				
+				placeFormattedText (textIndex + i);
+				alignBaseline();
+				
+				setFormattedPositions (i, remainingPositions.length);
+				
+				remainingPositions = positions;
+				tempWidth = widthValue;
+				
 			}
+			
+			// positions only contains the final unbroken line at the end
+			
+		}
+		
+		#if !js inline #end function placeText (endIndex:Int):Void {
+			
+			if (width >= 4 && wordWrap) {
+				
+				breakLongWords (endIndex);
+				
+			}
+			
+			placeFormattedText (endIndex);
 			
 		}
 		
 		nextFormatRange ();
+		setLineMetrics ();
 		
 		lineFormat = formatRange.format;
 		var wrap;
@@ -1195,28 +1334,13 @@ class TextEngine {
 		
 		while (textIndex < maxLoops) {
 			
-			if ((breakIndex > -1) && (spaceIndex == -1 || breakIndex < spaceIndex) && (formatRange.end >= breakIndex)) {
+			if ((breakIndex > -1) && (spaceIndex == -1 || breakIndex < spaceIndex)) {
 				// if a line break is the next thing that needs to be dealt with
 				
 				if (textIndex <= breakIndex) {
 					
-					if (wordWrap && previousSpaceIndex <= textIndex && width >= 4) {
-						
-						breakLongWords (breakIndex);
-						
-					}
-					
-					nextLayoutGroup (textIndex, breakIndex);
-					
-					layoutGroup.positions = getPositions (text, textIndex, breakIndex);
-					layoutGroup.offsetX = offsetX;
-					layoutGroup.ascent = ascent;
-					layoutGroup.descent = descent;
-					layoutGroup.leading = leading;
-					layoutGroup.lineIndex = lineIndex;
-					layoutGroup.offsetY = offsetY;
-					layoutGroup.width = getPositionsWidth (layoutGroup.positions);
-					layoutGroup.height = heightValue;
+					setFormattedPositions (textIndex, breakIndex);
+					placeText (breakIndex);
 					
 					layoutGroup = null;
 					
@@ -1236,6 +1360,7 @@ class TextEngine {
 				if (formatRange.end == breakIndex) {
 					
 					nextFormatRange ();
+					setLineMetrics ();
 					lineFormat = formatRange.format;
 					
 				}
@@ -1252,7 +1377,7 @@ class TextEngine {
 				textIndex = breakIndex + 1;
 				breakIndex = getLineBreakIndex (textIndex);
 				
-			} else if (formatRange.end >= spaceIndex && spaceIndex > -1 && textIndex < formatRange.end) {
+			} else if (spaceIndex > -1) {
 				// if a space is the next thing that needs to be dealt with
 				
 				if (layoutGroup != null && layoutGroup.startIndex != layoutGroup.endIndex) {
@@ -1265,7 +1390,7 @@ class TextEngine {
 				
 				while (true) {
 					
-					if (textIndex == formatRange.end) break;
+					if (textIndex >= text.length) break;
 					
 					var endIndex = -1;
 					
@@ -1287,14 +1412,13 @@ class TextEngine {
 						
 					}
 					
-					if (endIndex == -1 || endIndex > formatRange.end) {
+					if (endIndex == -1) {
 						
-						endIndex = formatRange.end;
+						endIndex = text.length;
 						
 					}
 					
-					positions = getPositions (text, textIndex, endIndex);
-					widthValue = getPositionsWidth (positions);
+					setFormattedPositions (textIndex, endIndex);
 					
 					if (lineFormat.align == JUSTIFY) {
 						
@@ -1309,7 +1433,7 @@ class TextEngine {
 							
 						}
 						
-						if (positions.length > 0 && endIndex == spaceIndex+1) {
+						if (positions.length > 0 && endIndex == spaceIndex + 1) {
 							
 							// Trim right space of this word
 							endIndex--;
@@ -1407,23 +1531,7 @@ class TextEngine {
 							
 						}
 						
-						if (width >= 4) breakLongWords (endIndex);
-						
-						nextLayoutGroup (textIndex, endIndex);
-						
-						layoutGroup.positions = positions;
-						layoutGroup.offsetX = offsetX;
-						layoutGroup.ascent = ascent;
-						layoutGroup.descent = descent;
-						layoutGroup.leading = leading;
-						layoutGroup.lineIndex = lineIndex;
-						layoutGroup.offsetY = offsetY;
-						layoutGroup.width = widthValue;
-						layoutGroup.height = heightValue;
-						
-						offsetX += widthValue;
-						
-						textIndex = endIndex;
+						placeText (endIndex);
 						
 						wrap = false;
 						
@@ -1431,6 +1539,7 @@ class TextEngine {
 						
 						if (layoutGroup != null && textIndex == spaceIndex) {
 							
+							// TODO: does this case ever happen?
 							if (lineFormat.align != JUSTIFY) {
 								
 								layoutGroup.endIndex = spaceIndex;
@@ -1439,19 +1548,13 @@ class TextEngine {
 								
 							}
 							
+							offsetX += widthValue;
+							
+							textIndex = endIndex;
+							
 						} else if (layoutGroup == null || lineFormat.align == JUSTIFY) {
 							
-							nextLayoutGroup (textIndex, endIndex);
-							
-							layoutGroup.positions = positions;
-							layoutGroup.offsetX = offsetX;
-							layoutGroup.ascent = ascent;
-							layoutGroup.descent = descent;
-							layoutGroup.leading = leading;
-							layoutGroup.lineIndex = lineIndex;
-							layoutGroup.offsetY = offsetY;
-							layoutGroup.width = widthValue;
-							layoutGroup.height = heightValue;
+							placeText (endIndex);
 							
 						} else {
 							
@@ -1459,14 +1562,22 @@ class TextEngine {
 							layoutGroup.positions = layoutGroup.positions.concat (positions);
 							layoutGroup.width += widthValue;
 							
+							if (endIndex == formatRange.end) {
+								
+								layoutGroup = null;
+								nextFormatRange ();
+								setLineMetrics ();
+								
+							}
+							
 							// If next char is newline, process it immediately and prevent useless extra layout groups
 							if (breakIndex == endIndex) endIndex++;
 							
+							offsetX += widthValue;
+							
+							textIndex = endIndex;
+							
 						}
-						
-						offsetX += widthValue;
-						
-						textIndex = endIndex;
 						
 					}
 					
@@ -1476,8 +1587,10 @@ class TextEngine {
 						
 						layoutGroup = null;
 						textIndex = formatRange.end;
-						nextFormatRange ();
 						
+						nextFormatRange ();
+						setLineMetrics ();
+							
 					} else {
 						
 						// Check if we can continue wrapping this line until the next line-break or end-of-String.
@@ -1503,7 +1616,7 @@ class TextEngine {
 						
 					}
 					
-					if ((breakIndex > -1 && breakIndex <= textIndex && (spaceIndex > breakIndex || spaceIndex == -1)) || textIndex > text.length || spaceIndex > formatRange.end) {
+					if ((breakIndex > -1 && breakIndex <= textIndex && (spaceIndex > breakIndex || spaceIndex == -1)) || textIndex > text.length) {
 						
 						break;
 						
@@ -1512,50 +1625,19 @@ class TextEngine {
 				}
 				
 			} else {
-				// if there are no line breaks or spaces to deal with next, place remaining text in the format range
 				
-				if (textIndex > formatRange.end) {
+				if (textIndex < text.length) {
+				
+					// if there are no line breaks or spaces to deal with next, place all remaining text
 					
-					break;
+					setFormattedPositions (textIndex, text.length);
+					placeText (text.length);
 					
-				} else if (textIndex < formatRange.end || textIndex == text.length) {
-					
-					if (wordWrap && width >= 4) {
-						
-						breakLongWords(formatRange.end);
-						
-					}
-					
-					positions = getPositions (text, textIndex, formatRange.end);
-					widthValue = getPositionsWidth (positions);
-					
-					nextLayoutGroup (textIndex, formatRange.end);
-					
-					layoutGroup.positions = getPositions (text, textIndex, formatRange.end);
-					layoutGroup.offsetX = offsetX;
-					layoutGroup.ascent = ascent;
-					layoutGroup.descent = descent;
-					layoutGroup.leading = leading;
-					layoutGroup.lineIndex = lineIndex;
-					layoutGroup.offsetY = offsetY;
-					layoutGroup.width = getPositionsWidth (layoutGroup.positions);
-					layoutGroup.height = heightValue;
-					
-					offsetX += widthValue;
-					textIndex = formatRange.end;
+					alignBaseline ();
 					
 				}
 				
-				nextFormatRange ();
-				
-				if (textIndex == formatRange.end) {
-					
-					alignBaseline();
-					
-					textIndex++;
-					break;
-					
-				}
+				textIndex++;
 				
 			}
 			

--- a/src/openfl/_internal/text/TextEngine.hx
+++ b/src/openfl/_internal/text/TextEngine.hx
@@ -1099,11 +1099,14 @@ class TextEngine {
 				
 				while (true) {
 					
-					var tempPositions = getPositions (text, tempIndex, tempRangeEnd);
-					
-					positions = positions.concat(tempPositions);
-					
-					widthValue += getPositionsWidth (positions);
+					if (tempIndex != tempRangeEnd) {
+						
+						var tempPositions = getPositions (text, tempIndex, tempRangeEnd);
+						positions = positions.concat(tempPositions);
+						
+						widthValue += getPositionsWidth (positions);
+						
+					}
 					
 					if (tempRangeEnd != endIndex) {
 						
@@ -1165,24 +1168,28 @@ class TextEngine {
 					
 					var tempRangeEnd = endIndex < formatRange.end ? endIndex : formatRange.end;
 					
-					positions = getPositions (text, textIndex, tempRangeEnd);
-					widthValue = getPositionsWidth (positions);
-					
-					nextLayoutGroup (textIndex, tempRangeEnd);
-					
-					layoutGroup.positions = positions;
-					layoutGroup.offsetX = offsetX;
-					layoutGroup.ascent = ascent;
-					layoutGroup.descent = descent;
-					layoutGroup.leading = leading;
-					layoutGroup.lineIndex = lineIndex;
-					layoutGroup.offsetY = offsetY;
-					layoutGroup.width = widthValue;
-					layoutGroup.height = heightValue;
-					
-					offsetX += widthValue;
-					
-					textIndex = tempRangeEnd;
+					if (textIndex != tempRangeEnd) {
+						
+						positions = getPositions (text, textIndex, tempRangeEnd);
+						widthValue = getPositionsWidth (positions);
+						
+						nextLayoutGroup (textIndex, tempRangeEnd);
+						
+						layoutGroup.positions = positions;
+						layoutGroup.offsetX = offsetX;
+						layoutGroup.ascent = ascent;
+						layoutGroup.descent = descent;
+						layoutGroup.leading = leading;
+						layoutGroup.lineIndex = lineIndex;
+						layoutGroup.offsetY = offsetY;
+						layoutGroup.width = widthValue;
+						layoutGroup.height = heightValue;
+						
+						offsetX += widthValue;
+						
+						textIndex = tempRangeEnd;
+						
+					}
 					
 					if (tempRangeEnd == formatRange.end) layoutGroup = null;
 					


### PR DESCRIPTION
Closes #1675, #1984 I think. Redo of #1771 and #1942. Multiple formats within the same word behave now, I hope.

The diff is kind of a mess, but this PR ignores `formatRange.end` when word wrapping. All text between `textIndex` and the next space/break/end of text is placed at once, and all format changes, word wrapping, and breaking of long words are handled within each of those placements.
