### PR TITLE
Fixes TextField text update when filter applied

### DIFF
--- a/src/openfl/filters/DropShadowFilter.hx
+++ b/src/openfl/filters/DropShadowFilter.hx
@@ -247,7 +247,7 @@ import openfl.geom.Rectangle;
 		
 		__updateSize ();
 		
-		__needSecondBitmapData = true;
+		__needSecondBitmapData = false;
 		__preserveObject = !__hideObject;
 		__renderDirty = true;
 		
@@ -274,6 +274,9 @@ import openfl.geom.Rectangle;
 		destPoint.y += __offsetY;
 		
 		var finalImage = ImageDataUtil.gaussianBlur (bitmapData.image, sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), __blurX, __blurY, __quality, __strength);
+		
+		destPoint.x = __offsetX;
+		destPoint.y = __offsetY;
 		
 		if (finalImage == bitmapData.image) return bitmapData;
 		return sourceBitmapData;


### PR DESCRIPTION
DropShadowFilter in HTML5 translates by the __offsetX/__offsetY every time .text property gets updated. In addition it does not clear between the updates so the effect is that every single update stacks over the previous image instead of just recent update displayed.

Tested this change on HTML5 Cairo/Canvas + FLASH for TextField and Bitmap.