### PR TITLE
Fix hasRect() always false for non square tiles

### DIFF
--- a/src/openfl/display/Tileset.hx
+++ b/src/openfl/display/Tileset.hx
@@ -86,7 +86,7 @@ class Tileset
 	{
 		for (tileData in __data)
 		{
-			if (rect.x == tileData.x && rect.y == tileData.y && rect.width == tileData.height && rect.height == tileData.height)
+			if (rect.x == tileData.x && rect.y == tileData.y && rect.width == tileData.width && rect.height == tileData.height)
 			{
 				return true;
 			}

--- a/src/openfl/display/Tileset.hx
+++ b/src/openfl/display/Tileset.hx
@@ -113,7 +113,7 @@ class Tileset
 		{
 			tileData = __data[i];
 
-			if (rect.x == tileData.x && rect.y == tileData.y && rect.width == tileData.height && rect.height == tileData.height)
+			if (rect.x == tileData.x && rect.y == tileData.y && rect.width == tileData.width && rect.height == tileData.height)
 			{
 				return i;
 			}


### PR DESCRIPTION
fix: Tileset.hasRect() always returns false for non square tiles due to comparing rect.width == tileData.height