### PR TITLE
fixing glowFilter shader so it considers strength property

### DIFF
--- a/src/openfl/filters/GlowFilter.hx
+++ b/src/openfl/filters/GlowFilter.hx
@@ -270,7 +270,7 @@ import openfl.geom.Rectangle;
 		__glowShader.uColor.value[0] = ((color >> 16) & 0xFF) / 255;
 		__glowShader.uColor.value[1] = ((color >> 8) & 0xFF) / 255;
 		__glowShader.uColor.value[2] = (color & 0xFF) / 255;
-		__glowShader.uColor.value[3] = alpha;
+		__glowShader.uColor.value[3] = alpha * (__strength / __numShaderPasses );
 		#end
 		
 		return __glowShader;


### PR DESCRIPTION
this  should fix  the glowFilter shader so that it considers the strength property  and makes glow effects similar to the software renderer.

here's  few comparisons (10%, 100% and 1000% strength)  both software and hardware rendering is a bit off compared to flash, but i don't want to do any changes as people probably have tweaked the filter properties to look the way the want it and don't expect changes.

![tmp](https://user-images.githubusercontent.com/3193925/48957673-5495d200-ef5a-11e8-8825-1104ff27525d.png)