### PR TITLE
Sanity check for the "onload" parameter

### DIFF
--- a/src/openfl/_internal/macros/AssetsMacro.hx
+++ b/src/openfl/_internal/macros/AssetsMacro.hx
@@ -61,7 +61,7 @@ class AssetsMacro
 								preload = b.image;
 							}
 
-							if (onload != null)
+							if (onload != null && Reflect.isFunction(onload))
 							{
 								onload(b);
 							}


### PR DESCRIPTION
No idea what "onload" is or why sometimes is a boolean value, but this fixes it.
If this is the correct way, we could replicate this change to lime's AssetsMacro