### PR TITLE
Software support for DisplacementMapFilter

### DIFF
--- a/src/openfl/filters/DisplacementMapFilter.hx
+++ b/src/openfl/filters/DisplacementMapFilter.hx
@@ -1,7 +1,13 @@
 package openfl.filters; #if !flash
 
+#if (js && html5)
+import lime._internal.graphics.ImageCanvasUtil;
+#end
 
-// import lime._internal.graphics.ImageDataUtil;
+import lime._internal.graphics.ImageDataUtil;
+import lime.math.Vector2;
+import lime.math.Vector4;
+
 import openfl.display.BitmapDataChannel;
 import openfl.geom.Rectangle;
 import openfl.geom.Point;
@@ -61,7 +67,7 @@ import openfl.display.Shader;
 		__color = color;
 		__alpha = alpha;
 		
-		__needSecondBitmapData = false;
+		__needSecondBitmapData = true;
 		__preserveObject = false;
 		__renderDirty = true;
 		
@@ -78,11 +84,28 @@ import openfl.display.Shader;
 	
 	
 	@:noCompletion private override function __applyFilter(bitmapData:BitmapData, sourceBitmapData:BitmapData, sourceRect:Rectangle, destPoint:Point):BitmapData {
-		
-		// TODO
-		// ImageDataUtil.displace(bitmapData.image, sourceBitmapData.image, __mapBitmap.image, __componentX, __componentY, __scaleX, __scaleY);
+
+		__updateMapMatrix();
+
+		#if (js && html5)
+		ImageCanvasUtil.convertToData (bitmapData.image);
+		ImageCanvasUtil.convertToData (sourceBitmapData.image);
+		ImageCanvasUtil.convertToData (__mapBitmap.image);
+		#end
+
+		ImageDataUtil.displaceMap(
+			bitmapData.image,
+			sourceBitmapData.image,
+
+			__mapBitmap.image,
+			new Vector2(__mapPoint.x / __mapBitmap.width, __mapPoint.y / __mapBitmap.height),
+
+			new Vector4(__matrixData[0], __matrixData[4], __matrixData[8], __matrixData[12]),
+			new Vector4(__matrixData[1], __matrixData[5], __matrixData[9], __matrixData[13]),
+			__smooth
+		);
+
 		return bitmapData;
-		
 	}
 	
 	


### PR DESCRIPTION
Software support for Displacement Map Filter

Uses: https://github.com/openfl/lime/pull/1249

Hardware, smoothing ON:
![html5_hardware_smoothing](https://user-images.githubusercontent.com/5732018/47140062-aabd8880-d2bd-11e8-8119-dca296323fe6.png)

Software, smoothing OFF:
![html5_software_no_smoothing](https://user-images.githubusercontent.com/5732018/47140063-aabd8880-d2bd-11e8-8e55-3ed937b167d2.png)

Software, smoothing ON:
![html5_software_smoothing](https://user-images.githubusercontent.com/5732018/47140064-aabd8880-d2bd-11e8-96f1-ae52ae4c3faf.png)

Tested on HTML5, hardware/software with this code below. I've updates this part of Software Displacement Map Filter due to find in here that I've PR also (removed `clone()` and set `__needSecondBitmapData` to true: https://github.com/openfl/openfl/pull/2039

`
package;

import openfl.geom.Point;
import openfl.display.Bitmap;
import openfl.filters.DisplacementMapFilter;
import openfl.filters.DisplacementMapFilterMode;
import openfl.display.BitmapDataChannel;
import openfl.utils.Assets;
import openfl.events.MouseEvent;
import openfl.display.Sprite;

class Main extends Sprite {
    private var bitmap:Bitmap;

    public function new() {
        super();

        var displacementMap:DisplacementMapFilter = new DisplacementMapFilter(
            Assets.getBitmapData('assets/map.png'), new Point(), BitmapDataChannel.RED, BitmapDataChannel.RED, 10.0, 10.0, DisplacementMapFilterMode.WRAP, 0, 1.0
        );

        this.bitmap = new Bitmap(Assets.getBitmapData('assets/image.png'));
        this.addChild(this.bitmap);

        this.bitmap.filters = [ displacementMap ];

        this.addEventListener(MouseEvent.CLICK, function(e:MouseEvent) {
            this.bitmap.invalidate();
        });

    }
}
`