### PR TITLE
Fixing issue where a stop on the last frame of a MovieClip could end up on the first frame.

### DIFF
--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -600,8 +600,8 @@ class MovieClip extends Sprite #if (openfl_dynamic && haxe_ver < "4.0.0") implem
 			}
 			
 			if (!__playing) {
-				
-				break;
+
+				return false;
 				
 			}
 			


### PR DESCRIPTION
MovieClips with FrameScripts that tells an animation to stop on one of the the last frames could en up stopping on the first frame if delta time was too long.

the `__enterFrame` function calculates the next frame and checks if it has passed the end  and should start on the beginning, and if so it places the play head back to the first frame and continues from there.

```haxe
if (nextFrame < __currentFrame) {

    if (!__evaluateFrameScripts (__totalFrames)) { <-- execute all scripts until last frame
      // if one of the scripts interrupts the playback  we should get here//
        super.__enterFrame (deltaTime);
        return; 

    }

    __currentFrame = 1;   //<----------- jumps to first frame

}

if (!__evaluateFrameScripts (nextFrame)) {

    super.__enterFrame (deltaTime);
    return;

}
```
The problem the way i see it is that `__evaluateFrameScripts` returns true even if the movie clip no longer plays which will cause ` __currentFrame = 1;` to be executed. this is why i am replacing the break with a return false. 
  
```haxe
@:noCompletion private function __evaluateFrameScripts (advanceToFrame:Int):Bool {

    for (frame in __currentFrame...advanceToFrame + 1) {

        if (frame == __lastFrameScriptEval) continue;

        __lastFrameScriptEval = frame;
        __currentFrame = frame;

        if (__frameScripts.exists (frame)) {

            var script = __frameScripts.get (frame);
            script ();

            if (__currentFrame != frame) {

                return false;

            }

        }

        if (!__playing) {

            break; //<------ breaks the loop and causes the return true below

        }

    }

    return true;

}
```
