### PR TITLE
Fixed runtime error in VideoTexture - "canplay" handler wasn't being cleaned up

### DIFF
--- a/src/openfl/display3D/textures/VideoTexture.hx
+++ b/src/openfl/display3D/textures/VideoTexture.hx
@@ -90,13 +90,11 @@ import openfl.net.NetStream;
 	public function attachNetStream(netStream:NetStream):Void
 	{
 		#if (js && html5)
-
-        if(__netStream != null)
-        {
-            __netStream.__video.removeEventListener("canplay", onCanPlay, false);
-        }
-
-        #end
+		if (__netStream != null)
+		{
+			__netStream.__video.removeEventListener("canplay", onCanPlay, false);
+		}
+		#end
 
 		__netStream = netStream;
 
@@ -115,13 +113,12 @@ import openfl.net.NetStream;
 		#end
 	}
 
-    
-    #if (js && html5)
-    function onCanPlay(_):Void
-    {
-        __textureReady();
-    }
-    #end
+	#if (js && html5)
+	function onCanPlay(_):Void
+	{
+		__textureReady();
+	}
+	#end
 
 	@:noCompletion private override function __getTexture():GLTexture
 	{

--- a/src/openfl/display3D/textures/VideoTexture.hx
+++ b/src/openfl/display3D/textures/VideoTexture.hx
@@ -89,6 +89,15 @@ import openfl.net.NetStream;
 	**/
 	public function attachNetStream(netStream:NetStream):Void
 	{
+		#if (js && html5)
+
+        if(__netStream != null)
+        {
+            __netStream.__video.removeEventListener("canplay", onCanPlay, false);
+        }
+
+        #end
+
 		__netStream = netStream;
 
 		#if (js && html5)
@@ -101,13 +110,18 @@ import openfl.net.NetStream;
 		}
 		else
 		{
-			__netStream.__video.addEventListener("canplay", function(_)
-			{
-				__textureReady();
-			}, false);
+			__netStream.__video.addEventListener("canplay", onCanPlay, false);
 		}
 		#end
 	}
+
+    
+    #if (js && html5)
+    function onCanPlay(_):Void
+    {
+        __textureReady();
+    }
+    #end
 
 	@:noCompletion private override function __getTexture():GLTexture
 	{

--- a/src/openfl/display3D/textures/VideoTexture.hx
+++ b/src/openfl/display3D/textures/VideoTexture.hx
@@ -92,7 +92,7 @@ import openfl.net.NetStream;
 		#if (js && html5)
 		if (__netStream != null)
 		{
-			__netStream.__video.removeEventListener("canplay", onCanPlay, false);
+			__netStream.__video.removeEventListener("canplay", __onCanPlay, false);
 		}
 		#end
 
@@ -108,13 +108,13 @@ import openfl.net.NetStream;
 		}
 		else
 		{
-			__netStream.__video.addEventListener("canplay", onCanPlay, false);
+			__netStream.__video.addEventListener("canplay", __onCanPlay, false);
 		}
 		#end
 	}
 
 	#if (js && html5)
-	function onCanPlay(_):Void
+	@:noCompletion private function __onCanPlay(_):Void
 	{
 		__textureReady();
 	}


### PR DESCRIPTION
Fixed issue where "canplay" event was coming through after VideoTexture has been disposed, throwing a runtime error:

TypeError: Cannot read property '__video' of null