### PR TITLE
Culling fix

### DIFF
--- a/src/openfl/_internal/renderer/context3D/Context3DGraphics.hx
+++ b/src/openfl/_internal/renderer/context3D/Context3DGraphics.hx
@@ -771,9 +771,14 @@ class Context3DGraphics
 								vertexBufferPosition += (dataPerVertex * length);
 							}
 
-							if (culling != NONE)
+							// This code is here because other draw calls are not aware (currently) of the culling type and just generally expect it to use
+							// back face culling by default
+							switch (culling)
 							{
-								context.setCulling(BACK);
+								case POSITIVE, NONE:
+									context.setCulling(BACK);
+
+								default:
 							}
 
 							#if gl_stats

--- a/src/openfl/_internal/renderer/context3D/Context3DGraphics.hx
+++ b/src/openfl/_internal/renderer/context3D/Context3DGraphics.hx
@@ -744,6 +744,9 @@ class Context3DGraphics
 								case NEGATIVE:
 									context.setCulling(BACK);
 
+								case NONE:
+									context.setCulling(NONE);
+
 								default:
 							}
 


### PR DESCRIPTION
Fixed restoring default culling value (``Context3DTriangleFace.BACK``) after calling the ``context.__drawTriangles`` function.