### PR TITLE
bugfix : New logic for swf asset classes caused generated classes to extend null

### DIFF
--- a/scripts/Tools.hx
+++ b/scripts/Tools.hx
@@ -229,9 +229,11 @@ class Tools
 					var superClassData = swf.data.abcData.resolveMultiNameByIndex(classData.superclass);
 					switch (superClassData.nameSpace)
 					{
-						case NPublic(_) if (!~/^flash\./.match(superClassData.nameSpaceName)):
+						case NPublic(_): 
+							if (!~/^flash\./.match(superClassData.nameSpaceName)){
 							baseClassName = ("" == superClassData.nameSpaceName ? "" : superClassData.nameSpaceName + ".")
 								+ superClassData.name;
+							}
 						case _:
 					}
 				}


### PR DESCRIPTION
Classes generated for normal SWF Movieclip assets  ends up extending null with current code.
ex:
```
class MySwfAsset extends null {
```

i am not sure if the `if` statement was intended to be inside the `case` statement (never seen that used before) but moving it down to the "case logic" part seems to solve the problem.