### PR TITLE
rename argument 'arguments' in externs openfl.swc

### DIFF
--- a/lib/flash/net/SharedObject.as
+++ b/lib/flash/net/SharedObject.as
@@ -430,7 +430,7 @@ package flash.net {
 		public static function getRemote (name:String, remotePath:String = null, persistence:Object = false, secure:Boolean = false):SharedObject { return null; }
 		
 		
-		public function send (arguments:Array):void {}
+		public function send (message:Array):void {}
 		
 		
 		public function setDirty (propertyName:String):void {}

--- a/lib/openfl/net/SharedObject.as
+++ b/lib/openfl/net/SharedObject.as
@@ -430,7 +430,7 @@ package openfl.net {
 		public static function getRemote (name:String, remotePath:String = null, persistence:Object = false, secure:Boolean = false):SharedObject { return null; }
 		
 		
-		public function send (arguments:Array):void {}
+		public function send (message:Array):void {}
 		
 		
 		public function setDirty (propertyName:String):void {}

--- a/lib/openfl/net/SharedObject.d.ts
+++ b/lib/openfl/net/SharedObject.d.ts
@@ -431,7 +431,7 @@ declare namespace openfl.net {
 		public static getRemote (name:string, remotePath?:string, persistence?:boolean | string, secure?:boolean):SharedObject;
 		
 		
-		public send (arguments:Array<any>):void;
+		public send (message:Array<any>):void;
 		
 		
 		public setDirty (propertyName:string):void;

--- a/lib/openfl/net/SharedObject.hx
+++ b/lib/openfl/net/SharedObject.hx
@@ -408,7 +408,7 @@ extern class SharedObject extends EventDispatcher
 	 */
 	public static function getLocal(name:String, localPath:String = null, secure:Bool = false):SharedObject;
 	public static function getRemote(name:String, remotePath:String = null, persistence:Dynamic = false, secure:Bool = false):SharedObject;
-	public function send(arguments:Array<Dynamic>):Void;
+	public function send(message:Array<Dynamic>):Void;
 	public function setDirty(propertyName:String):Void;
 	public function setProperty(propertyName:String, value:Object = null):Void;
 }


### PR DESCRIPTION
Trying to release build project with external openfl.swc using Apache Royale produces errors by closure compiler

```
Jun 13, 2019 11:42:44 AM com.google.javascript.jscomp.LoggerErrorManager println
SEVERE: externs\flash\net\SharedObject.js:323: ERROR - Shadowing "arguments" is not allowed
flash.net.SharedObject.prototype.send = function(arguments) {
                                                 ^^^^^^^^^

Jun 13, 2019 11:42:44 AM com.google.javascript.jscomp.LoggerErrorManager println
SEVERE: externs\openfl\net\SharedObject.js:323: ERROR - Shadowing "arguments" is not allowed
openfl.net.SharedObject.prototype.send = function(arguments) {
                                                  ^^^^^^^^^
```

Renaming argument with name 'arguments' fixes that problem