### PR TITLE
Change HTMLParser to allow for whitespace after the '=' symbol

### DIFF
--- a/src/openfl/_internal/formats/html/HTMLParser.hx
+++ b/src/openfl/_internal/formats/html/HTMLParser.hx
@@ -12,20 +12,20 @@ import openfl.Vector;
 @SuppressWarnings("checkstyle:FieldDocComment")
 class HTMLParser
 {
-	private static var __regexAlign:EReg = ~/align=("([^"]+)"|'([^']+)')/i;
+	private static var __regexAlign:EReg = ~/align\s?=\s?("([^"]+)"|'([^']+)')/i;
 	private static var __regexBreakTag:EReg = ~/<br\s*\/?>/gi;
-	private static var __regexBlockIndent:EReg = ~/blockindent=("([^"]+)"|'([^']+)')/i;
-	private static var __regexColor:EReg = ~/color=("#([^"]+)"|'#([^']+)')/i;
+	private static var __regexBlockIndent:EReg = ~/blockindent\s?=\s?("([^"]+)"|'([^']+)')/i;
+	private static var __regexColor:EReg = ~/color\s?=\s?("#([^"]+)"|'#([^']+)')/i;
 	private static var __regexEntities:Array<EReg> = [~/&quot;/g, ~/&apos;/g, ~/&amp;/g, ~/&lt;/g, ~/&gt;/g, ~/&nbsp;/g];
-	private static var __regexFace:EReg = ~/face=("([^"]+)"|'([^']+)')/i;
+	private static var __regexFace:EReg = ~/face\s?=\s?("([^"]+)"|'([^']+)')/i;
 	private static var __regexHTMLTag:EReg = ~/<.*?>/g;
-	private static var __regexHref:EReg = ~/href=("([^"]+)"|'([^']+)')/i;
-	private static var __regexIndent:EReg = ~/ indent=("([^"]+)"|'([^']+)')/i;
-	private static var __regexLeading:EReg = ~/leading=("([^"]+)"|'([^']+)')/i;
-	private static var __regexLeftMargin:EReg = ~/leftmargin=("([^"]+)"|'([^']+)')/i;
-	private static var __regexRightMargin:EReg = ~/rightmargin=("([^"]+)"|'([^']+)')/i;
-	private static var __regexSize:EReg = ~/size=("([^"]+)"|'([^']+)')/i;
-	private static var __regexTabStops:EReg = ~/tabstops=("([^"]+)"|'([^']+)')/i;
+	private static var __regexHref:EReg = ~/href\s?=\s?("([^"]+)"|'([^']+)')/i;
+	private static var __regexIndent:EReg = ~/ indent\s?=\s?("([^"]+)"|'([^']+)')/i;
+	private static var __regexLeading:EReg = ~/leading\s?=\s?("([^"]+)"|'([^']+)')/i;
+	private static var __regexLeftMargin:EReg = ~/leftmargin\s?=\s?("([^"]+)"|'([^']+)')/i;
+	private static var __regexRightMargin:EReg = ~/rightmargin\s?=\s?("([^"]+)"|'([^']+)')/i;
+	private static var __regexSize:EReg = ~/size\s?=\s?("([^"]+)"|'([^']+)')/i;
+	private static var __regexTabStops:EReg = ~/tabstops\s?=\s?("([^"]+)"|'([^']+)')/i;
 
 	public static function parse(value:String, textFormat:TextFormat, textFormatRanges:Vector<TextFormatRange>):String
 	{


### PR DESCRIPTION
Changed the HTMLParser regex statements to allow for optional whitespace after the '=' symbol. E.g. <font color = "#FFFFFF">
