### PR TITLE
helping GC free memory faster

### DIFF
--- a/src/openfl/events/Event.hx
+++ b/src/openfl/events/Event.hx
@@ -905,6 +905,8 @@ class Event
 	@:noCompletion private function __init():Void
 	{
 		// type = null;
+		target = null;
+		currentTarget = null;
 		bubbles = false;
 		cancelable = false;
 		eventPhase = AT_TARGET;


### PR DESCRIPTION
when troubleshooting a memory leak i realized that object references remain in Event objects even after all other references where removed.  Events returning to their object pools currently keeps `target` and `currentTarget` values and prevents the GC from freeing those objects.

Running `cpp.vm.Gc.trace`  on one of my memory intensive movieclips reviled  that it was not released due to a reference in an inactive event object.
```
Class referenced from:
MarkClassStatics.(null)
openfl.events.Event.__pool
ObjectPool.__inactiveObject0    <------
Event.target
MovieClip.__totalFrames
...
```
this pull request should fix this by clearing  `target` and `currentTarget` when Events are returned to the object pool.
