### PR TITLE
Fix transform updates for canvas when cacheAsBitmap = true

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1958,7 +1958,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 			var rect = null;
 			
 			var needRender = (__cacheBitmap == null || (__renderDirty && (force || (__children != null && __children.length > 0) || (__graphics != null && __graphics.__dirty))) || opaqueBackground != __cacheBitmapBackground || (renderer.__type != OPENGL && !__cacheBitmapColorTransform.__equals (colorTransform)));
-			var updateTransform = (needRender || (renderer.__type == OPENGL && !__cacheBitmap.__worldTransform.equals (__worldTransform)));
+			var updateTransform = (needRender || ((renderer.__type == OPENGL #if js || renderer.__type == CANVAS #end) && !__cacheBitmap.__worldTransform.equals (__worldTransform)));
 			var hasFilters = __filters != null;
 			
 			if (hasFilters && !needRender) {


### PR DESCRIPTION
This PR fixes the transform of a display object not being updated when the latter is cached as bitmap. You can easily reproduce it like so:

```haxe
var sprite = new Sprite();
sprite.graphics.beginFill(0x333366);
sprite.graphics.drawRect(0, 0, 80, 80);
sprite.graphics.endFill();
addChild(sprite);

sprite.cacheAsBitmap = true;
		
stage.addEventListener(MouseEvent.MOUSE_MOVE, function (e:MouseEvent) {
	
	sprite.x = e.stageX; // Doesn't update the displayed position with -Dcanvas
	sprite.y = e.stageY; 
	
});
```

the square won't follow the cursor when building with `html5 -Dcanvas`.

I tested `windows`, `neko`, `dom`, and `webgl` while I was at it, they all look fine.