### PR TITLE
Fix issue with drawQuads calculating incorrect graphics bounds

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -880,7 +880,7 @@ import js.html.CanvasRenderingContext2D;
 			
 			ri = (hasIndices ? (indices[i] * 4) : i * 4);
 			if (ri < 0) continue;
-			tileRect.setTo (rects[ri], rects[ri + 1], rects[ri + 2], rects[ri + 3]);
+			tileRect.setTo (0, 0, rects[ri + 2], rects[ri + 3]);
 			
 			if (tileRect.width <= 0 || tileRect.height <= 0) {
 				

--- a/src/openfl/net/SharedObject.hx
+++ b/src/openfl/net/SharedObject.hx
@@ -584,16 +584,6 @@ class SharedObject extends EventDispatcher {
 			
 		}
 		
-		if (localPath == null) {
-			
-			#if (js && html5)
-			localPath = Browser.window.location.href;
-			#else
-			localPath = "";
-			#end
-			
-		}
-		
 		if (__sharedObjects == null) {
 			
 			__sharedObjects = new Map ();
@@ -612,11 +602,6 @@ class SharedObject extends EventDispatcher {
 		
 		if (!__sharedObjects.exists (id)) {
 			
-			var sharedObject = new SharedObject ();
-			sharedObject.data = {};
-			sharedObject.__localPath = localPath;
-			sharedObject.__name = name;
-			
 			var encodedData = null;
 			
 			try {
@@ -625,13 +610,27 @@ class SharedObject extends EventDispatcher {
 				
 				var storage = Browser.getLocalStorage ();
 				
-				if (storage != null) {
+				if (localPath == null) {
+					
+					// Check old default path, first
+					if (storage != null) {
+						encodedData = storage.getItem (Browser.window.location.href + ":" + name);
+						storage.removeItem (Browser.window.location.href + ":" + name);
+					}
+					
+					localPath = Browser.window.location.pathname;
+					
+				}
+				
+				if (storage != null && encodedData == null) {
 					
 					encodedData = storage.getItem (localPath + ":" + name);
 					
 				}
 				
 				#else
+				
+				if (localPath == null) localPath = "";
 				
 				var path = __getPath (localPath, name);
 				
@@ -644,6 +643,11 @@ class SharedObject extends EventDispatcher {
 				#end
 				
 			} catch (e:Dynamic) { }
+			
+			var sharedObject = new SharedObject ();
+			sharedObject.data = {};
+			sharedObject.__localPath = localPath;
+			sharedObject.__name = name;
 			
 			if (encodedData != null && encodedData != "") {
 				


### PR DESCRIPTION
I believe the calculation of the graphics bounds (minX, maxX etc) was incorrect if any drawQuads rects are not at position 0, 0. This resulted in bounds sometimes being way larger than necessary, or so small that some quads didn't display when they were supposed to.

If I'm not mistaken, the `rects` are positions in the texture, not the position of the final tile, and so the x and y should not be used when determining how to expand the graphics bounds.