### PR TITLE
Handle case where a closing HTML tag is found but no opening HTML tag

### DIFF
--- a/src/openfl/_internal/formats/html/HTMLParser.hx
+++ b/src/openfl/_internal/formats/html/HTMLParser.hx
@@ -92,7 +92,7 @@ class HTMLParser
 
 				if (isClosingTag)
 				{
-					if (tagName.toLowerCase() != tagStack[tagStack.length - 1].toLowerCase())
+					if (tagStack.length == 0 || tagName.toLowerCase() != tagStack[tagStack.length - 1].toLowerCase())
 					{
 						Log.info("Invalid HTML, unexpected closing tag ignored: " + tagName);
 						continue;


### PR DESCRIPTION
This request handles a case where an HTML string has no opening HTML tag but a closing HTML tag is found and the tag stack is empty.