### PR TITLE
Fix incorrect KeyboardEvent types in Flash externs

### DIFF
--- a/externs/flash/flash/events/KeyboardEvent.hx
+++ b/externs/flash/flash/events/KeyboardEvent.hx
@@ -10,15 +10,15 @@ extern class KeyboardEvent extends Event {
 	public static var KEY_UP (default, never):String;
 	
 	public var altKey:Bool;
-	public var charCode:Int;
+	public var charCode:UInt;
 	public var ctrlKey:Bool;
 	public var commandKey:Bool;
 	public var controlKey:Bool;
-	public var keyCode:Int;
+	public var keyCode:UInt;
 	public var keyLocation:KeyLocation;
 	public var shiftKey:Bool;
 	
-	public function new (type:String, bubbles:Bool = false, cancelable:Bool = false, charCodeValue:Int = 0, keyCodeValue:Int = 0, keyLocationValue:KeyLocation = null, ctrlKeyValue:Bool = false, altKeyValue:Bool = false, shiftKeyValue:Bool = false, controlKeyValue:Bool = false, commandKeyValue:Bool = false);
+	public function new (type:String, bubbles:Bool = false, cancelable:Bool = false, charCodeValue:UInt = 0, keyCodeValue:UInt = 0, keyLocationValue:KeyLocation = null, ctrlKeyValue:Bool = false, altKeyValue:Bool = false, shiftKeyValue:Bool = false, controlKeyValue:Bool = false, commandKeyValue:Bool = false);
 	
 	
 }


### PR DESCRIPTION
OpenFL seems to use `Int` instead of `UInt` in its Flash externs (`KeyboardEvent` in this case, but probably others too). This happened to not cause any issues so far, but that changed with Haxe 4 preview 5, where the following causes a crash on the Flash target:

```haxe
package;

import openfl.events.KeyboardEvent;
import openfl.display.Sprite;

class Main extends Sprite {
	public function new() {
		super();
		stage.addEventListener(KeyboardEvent.KEY_DOWN, function keydown(e:KeyboardEvent) {
			switch (e.keyCode) {
				case 39:
					trace(e.keyCode);
				case 40:
					trace(e.keyCode);
			}
		});
	}
}
```

![](https://i.imgur.com/8NctIYW.png)

If you compare the `-D dump=pretty` output between preview 4 and current builds, you can see that the switch-case is no longer generated with a temporary variable (probably due to an improvement in Haxe's static analyser / var fusion):

![](https://i.imgur.com/BN3bEeT.png)

If the extern uses the proper types (like it does in the extern from the standard library), this isn't an issue.