### PR TITLE
Fixing corrupted PNG export

### DIFF
--- a/scripts/format/swf/exporters/SWFLiteExporter.hx
+++ b/scripts/format/swf/exporters/SWFLiteExporter.hx
@@ -261,7 +261,7 @@ class SWFLiteExporter
 				png.add(CPalette(palette));
 				if (transparent) png.add(CUnknown("tRNS", alpha));
 				var valuesBA:ByteArray = values;
-				valuesBA.deflate();
+				valuesBA.compress();
 				png.add(CData(valuesBA));
 				png.add(CEnd);
 


### PR DESCRIPTION
Fixing an issue with SWFLiteExporter where it wouldn't compress PNG IDAT chunk, outputting corrupted PNG files