### PR TITLE
Hit test tile

### DIFF
--- a/src/openfl/display/Tile.hx
+++ b/src/openfl/display/Tile.hx
@@ -255,10 +255,14 @@ class Tile {
 	 */
 	private function __getWorldTransform():Matrix
 	{
-		if (parent == null) return matrix.clone(); //I am not in the world... what do I do!?
-		var retval = new Matrix();
-		retval = parent.__getWorldTransform();
-		retval.concat(matrix);
+		var retval = matrix.clone();
+		if (parent != null)
+		{
+			var parentMatrix = Matrix.__pool.get();
+			parentMatrix = parent.__getWorldTransform();
+			retval.concat(parentMatrix);
+			Matrix.__pool.release(parentMatrix);
+		}
 		return retval;
 	}
 	

--- a/src/openfl/display/TileContainer.hx
+++ b/src/openfl/display/TileContainer.hx
@@ -1,11 +1,15 @@
 package openfl.display;
 
+import openfl.geom.Rectangle;
+import openfl.geom.Matrix;
+
 
 #if !openfl_debug
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
-
+@:access(openfl.geom.Matrix)
+@:access(openfl.geom.Rectangle)
 
 class TileContainer extends Tile implements ITileContainer {
 	
@@ -213,6 +217,29 @@ class TileContainer extends Tile implements ITileContainer {
 		
 		__setRenderDirty ();
 		
+	}
+
+
+	/**
+	 * Override from tile. A single tile, just has his rectangle.
+	 * A container must get a rectangle that contains all other rectangles.
+	 * 
+	 * @param targetCoordinateSpace The tile that works as a coordinate system.
+	 * @return Rectangle The bounding box. If no box found, this will return {0,0,0,0} rectangle instead of null.
+	 */
+	public override function getBounds(targetCoordinateSpace:Tile):Rectangle
+	{
+		//Get a rectangle of at least my original size.
+		var arrRects = new Array<Rectangle>();
+		var retval = new Rectangle();
+		var tmpRect = Rectangle.__pool.get();
+		for (tile in __tiles) 
+		{
+			tmpRect = tile.getBounds(targetCoordinateSpace);
+			retval.__expand(tmpRect.x,tmpRect.y,tmpRect.width,tmpRect.height);
+		}
+		Rectangle.__pool.release(tmpRect);
+		return retval;
 	}
 	
 	

--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -82,7 +82,7 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 		tileColorTransformEnabled = true;
 		
 		__group = new TileContainer ();
-		
+		__group.tileset = tileset;
 		#if !flash
 		__width = width;
 		__height = height;
@@ -445,6 +445,7 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 		if (value != __tileset) {
 			
 			__tileset = value;
+			__group.tileset =  value;
 			__group.__dirty = true;
 			
 			#if !flash


### PR DESCRIPTION
Bounding box collision for tiles vs tiles.

A lot of code stolen from how DisplayObject does it.

Keeps the naming conventions so if we ever get a way to jump from `__group` to the parent `Tilemap` object, tile vs display object is totally possible.