### PR TITLE
Fix oversight in setTextFormat

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1241,6 +1241,11 @@ class TextField extends InteractiveObject {
 					
 					range.format = __textFormat.clone ();
 					range.format.__merge (format);
+					
+					__dirty = true;
+					__layoutDirty = true;
+					__setRenderDirty ();
+					
 					return;
 					
 				}


### PR DESCRIPTION
The early return means that the dirty flags are not set for the case where the existing and new text formats have the same range. The format wouldn't visually update until something else happened to the textfield to trigger the flags.