### PR TITLE
Fix for Issue-2091: Error in MovieClip animation

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -1513,6 +1513,13 @@ import js.html.CanvasRenderingContext2D;
 			__transformDirty = true;
 			
 		}
+		#else
+		if (__bounds != null) {
+
+			__dirty = true;
+			__transformDirty = true;
+
+		}
 		#end
 		
 		__bitmap = null;


### PR DESCRIPTION
Fixing a problem where the cleanup for removed children did not mark graphics as dirty for non-html5/JS targets. this caused these graphics not to render when children was added again later in MovieClip animations.

see issue https://github.com/openfl/openfl/issues/2091 for more details.
