### PR TITLE
cancel mouseDown events to allow html5 context menu disabling

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1032,6 +1032,11 @@ class Stage extends DisplayObjectContainer implements IModule {
 		
 		__onMouse (type, Std.int (x * window.scale), Std.int (y * window.scale), button);
 		
+		if (!showDefaultContextMenu && button == 2) {
+			
+			window.onMouseDown.cancel ();
+			
+		}
 	}
 	
 	


### PR DESCRIPTION
I've only checked on Mac Chrome but cancelling the up event is not enough to prevent the context menu, this coincides with a [Lime PR](https://github.com/openfl/lime/pull/1271) that checks if the up or down event was cancelled

fixes #2098