### PR TITLE
Fixing an issue where classes generated for swf libraries would get the wrong return type.

### DIFF
--- a/scripts/Tools.hx
+++ b/scripts/Tools.hx
@@ -194,6 +194,11 @@ class Tools {
 		}
 		
 		var generatedClasses = [];
+
+		var classLookupMap = new Map<Int,String>();
+		for (className in swf.symbols.keys()) {
+			classLookupMap.set(swf.symbols[className], className);
+		}
 		
 		for (className in swf.symbols.keys ()) {
 			
@@ -254,34 +259,40 @@ class Tools {
 							var placeObject:TagPlaceObject = cast timelineContainer.tags[frameObject.placedAtIndex];
 							
 							if (placeObject != null && placeObject.instanceName != null) {
-								
-								var childSymbol = timelineContainer.getCharacter (frameObject.characterId);
+
+								var id = frameObject.characterId;
+								var childSymbol = timelineContainer.getCharacter (id);
 								var className = null;
-								
+
+								if (classLookupMap.exists(id)) {
+									className = classLookupMap.get(id);
+								}
 								if (childSymbol != null) {
-									
-									if (Std.is (childSymbol, TagDefineSprite)) {
-										
-										className = "openfl.display.MovieClip";
-										
-									} else if (Std.is (childSymbol, TagDefineBits) || Std.is (childSymbol, TagDefineBitsJPEG2) || Std.is (childSymbol, TagDefineBitsLossless)) {
-										
-										className = "openfl.display.BitmapData";
-										
-									} else if (Std.is (childSymbol, TagDefineShape) || Std.is (childSymbol, TagDefineMorphShape)) {
-										
-										className = "openfl.display.Shape";
-										
-									} else if (Std.is (childSymbol, TagDefineText) || Std.is (childSymbol, TagDefineEditText)) {
-										
-										className = "openfl.text.TextField";
-										
-									} else if (Std.is (childSymbol, TagDefineButton2)) {
-										
-										className = "openfl.display.SimpleButton";
-										
+
+									if (className == null) {
+
+										if (Std.is (childSymbol, TagDefineSprite)) {
+
+											className = "openfl.display.MovieClip";
+
+										} else if (Std.is (childSymbol, TagDefineBits) || Std.is (childSymbol, TagDefineBitsJPEG2) || Std.is (childSymbol, TagDefineBitsLossless)) {
+
+											className = "openfl.display.BitmapData";
+
+										} else if (Std.is (childSymbol, TagDefineShape) || Std.is (childSymbol, TagDefineMorphShape)) {
+
+											className = "openfl.display.Shape";
+
+										} else if (Std.is (childSymbol, TagDefineText) || Std.is (childSymbol, TagDefineEditText)) {
+
+											className = "openfl.text.TextField";
+
+										} else if (Std.is (childSymbol, TagDefineButton2)) {
+
+											className = "openfl.display.SimpleButton";
+
+										}
 									}
-									
 									if (className != null && !objectReferences.exists (placeObject.instanceName)) {
 										
 										objectReferences[placeObject.instanceName] = true;


### PR DESCRIPTION
When using SWF libraries with movieClips inside movieClips and custom classes for both of these, the flash target would not use the correct return type for getters/setters in the generated classes.
It would always default to the “native “ classes MovieClip, SimpleButton, Bitmap Etc.

This would cause the generated classes to be different between non-flash targets and flash (flash/air). If custom properties or functions of the Child element was attempted accessed from outside this class the compilation would fail for Flash targets as the return type would have been MovieClip and not the custom Class.

ex. of generated code.

Non-Flash target
```
class Form extends MovieClip {
    @:keep public var datePicker(default, null):components.CustomDatePicker;
    @:keep public var okBtn (default, null):openfl.display.SimpleButton;
```
Flash target
```
@:bind @:native("Form") class Form extends flash.display.MovieClip {
    @:keep public var datePicker(default, null):openfl.display.MovieClip;  <---- Wrong type
    @:keep public var okBtn (default, null):openfl.display.SimpleButton;
```

```
var form = new Form();
form.datePicker.getDate(); <- would fail on Flash/actionscript targets.
```

Solution:
My current understanding of the SWF format is that Classes and Symbols are linked by the SymbolClassTag, and the simplest way to check if a symbol is linked to a given class is to see if the symbol Id is present in this structure.  I have therefor used the existing symbols map to make a lookup table and use this to check if a child element should use a non-standard return type when getters/setters are generated.
