### PR TITLE
Fixing issue with EdgeMap calculations that cause complex SWFShape assets to render incorrectly

### DIFF
--- a/scripts/format/swf/data/SWFShape.hx
+++ b/scripts/format/swf/data/SWFShape.hx
@@ -1,4 +1,4 @@
-package format.swf.data;
+﻿package format.swf.data;
 
 import format.swf.SWFData;
 import format.swf.data.consts.GradientInterpolationMode;
@@ -720,10 +720,17 @@ class SWFShape
 	private function removeEdgeFromCoordMap(edge:IEdge):Void
 	{
 		var key:String = edge.from.x + "_" + edge.from.y;
-		var coordMapArray = coordMap.get(key);
-		if (coordMapArray != null)
-		{
-			coordMap.remove(key);
+		var coordMapArray:Array<IEdge> = coordMap.get(key);
+
+		if(coordMapArray != null) {
+			if(coordMapArray.length == 1) {
+				coordMap.remove(key);
+			} else {
+				var i:Int = coordMapArray.indexOf(edge);
+				if(i > -1) {
+					coordMapArray.remove(edge);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request will fix the issue were EdgeMap calculations would cause complex SWFShape assets to render incorrectly. The cause of the problem was that the code would remove the entire array containing Edge objects instead of removing just the one Edge object that was provided.   

This fix only helps for shapes that were missing "chunks" it will not solve the small gaps between connected surfaces that usually looks like lines in a lighter color.
