### PR TITLE
Support inverted rectangles as dragging bounds

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1922,8 +1922,8 @@ class Stage extends DisplayObjectContainer implements IModule {
 			__dragBounds = new Rectangle ();
 			__dragBounds.x = bounds.right < bounds.x ? bounds.right : bounds.x;
 			__dragBounds.y = bounds.bottom < bounds.y ? bounds.bottom : bounds.y;
-			__dragBounds.width = Math.abs(bounds.width);
-			__dragBounds.height = Math.abs(bounds.height);
+			__dragBounds.width = Math.abs (bounds.width);
+			__dragBounds.height = Math.abs (bounds.height);
 		}
 		
 		__dragObject = sprite;

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1916,7 +1916,16 @@ class Stage extends DisplayObjectContainer implements IModule {
 	
 	private function __startDrag (sprite:Sprite, lockCenter:Bool, bounds:Rectangle):Void {
 		
-		__dragBounds = (bounds == null) ? null : bounds.clone ();
+		if (bounds == null) {
+			__dragBounds = null;
+		} else {
+			__dragBounds = new Rectangle ();
+			__dragBounds.x = bounds.right < bounds.x ? bounds.right : bounds.x;
+			__dragBounds.y = bounds.bottom < bounds.y ? bounds.bottom : bounds.y;
+			__dragBounds.width = Math.abs(bounds.width);
+			__dragBounds.height = Math.abs(bounds.height);
+		}
+		
 		__dragObject = sprite;
 		
 		if (__dragObject != null) {

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1917,13 +1917,20 @@ class Stage extends DisplayObjectContainer implements IModule {
 	private function __startDrag (sprite:Sprite, lockCenter:Bool, bounds:Rectangle):Void {
 		
 		if (bounds == null) {
+			
 			__dragBounds = null;
+			
 		} else {
+			
 			__dragBounds = new Rectangle ();
-			__dragBounds.x = bounds.right < bounds.x ? bounds.right : bounds.x;
-			__dragBounds.y = bounds.bottom < bounds.y ? bounds.bottom : bounds.y;
+			
+			var right = bounds.right;
+			var bottom = bounds.bottom;
+			__dragBounds.x = right < bounds.x ? right : bounds.x;
+			__dragBounds.y = bottom < bounds.y ? bottom : bounds.y;
 			__dragBounds.width = Math.abs (bounds.width);
 			__dragBounds.height = Math.abs (bounds.height);
+			
 		}
 		
 		__dragObject = sprite;


### PR DESCRIPTION
In flash, if you pass a rectangle with negative width or height as a parameter to Sprite's `startDrag` function as dragging bounds, the dragging will work properly  while in openfl it won't. "Inverted" rectangles are not supported so the dragging is behaving weirdly. Therefore this PR fixes the issue