### PR TITLE
Minor buttonMode fix

### DIFF
--- a/src/openfl/display/MovieClip.hx
+++ b/src/openfl/display/MovieClip.hx
@@ -1088,6 +1088,11 @@ class MovieClip extends Sprite #if (openfl_dynamic && haxe_ver < "4.0.0") implem
 			stage.removeEventListener(MouseEvent.MOUSE_UP, __onMouseUp);
 		}
 
+		if (!__buttonMode)
+		{
+			return;
+		}
+
 		if (event.target == this && __enabled && __hasOver)
 		{
 			gotoAndStop("_over");


### PR DESCRIPTION
A quick fix of the behavior of MovieClips when buttonMode is turned false on the mouse down event.