### PR TITLE
Tile QoL - Width and Height for Tile and TileContainer

### DIFF
--- a/src/openfl/display/Tile.hx
+++ b/src/openfl/display/Tile.hx
@@ -58,6 +58,15 @@ class Tile
 	@SuppressWarnings("checkstyle:Dynamic") public var data:Dynamic;
 
 	/**
+		Indicates the height of the tile, in pixels. The height is
+		calculated based on the bounds of the tile after local transformations.
+		When you set the `height` property, the `scaleY` property
+		is adjusted accordingly.
+		If a tile has a height of zero, no change is applied
+	**/
+	public var height(get, set):Float;
+
+	/**
 		The ID of the tile to draw from the Tileset
 	**/
 	public var id(get, set):Int;
@@ -144,6 +153,15 @@ class Tile
 		Whether or not the tile object is visible.
 	**/
 	public var visible(get, set):Bool;
+
+	/**
+		Indicates the width of the tile, in pixels. The width is
+		calculated based on the bounds of the tile after local transformations.
+		When you set the `width` property, the `scaleX` property
+		is adjusted accordingly.
+		If a tile has a width of zero, no change is applied
+	**/
+	public var width(get, set):Float;
 
 	/**
 		Indicates the _x_ coordinate of the Tile instance relative
@@ -297,7 +315,7 @@ class Tile
 		result.x = 0;
 		result.y = 0;
 
-		// Copied from DisplayObject
+		// Copied from DisplayObject. Create the translation matrix.
 		var matrix = #if flash __tempMatrix #else Matrix.__pool.get() #end;
 		matrix.copyFrom(__getWorldTransform());
 
@@ -315,6 +333,17 @@ class Tile
 			#end
 		}
 
+		__getBounds(result,matrix);
+
+		#if !flash
+		Matrix.__pool.release(matrix);
+		#end
+
+		return result;
+	}
+
+	@:noCompletion private function __getBounds(result:Rectangle, matrix:Matrix):Void
+	{
 		#if flash
 		function __transform(rect:Rectangle, m:Matrix):Void
 		{
@@ -352,10 +381,8 @@ class Tile
 		__transform(result, matrix);
 		#else
 		result.__transform(result, matrix);
-		Matrix.__pool.release(matrix);
 		#end
 
-		return result;
 	}
 
 	/**
@@ -480,6 +507,50 @@ class Tile
 			__setRenderDirty();
 		}
 
+		return value;
+	}
+
+	@:noCompletion private function get_height():Float
+	{
+		// TODO use rectangle pooling
+
+		var result:Rectangle;
+
+		if (tileset == null)
+		{
+			var parentTileset = parent.__findTileset();
+			if (parentTileset == null) return 0;
+			result = parentTileset.getRect(id);
+			if (result == null) return 0;
+		}
+		else
+		{
+			result = tileset.getRect(id);
+		}
+		
+		__getBounds(result,matrix);
+		return result.height;
+	}
+
+	@:noCompletion private function set_height(value:Float):Float
+	{
+		// TODO use rectangle pooling
+
+		var result:Rectangle;
+
+		if (tileset == null)
+		{
+			var parentTileset = parent.__findTileset();
+			if (parentTileset == null) return value;
+			result = parentTileset.getRect(id);
+			if (result == null) return value;
+		}
+		else
+		{
+			result = tileset.getRect(id);
+		}
+		
+		scaleY = value / result.height;
 		return value;
 	}
 
@@ -745,6 +816,50 @@ class Tile
 			__setRenderDirty();
 		}
 
+		return value;
+	}
+
+	@:noCompletion private function get_width():Float
+	{
+		// TODO use rectangle pooling
+
+		var result:Rectangle;
+
+		if (tileset == null)
+		{
+			var parentTileset = parent.__findTileset();
+			if (parentTileset == null) return 0;
+			result = parentTileset.getRect(id);
+			if (result == null) return 0;
+		}
+		else
+		{
+			result = tileset.getRect(id);
+		}
+		
+		__getBounds(result,matrix);
+		return result.width;
+	}
+
+	@:noCompletion private function set_width(value:Float):Float
+	{
+		// TODO use rectangle pooling
+
+		var result:Rectangle;
+
+		if (tileset == null)
+		{
+			var parentTileset = parent.__findTileset();
+			if (parentTileset == null) return value;
+			result = parentTileset.getRect(id);
+			if (result == null) return value;
+		}
+		else
+		{
+			result = tileset.getRect(id);
+		}
+		
+		scaleX = value / result.width;
 		return value;
 	}
 

--- a/src/openfl/display/Tile.hx
+++ b/src/openfl/display/Tile.hx
@@ -304,10 +304,10 @@ class Tile
 
 		// Copied from DisplayObject. Create the translation matrix.
 		var matrix = #if flash __tempMatrix #else Matrix.__pool.get() #end;
-		matrix.copyFrom(__getWorldTransform());
 
 		if (targetCoordinateSpace != null && targetCoordinateSpace != this)
 		{
+			matrix.copyFrom(__getWorldTransform()); // ? Is this correct?
 			var targetMatrix = #if flash new Matrix() #else Matrix.__pool.get() #end;
 
 			targetMatrix.copyFrom(targetCoordinateSpace.__getWorldTransform());
@@ -318,6 +318,10 @@ class Tile
 			#if !flash
 			Matrix.__pool.release(targetMatrix);
 			#end
+		}
+		else
+		{
+			matrix.identity();
 		}
 
 		__getBounds(result,matrix);

--- a/src/openfl/display/Tile.hx
+++ b/src/openfl/display/Tile.hx
@@ -298,22 +298,9 @@ class Tile
 	**/
 	public function getBounds(targetCoordinateSpace:Tile):Rectangle
 	{
-		var result:Rectangle;
+		var result:Rectangle = new Rectangle();
 
-		if (tileset == null)
-		{
-			var parentTileset = parent.__findTileset();
-			if (parentTileset == null) return new Rectangle();
-			result = parentTileset.getRect(id);
-			if (result == null) return new Rectangle();
-		}
-		else
-		{
-			result = tileset.getRect(id);
-		}
-
-		result.x = 0;
-		result.y = 0;
+		__findTileRect(result);
 
 		// Copied from DisplayObject. Create the translation matrix.
 		var matrix = #if flash __tempMatrix #else Matrix.__pool.get() #end;
@@ -418,6 +405,36 @@ class Tile
 	{
 		__setRenderDirty();
 	}
+	
+	@:noCompletion private function __findTileRect(result:Rectangle):Void
+	{
+		if (tileset == null)
+		{
+			var parentTileset:Tileset = parent.__findTileset();
+			if (parentTileset == null)
+			{
+				result.setTo(0,0,0,0);
+			}
+			else
+			{
+				// ? Is this a way to call getRect once without making extra vars? I don't fully grasp haxe pattern matching. Could be done with an if?
+				switch parentTileset.getRect(id)
+				{
+					case null:
+						result.setTo(0,0,0,0);
+					case not_null:
+						result.copyFrom(not_null);
+				}
+			}
+		}
+		else
+		{
+			result.copyFrom(tileset.getRect(id));
+		}
+
+		result.x = 0;
+		result.y = 0;
+	}
 
 	@:noCompletion private function __findTileset():Tileset
 	{
@@ -512,45 +529,26 @@ class Tile
 
 	@:noCompletion private function get_height():Float
 	{
-		// TODO use rectangle pooling
+		// TODO how does pooling work with flash target?
+		var result:Rectangle = #if flash new Rectangle() #else Rectangle.__pool.get() #end;
 
-		var result:Rectangle;
+		__findTileRect(result);
 
-		if (tileset == null)
-		{
-			var parentTileset = parent.__findTileset();
-			if (parentTileset == null) return 0;
-			result = parentTileset.getRect(id);
-			if (result == null) return 0;
-		}
-		else
-		{
-			result = tileset.getRect(id);
-		}
-		
 		__getBounds(result,matrix);
-		return result.height;
+		var h = result.height;
+		#if !flash Rectangle.__pool.release(result); #end
+		return h;
 	}
 
 	@:noCompletion private function set_height(value:Float):Float
 	{
-		// TODO use rectangle pooling
+		// TODO how does pooling work with flash target?
+		var result:Rectangle = #if flash new Rectangle() #else Rectangle.__pool.get() #end;
 
-		var result:Rectangle;
-
-		if (tileset == null)
-		{
-			var parentTileset = parent.__findTileset();
-			if (parentTileset == null) return value;
-			result = parentTileset.getRect(id);
-			if (result == null) return value;
-		}
-		else
-		{
-			result = tileset.getRect(id);
-		}
-		
+		__findTileRect(result);
+	
 		scaleY = value / result.height;
+		#if !flash Rectangle.__pool.release(result); #end
 		return value;
 	}
 
@@ -821,45 +819,26 @@ class Tile
 
 	@:noCompletion private function get_width():Float
 	{
-		// TODO use rectangle pooling
+		// TODO how does pooling work with flash target?
+		var result:Rectangle = #if flash new Rectangle() #else Rectangle.__pool.get() #end;
 
-		var result:Rectangle;
+		__findTileRect(result);
 
-		if (tileset == null)
-		{
-			var parentTileset = parent.__findTileset();
-			if (parentTileset == null) return 0;
-			result = parentTileset.getRect(id);
-			if (result == null) return 0;
-		}
-		else
-		{
-			result = tileset.getRect(id);
-		}
-		
 		__getBounds(result,matrix);
-		return result.width;
+		var w = result.width;
+		#if !flash Rectangle.__pool.release(result); #end
+		return w;
 	}
 
 	@:noCompletion private function set_width(value:Float):Float
 	{
-		// TODO use rectangle pooling
+		// TODO how does pooling work with flash target?
+		var result:Rectangle = #if flash new Rectangle() #else Rectangle.__pool.get() #end;
 
-		var result:Rectangle;
+		__findTileRect(result);
 
-		if (tileset == null)
-		{
-			var parentTileset = parent.__findTileset();
-			if (parentTileset == null) return value;
-			result = parentTileset.getRect(id);
-			if (result == null) return value;
-		}
-		else
-		{
-			result = tileset.getRect(id);
-		}
-		
 		scaleX = value / result.width;
+		#if !flash Rectangle.__pool.release(result); #end
 		return value;
 	}
 

--- a/src/openfl/display/Tile.hx
+++ b/src/openfl/display/Tile.hx
@@ -533,8 +533,7 @@ class Tile
 
 	@:noCompletion private function get_height():Float
 	{
-		// TODO how does pooling work with flash target?
-		var result:Rectangle = #if flash new Rectangle() #else Rectangle.__pool.get() #end;
+		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
 
 		__findTileRect(result);
 
@@ -546,8 +545,7 @@ class Tile
 
 	@:noCompletion private function set_height(value:Float):Float
 	{
-		// TODO how does pooling work with flash target?
-		var result:Rectangle = #if flash new Rectangle() #else Rectangle.__pool.get() #end;
+		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
 
 		__findTileRect(result);
 	

--- a/src/openfl/display/Tile.hx
+++ b/src/openfl/display/Tile.hx
@@ -414,21 +414,28 @@ class Tile
 	{
 		if (tileset == null)
 		{
-			var parentTileset:Tileset = parent.__findTileset();
-			if (parentTileset == null)
+			if (parent != null)
+			{
+				var parentTileset:Tileset = parent.__findTileset();
+				if (parentTileset == null)
+				{
+					result.setTo(0,0,0,0);
+				}
+				else
+				{
+					// ? Is this a way to call getRect once without making extra vars? I don't fully grasp haxe pattern matching. Could be done with an if?
+					switch parentTileset.getRect(id)
+					{
+						case null:
+							result.setTo(0,0,0,0);
+						case not_null:
+							result.copyFrom(not_null);
+					}
+				}
+			}
+			else 
 			{
 				result.setTo(0,0,0,0);
-			}
-			else
-			{
-				// ? Is this a way to call getRect once without making extra vars? I don't fully grasp haxe pattern matching. Could be done with an if?
-				switch parentTileset.getRect(id)
-				{
-					case null:
-						result.setTo(0,0,0,0);
-					case not_null:
-						result.copyFrom(not_null);
-				}
 			}
 		}
 		else
@@ -548,8 +555,9 @@ class Tile
 		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
 
 		__findTileRect(result);
-	
-		scaleY = value / result.height;
+		if (result.height != 0) {
+			scaleY = value / result.height;
+		}
 		#if !flash Rectangle.__pool.release(result); #end
 		return value;
 	}
@@ -834,12 +842,12 @@ class Tile
 
 	@:noCompletion private function set_width(value:Float):Float
 	{
-		// TODO how does pooling work with flash target?
-		var result:Rectangle = #if flash new Rectangle() #else Rectangle.__pool.get() #end;
+		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
 
 		__findTileRect(result);
-
-		scaleX = value / result.width;
+		if (result.width != 0) {
+			scaleX = value / result.width;
+		}
 		#if !flash Rectangle.__pool.release(result); #end
 		return value;
 	}

--- a/src/openfl/display/TileContainer.hx
+++ b/src/openfl/display/TileContainer.hx
@@ -163,7 +163,7 @@ class TileContainer extends Tile implements ITileContainer
 
 		for (tile in __tiles)
 		{
-			// TODO: Generate less Rectangle objects?
+			// TODO: Generate less Rectangle objects? Could be done with __getBounds but need a initial rectangle and the stack of transformations
 			rect = tile.getBounds(targetCoordinateSpace);
 
 			#if flash
@@ -353,5 +353,103 @@ class TileContainer extends Tile implements ITileContainer
 	@:noCompletion private function get_numTiles():Int
 	{
 		return __length;
+	}
+
+	override function get_height():Float {
+		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
+		var rect = null;
+
+		for (tile in __tiles)
+		{
+			// TODO: Generate less Rectangle objects? Could be done with __getBounds but need a initial rectangle and the stack of transformations
+			rect = tile.getBounds(this);
+
+			#if flash
+			result = result.union(rect);
+			#else
+			result.__expand(rect.x, rect.y, rect.width, rect.height);
+			#end
+		}
+
+		__getBounds(result,matrix);
+
+		var h = result.height;
+		#if !flash Rectangle.__pool.release(result); #end
+
+		return h;
+	}
+
+	override function set_height(value:Float):Float {
+		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
+		var rect = null;
+
+		for (tile in __tiles)
+		{
+			// TODO: Generate less Rectangle objects? Could be done with __getBounds but need a initial rectangle and the stack of transformations
+			rect = tile.getBounds(this);
+
+			#if flash
+			result = result.union(rect);
+			#else
+			result.__expand(rect.x, rect.y, rect.width, rect.height);
+			#end
+		}
+		
+		if (result.height != 0) {
+			scaleY = value / result.height;
+		}
+
+		#if !flash Rectangle.__pool.release(result); #end
+
+		return value;
+	}
+
+	override function get_width():Float {
+		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
+		var rect = null;
+
+		for (tile in __tiles)
+		{
+			// TODO: Generate less Rectangle objects? Could be done with __getBounds but need a initial rectangle and the stack of transformations
+			rect = tile.getBounds(this);
+
+			#if flash
+			result = result.union(rect);
+			#else
+			result.__expand(rect.x, rect.y, rect.width, rect.height);
+			#end
+		}
+
+		__getBounds(result,matrix);
+
+		var w = result.width;
+		#if !flash Rectangle.__pool.release(result); #end
+		
+		return w;
+	}
+
+	override function set_width(value:Float):Float {
+		var result:Rectangle = #if flash __tempRectangle #else Rectangle.__pool.get() #end;
+		var rect = null;
+
+		for (tile in __tiles)
+		{
+			// TODO: Generate less Rectangle objects? Could be done with __getBounds but need a initial rectangle and the stack of transformations
+			rect = tile.getBounds(this);
+
+			#if flash
+			result = result.union(rect);
+			#else
+			result.__expand(rect.x, rect.y, rect.width, rect.height);
+			#end
+		}
+
+		if (result.width != 0) {
+			scaleX = value / result.width;
+		}
+
+		#if !flash Rectangle.__pool.release(result); #end
+
+		return value;
 	}
 }


### PR DESCRIPTION
Support for width and height for tiles and tilecontainer.

Both setter and getter should work.

If the tile can't find a "rectangle" to begin with, the result will be zero for `get`, and do nothing for `set`.

Note: This also fixes a `getBounds(self)` problem with tile. Noted when started and then AlexFrost bumped into it and reported to discord.

---

My test suite:
[TileWidthAndHeightTest.zip](https://github.com/openfl/openfl/files/3205041/TileWidthAndHeightTest.zip)
