### PR TITLE
DrawQuads should not use rect position for graphics bounds

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -880,7 +880,7 @@ import js.html.CanvasRenderingContext2D;
 			
 			ri = (hasIndices ? (indices[i] * 4) : i * 4);
 			if (ri < 0) continue;
-			tileRect.setTo (rects[ri], rects[ri + 1], rects[ri + 2], rects[ri + 3]);
+			tileRect.setTo (0, 0, rects[ri + 2], rects[ri + 3]);
 			
 			if (tileRect.width <= 0 || tileRect.height <= 0) {
 				


### PR DESCRIPTION
I believe the calculation of the graphics bounds (minX, maxX etc) was incorrect if any drawQuads rects are not at position 0, 0. This resulted in bounds sometimes being way larger than necessary, or so small that some quads didn't display when they were supposed to.

If I'm not mistaken, the `rects` are positions in the texture, not the position of the final tile, and so the x and y should not be used when determining how to expand the graphics bounds.