### PR TITLE
Add id to alphaCheck if we didn't find an alpha channel. 

### DIFF
--- a/src/openfl/_internal/formats/swf/SWFLiteLibrary.hx
+++ b/src/openfl/_internal/formats/swf/SWFLiteLibrary.hx
@@ -112,6 +112,8 @@ import openfl.utils.AssetManifest;
 					}
 				}
 			}
+
+			alphaCheck.set(id, true);
 		}
 
 		return super.getImage(id);


### PR DESCRIPTION
Prevents subsequent exhaustive searches through swf.symbols