### PR TITLE
Moved flushVertexBufferData() outside recursion

### DIFF
--- a/src/openfl/_internal/renderer/context3D/Context3DTilemap.hx
+++ b/src/openfl/_internal/renderer/context3D/Context3DTilemap.hx
@@ -67,6 +67,8 @@ class Context3DTilemap
 		buildBufferTileContainer(tilemap, tilemap.__group, renderer, parentTransform, tilemap.__tileset, tilemap.tileAlphaEnabled, tilemap.__worldAlpha,
 			tilemap.tileColorTransformEnabled, tilemap.__worldColorTransform, null, rect, matrix);
 
+		tilemap.__buffer.flushVertexBufferData();
+		
 		Rectangle.__pool.release(rect);
 		Matrix.__pool.release(matrix);
 		Matrix.__pool.release(parentTransform);
@@ -272,7 +274,6 @@ class Context3DTilemap
 		}
 
 		group.__dirty = false;
-		tilemap.__buffer.flushVertexBufferData();
 		Matrix.__pool.release(tileTransform);
 	}
 


### PR DESCRIPTION
Honestly I don't really understand what "tilemap.__buffer.flushVertexBufferData();" does but it is a somewhat intensive process that gets run once for every tile container.

If you have a lot of tileconteiners it slows down your code to a crawl.

Moving it there speeds up a looooot the rendering for me.

I couldn't find any bug or problem in how tiles and containers render with this change.