### PR TITLE
Include js externs in openfl.swc

### DIFF
--- a/lib/flash/display/CanvasRenderer.as
+++ b/lib/flash/display/CanvasRenderer.as
@@ -6,7 +6,9 @@ package flash.display {
 
 	// typedef CanvasRenderContext = js.html.CanvasRenderingContext2D;
 	
-	
+	/** 
+	 * @externs 
+	 */
 	public class CanvasRenderer extends DisplayObjectRenderer {
 		
 		

--- a/lib/flash/display/GraphicsShader.as
+++ b/lib/flash/display/GraphicsShader.as
@@ -5,7 +5,7 @@ package flash.display {
 	
 	
 	/**
-	 * externs
+	 * @externs
 	 */
 	public class GraphicsShader extends Shader {
 		

--- a/lib/flash/media/Video.as
+++ b/lib/flash/media/Video.as
@@ -6,7 +6,7 @@ package flash.media {
 	
 	
 	/**
-	 * @exterms
+	 * @externs
 	 */
 	public class Video extends DisplayObject {
 		

--- a/lib/flash/text/FontType.as
+++ b/lib/flash/text/FontType.as
@@ -2,6 +2,7 @@ package flash.text {
 	
 	
 	/**
+	 * @externs
 	 * The FontType class contains the enumerated constants
 	 * `"embedded"` and `"device"` for the
 	 * `fontType` property of the Font class.

--- a/lib/flash/utils/IAssetCache.as
+++ b/lib/flash/utils/IAssetCache.as
@@ -5,7 +5,9 @@ package flash.utils {
 	import flash.media.Sound;
 	import flash.text.Font;
 	
-	
+	/**
+	 * @externs
+	 */
 	public interface IAssetCache {
 		
 		function get enabled ():Boolean;

--- a/lib/openfl/display/CanvasRenderer.as
+++ b/lib/openfl/display/CanvasRenderer.as
@@ -6,7 +6,9 @@ package openfl.display {
 
 	// typedef CanvasRenderContext = js.html.CanvasRenderingContext2D;
 	
-	
+	/** 
+	 * @externs 
+	 */
 	public class CanvasRenderer extends DisplayObjectRenderer {
 		
 		

--- a/lib/openfl/display/GraphicsShader.as
+++ b/lib/openfl/display/GraphicsShader.as
@@ -5,7 +5,7 @@ package openfl.display {
 	
 	
 	/**
-	 * externs
+	 * @externs
 	 */
 	public class GraphicsShader extends Shader {
 		

--- a/lib/openfl/media/Video.as
+++ b/lib/openfl/media/Video.as
@@ -6,7 +6,7 @@ package openfl.media {
 	
 	
 	/**
-	 * @exterms
+	 * @externs
 	 */
 	public class Video extends DisplayObject {
 		

--- a/lib/openfl/text/FontType.as
+++ b/lib/openfl/text/FontType.as
@@ -2,6 +2,7 @@ package openfl.text {
 	
 	
 	/**
+	 * @externs
 	 * The FontType class contains the enumerated constants
 	 * `"embedded"` and `"device"` for the
 	 * `fontType` property of the Font class.

--- a/lib/openfl/utils/IAssetCache.as
+++ b/lib/openfl/utils/IAssetCache.as
@@ -5,7 +5,9 @@ package openfl.utils {
 	import openfl.media.Sound;
 	import openfl.text.Font;
 	
-	
+	/**
+	 * @externs
+	 */	
 	public interface IAssetCache {
 		
 		function get enabled ():Boolean;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "build-lib": "cd scripts && haxe build.hxml",
     "build-lib-esm": "cd scripts && node generate-es2015 gen",
     "build-lib-esm-reexports-barrels": "cd scripts && node generate-es2015 non-gen",
-    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF -output=dist/openfl.swc",
+    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -output=dist/openfl.swc",
     "build-tools": "cd scripts && haxe tools-npm.hxml",
     "build-test-es5": "cd test/npm/es5 && webpack",
     "build-test-es6": "cd test/npm/es6 && webpack",


### PR DESCRIPTION
There is a problem while compiling ActionScript sources using Royale against openfl.swc in release mode. It uses closure compiler under the hood to minimize compiled js file. Closure compiler needs externs symbols in js, otherwise, it will minimize package names and fields/methods. That will cause errors in minimized code since openfl.js and openfl.min.js is not minimized in that way.

Also, you can ignore warnings in swc build. Any warning will cause error status 2 and fail build.