### PR TITLE
Fix #2124

### DIFF
--- a/src/openfl/_internal/formats/html/HTMLParser.hx
+++ b/src/openfl/_internal/formats/html/HTMLParser.hx
@@ -106,6 +106,7 @@ class HTMLParser
 					{
 						value += "\n";
 						noLineBreak = true;
+						textFormatRanges[textFormatRanges.length - 1].end++;
 					}
 
 					if (start < segment.length)
@@ -227,6 +228,10 @@ class HTMLParser
 							textFormatRanges.push(new TextFormatRange(format, value.length, value.length + sub.length));
 							value += sub;
 							noLineBreak = false;
+						}
+						else if (textFormatRanges.length > 0)
+						{
+							textFormatRanges[textFormatRanges.length - 1].end++;
 						}
 					}
 					else


### PR DESCRIPTION
Closes #2124 

Adjusts format ranges if a `\n` is inserted due to a `<p>` tag