### PR TITLE
Disable culling when flushing BatchRenderer

### DIFF
--- a/src/openfl/_internal/renderer/context3D/batcher/BatchRenderer.hx
+++ b/src/openfl/_internal/renderer/context3D/batcher/BatchRenderer.hx
@@ -178,6 +178,7 @@ class BatchRenderer
 
 		var context = renderer.context3D;
 
+		context.setCulling(NONE);
 		context.setScissorRectangle(null);
 		renderer.__setBlendMode(__batch.blendMode);
 


### PR DESCRIPTION
This change disables culling, which could be present after previous drawTriangles() calls, so it could render quads with negative scaling (otherwise they will be invisible)