### PR TITLE
Fix processing SWF library files with no scripts

### DIFF
--- a/scripts/FrameScriptParser.hx
+++ b/scripts/FrameScriptParser.hx
@@ -63,6 +63,7 @@ class FrameScriptParser
 							var in_if:Bool = false;
 							var while_loops = [];
 
+							if(pcodes != null)
 							for (pindex in 0...pcodes.length)
 							{
 								var pcode = pcodes[pindex];

--- a/scripts/format/swf/exporters/SWFLiteExporter.hx
+++ b/scripts/format/swf/exporters/SWFLiteExporter.hx
@@ -895,6 +895,8 @@ class SWFLiteExporter
 								var js = "";
 								var prop:MultiName = null;
 								var stack:Array<Dynamic> = new Array();
+								
+								if(pcodes != null)
 								for (pcode in pcodes)
 								{
 									switch (pcode.opr)


### PR DESCRIPTION
While processing any of these example SWF asset library files: https://icer.ink/media1.clubpenguin.com/play/v2/client/puffle/care/
you'd normally get an error:
```
> openfl process assetLibraryBlue.swf blue.bundle
Called from ? line 1
Called from Tools.hx line 629
Called from Tools.hx line 673
Called from format/swf/exporters/SWFLiteExporter.hx line 62
Called from format/swf/exporters/SWFLiteExporter.hx line 98
Called from format/swf/exporters/SWFLiteExporter.hx line 898
Uncaught exception - Invalid field access : length
```

This commit fixes that and allows processing these SWF files, for both SWFLiteExporter and SWFLibraryExporter.