### PR TITLE
Replace internal representation of Graphics api enums to String

### DIFF
--- a/src/openfl/display/CapsStyle.hx
+++ b/src/openfl/display/CapsStyle.hx
@@ -1,4 +1,4 @@
-package openfl.display; #if !flash #if !openfljs
+package openfl.display; #if !flash
 
 
 /**
@@ -8,72 +8,31 @@ package openfl.display; #if !flash #if !openfljs
  * `openfl.display.Graphics.lineStyle()` method. You can specify the
  * following three types of caps:
  */
-@:enum abstract CapsStyle(Null<Int>) {
+@:enum abstract CapsStyle(String) from String to String {
 	
 	
 	/**
 	 * Used to specify no caps in the `caps` parameter of the
 	 * `openfl.display.Graphics.lineStyle()` method.
 	 */
-	public var NONE = 0;
+	public var NONE = "none";
 	
 	/**
 	 * Used to specify round caps in the `caps` parameter of the
 	 * `openfl.display.Graphics.lineStyle()` method.
 	 */
-	public var ROUND = 1;
+	public var ROUND = "round";
 	
 	/**
 	 * Used to specify square caps in the `caps` parameter of the
 	 * `openfl.display.Graphics.lineStyle()` method.
 	 */
-	public var SQUARE = 2;
-	
-	
-	@:from private static function fromString (value:String):CapsStyle {
-		
-		return switch (value) {
-			
-			case "none": NONE;
-			case "round": ROUND;
-			case "square": SQUARE;
-			default: null;
-			
-		}
-		
-	}
-	
-	
-	@:to private static function toString (value:Int):String {
-		
-		return switch (value) {
-			
-			case CapsStyle.NONE: "none";
-			case CapsStyle.ROUND: "round";
-			case CapsStyle.SQUARE: "square";
-			default: null;
-			
-		}
-		
-	}
-	
-	
-}
-
-
-#else
-
-
-@:enum abstract CapsStyle(String) from String to String {
-	
-	public var NONE = "none";
-	public var ROUND = "round";
 	public var SQUARE = "square";
 	
+	
 }
 
 
-#end
 #else
 typedef CapsStyle = flash.display.CapsStyle;
 #end

--- a/src/openfl/display/GradientType.hx
+++ b/src/openfl/display/GradientType.hx
@@ -1,4 +1,4 @@
-package openfl.display; #if !flash #if !openfljs
+package openfl.display; #if !flash
 
 
 /**
@@ -7,61 +7,21 @@ package openfl.display; #if !flash #if !openfljs
  * `lineGradientStyle()` methods of the openfl.display.Graphics
  * class.
  */
-@:enum abstract GradientType(Null<Int>) {
-	
+@:enum abstract GradientType(String) from String to String {
 	
 	/**
 	 * Value used to specify a linear gradient fill.
 	 */
-	public var LINEAR = 0;
+	public var LINEAR = "linear";
 	
 	/**
 	 * Value used to specify a radial gradient fill.
 	 */
-	public var RADIAL = 1;
-	
-	
-	@:from private static function fromString (value:String):GradientType {
-		
-		return switch (value) {
-			
-			case "linear": LINEAR;
-			case "radial": RADIAL;
-			default: null;
-			
-		}
-		
-	}
-	
-	
-	@:to private static function toString (value:Int):String {
-		
-		return switch (value) {
-			
-			case GradientType.LINEAR: "linear";
-			case GradientType.RADIAL: "radial";
-			default: null;
-			
-		}
-		
-	}
-	
-	
-}
-
-
-#else
-
-
-@:enum abstract GradientType(String) from String to String {
-	
-	public var LINEAR = "linear";
 	public var RADIAL = "radial";
 	
 }
 
 
-#end
 #else
 typedef GradientType = flash.display.GradientType;
 #end

--- a/src/openfl/display/InterpolationMethod.hx
+++ b/src/openfl/display/InterpolationMethod.hx
@@ -1,4 +1,4 @@
-package openfl.display; #if !flash #if !openfljs
+package openfl.display; #if !flash
 
 
 /**
@@ -8,79 +8,41 @@ package openfl.display; #if !flash #if !openfljs
  * `Graphics.lineGradientStyle()` methods. This parameter
  * determines the RGB space to use when rendering the gradient.
  */
-@:enum abstract InterpolationMethod(Null<Int>) {
-	
-	
-	/**
-	 * Specifies that the RGB interpolation method should be used. This means
-	 * that the gradient is rendered with exponential sRGB(standard RGB) space.
-	 * The sRGB space is a W3C-endorsed standard that defines a non-linear
-	 * conversion between red, green, and blue component values and the actual
-	 * intensity of the visible component color.
-	 *
-	 * For example, consider a simple linear gradient between two colors(with
-	 * the `spreadMethod` parameter set to
-	 * `SpreadMethod.REFLECT`). The different interpolation methods
-	 * affect the appearance as follows: 
-	 */
-	public var LINEAR_RGB = 0;
-	
-	/**
-	 * Specifies that the RGB interpolation method should be used. This means
-	 * that the gradient is rendered with exponential sRGB(standard RGB) space.
-	 * The sRGB space is a W3C-endorsed standard that defines a non-linear
-	 * conversion between red, green, and blue component values and the actual
-	 * intensity of the visible component color.
-	 *
-	 * For example, consider a simple linear gradient between two colors(with
-	 * the `spreadMethod` parameter set to
-	 * `SpreadMethod.REFLECT`). The different interpolation methods
-	 * affect the appearance as follows: 
-	 */
-	public var RGB = 1;
-	
-	
-	@:from private static function fromString (value:String):InterpolationMethod {
-		
-		return switch (value) {
-			
-			case "linearRGB": LINEAR_RGB;
-			case "rgb": RGB;
-			default: null;
-			
-		}
-		
-	}
-	
-	
-	@:to private static function toString (value:Int):String {
-		
-		return switch (value) {
-			
-			case InterpolationMethod.LINEAR_RGB: "linearRGB";
-			case InterpolationMethod.RGB: "rgb";
-			default: null;
-			
-		}
-		
-	}
-	
-	
-}
-
-
-#else
-
-
 @:enum abstract InterpolationMethod(String) from String to String {
 	
+	
+	/**
+	 * Specifies that the RGB interpolation method should be used. This means
+	 * that the gradient is rendered with exponential sRGB(standard RGB) space.
+	 * The sRGB space is a W3C-endorsed standard that defines a non-linear
+	 * conversion between red, green, and blue component values and the actual
+	 * intensity of the visible component color.
+	 *
+	 * For example, consider a simple linear gradient between two colors(with
+	 * the `spreadMethod` parameter set to
+	 * `SpreadMethod.REFLECT`). The different interpolation methods
+	 * affect the appearance as follows: 
+	 */
 	public var LINEAR_RGB = "linearRGB";
+	
+	/**
+	 * Specifies that the RGB interpolation method should be used. This means
+	 * that the gradient is rendered with exponential sRGB(standard RGB) space.
+	 * The sRGB space is a W3C-endorsed standard that defines a non-linear
+	 * conversion between red, green, and blue component values and the actual
+	 * intensity of the visible component color.
+	 *
+	 * For example, consider a simple linear gradient between two colors(with
+	 * the `spreadMethod` parameter set to
+	 * `SpreadMethod.REFLECT`). The different interpolation methods
+	 * affect the appearance as follows: 
+	 */
 	public var RGB = "rgb";
+	
 	
 }
 
 
-#end
 #else
 typedef InterpolationMethod = flash.display.InterpolationMethod;
 #end

--- a/src/openfl/display/JointStyle.hx
+++ b/src/openfl/display/JointStyle.hx
@@ -1,4 +1,4 @@
-package openfl.display; #if !flash #if !openfljs
+package openfl.display; #if !flash
 
 
 /**
@@ -9,72 +9,31 @@ package openfl.display; #if !flash #if !openfljs
  * three types of joints: miter, round, and bevel, as the following example
  * shows:
  */
-@:enum abstract JointStyle(Null<Int>) {
+@:enum abstract JointStyle(String) from String to String {
 	
 	
 	/**
 	 * Specifies beveled joints in the `joints` parameter of the
 	 * `openfl.display.Graphics.lineStyle()` method.
 	 */
-	public var BEVEL = 0;
+	public var BEVEL = "bevel";
 	
 	/**
 	 * Specifies mitered joints in the `joints` parameter of the
 	 * `openfl.display.Graphics.lineStyle()` method.
 	 */
-	public var MITER = 1;
+	public var MITER = "miter";
 	
 	/**
 	 * Specifies round joints in the `joints` parameter of the
 	 * `openfl.display.Graphics.lineStyle()` method.
 	 */
-	public var ROUND = 2;
-	
-	
-	@:from private static function fromString (value:String):JointStyle {
-		
-		return switch (value) {
-			
-			case "bevel": BEVEL;
-			case "miter": MITER;
-			case "round": ROUND;
-			default: null;
-			
-		}
-		
-	}
-	
-	
-	@:to private static function toString (value:Int):String {
-		
-		return switch (value) {
-			
-			case JointStyle.BEVEL: "bevel";
-			case JointStyle.MITER: "miter";
-			case JointStyle.ROUND: "round";
-			default: null;
-			
-		}
-		
-	}
-	
-	
-}
-
-
-#else
-
-
-@:enum abstract JointStyle(String) from String to String {
-	
-	public var BEVEL = "bevel";
-	public var MITER = "miter";
 	public var ROUND = "round";
 	
+	
 }
 
 
-#end
 #else
 typedef JointStyle = flash.display.JointStyle;
 #end

--- a/src/openfl/display/LineScaleMode.hx
+++ b/src/openfl/display/LineScaleMode.hx
@@ -1,11 +1,11 @@
-package openfl.display; #if !flash #if !openfljs
+package openfl.display; #if !flash
 
 
 /**
  * The LineScaleMode class provides values for the `scaleMode`
  * parameter in the `Graphics.lineStyle()` method.
  */
-@:enum abstract LineScaleMode(Null<Int>) {
+@:enum abstract LineScaleMode(String) from String to String {
 	
 	
 	/**
@@ -17,20 +17,20 @@ package openfl.display; #if !flash #if !openfljs
 	 * scaled only vertically, and the circle on the right is scaled both
 	 * vertically and horizontally.
 	 */
-	public var HORIZONTAL = 0;
+	public var HORIZONTAL = "horizontal";
 	
 	/**
 	 * With this setting used as the `scaleMode` parameter of the
 	 * `lineStyle()` method, the thickness of the line never scales.
 	 */
-	public var NONE = 1;
+	public var NONE = "none";
 	
 	/**
 	 * With this setting used as the `scaleMode` parameter of the
 	 * `lineStyle()` method, the thickness of the line always scales
 	 * when the object is scaled(the default).
 	 */
-	public var NORMAL = 2;
+	public var NORMAL = "normal";
 	
 	/**
 	 * With this setting used as the `scaleMode` parameter of the
@@ -41,56 +41,12 @@ package openfl.display; #if !flash #if !openfljs
 	 * left is scaled only horizontally, and the circle on the right is scaled
 	 * both vertically and horizontally.
 	 */
-	public var VERTICAL = 3;
-	
-	
-	@:from private static function fromString (value:String):LineScaleMode {
-		
-		return switch (value) {
-			
-			case "horizontal": HORIZONTAL;
-			case "none": NONE;
-			case "normal": NORMAL;
-			case "vertical": VERTICAL;
-			default: null;
-			
-		}
-		
-	}
-	
-	
-	@:to private static function toString (value:Int):String {
-		
-		return switch (value) {
-			
-			case LineScaleMode.HORIZONTAL: "horizontal";
-			case LineScaleMode.NONE: "none";
-			case LineScaleMode.NORMAL: "normal";
-			case LineScaleMode.VERTICAL: "vertical";
-			default: null;
-			
-		}
-		
-	}
-	
-	
-}
-
-
-#else
-
-
-@:enum abstract LineScaleMode(String) from String to String {
-	
-	public var HORIZONTAL = "horizontal";
-	public var NONE = "none";
-	public var NORMAL = "normal";
 	public var VERTICAL = "vertical";
 	
+	
 }
 
 
-#end
 #else
 typedef LineScaleMode = flash.display.LineScaleMode;
 #end

--- a/src/openfl/display/SpreadMethod.hx
+++ b/src/openfl/display/SpreadMethod.hx
@@ -1,4 +1,4 @@
-package openfl.display; #if !flash #if !openfljs
+package openfl.display; #if !flash
 
 
 /**
@@ -9,69 +9,28 @@ package openfl.display; #if !flash #if !openfljs
  * The following example shows the same gradient fill using various spread
  * methods:
  */
-@:enum abstract SpreadMethod(Null<Int>) {
+@:enum abstract SpreadMethod(String) from String to String {
 	
 	
 	/**
 	 * Specifies that the gradient use the _pad_ spread method.
 	 */
-	public var PAD = 0;
+	public var PAD = "pad";
 	
 	/**
 	 * Specifies that the gradient use the _reflect_ spread method.
 	 */
-	public var REFLECT = 1;
+	public var REFLECT = "reflect";
 	
 	/**
 	 * Specifies that the gradient use the _repeat_ spread method.
 	 */
-	public var REPEAT = 2;
-	
-	
-	@:from private static function fromString (value:String):SpreadMethod {
-		
-		return switch (value) {
-			
-			case "pad": PAD;
-			case "reflect": REFLECT;
-			case "repeat": REPEAT;
-			default: null;
-			
-		}
-		
-	}
-	
-	
-	@:to private static function toString (value:Int):String {
-		
-		return switch (value) {
-			
-			case SpreadMethod.PAD: "pad";
-			case SpreadMethod.REFLECT: "reflect";
-			case SpreadMethod.REPEAT: "repeat";
-			default: null;
-			
-		}
-		
-	}
-	
-	
-}
-
-
-#else
-
-
-@:enum abstract SpreadMethod(String) from String to String {
-	
-	public var PAD = "pad";
-	public var REFLECT = "reflect";
 	public var REPEAT = "repeat";
 	
+	
 }
 
 
-#end
 #else
 typedef SpreadMethod = flash.display.SpreadMethod;
 #end


### PR DESCRIPTION
There was a bug in npm distribution of library:

- swf converted to swflite with `openfl` tool using integer values for that types
- js implementation of swflite library expects that values to be string

That leads to exception in CanvasGraphics.createGradientPattern() method and not displaying any swflite files contains gradient fill at all.

So I guess making that values type platform-independent should be clearer and produce less type mismatch.

Unfortunately that change will break file format compatibility for swflite.