### PR TITLE
Add crossorigin="anonymous" attribute to <video /> element. This solv…

### DIFF
--- a/src/openfl/net/NetStream.hx
+++ b/src/openfl/net/NetStream.hx
@@ -1206,6 +1206,7 @@ class NetStream extends EventDispatcher
 
 		__video.setAttribute("playsinline", "");
 		__video.setAttribute("webkit-playsinline", "");
+		__video.setAttribute("crossorigin", "anonymous");
 
 		__video.addEventListener("error", video_onError, false);
 		__video.addEventListener("waiting", video_onWaiting, false);


### PR DESCRIPTION
…es a playback bug on Chrome when trying to stream a video from a different domain.