### PR TITLE
Less code duplication in BitmapData's pushQuadsToBatcher()

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -1634,20 +1634,8 @@ class BitmapData implements IBitmapDrawable
 		var scale9Grid = object.__worldScale9Grid;
 
 		#if openfl_power_of_two
-		var newWidth = 1;
-		var newHeight = 1;
-
-		while (newWidth < width)
-		{
-			newWidth <<= 1;
-		}
-
-		while (newHeight < height)
-		{
-			newHeight <<= 1;
-		}
-		var uvWidth = width / newWidth;
-		var uvHeight = height / newHeight;
+		var uvWidth = width / __textureWidth;
+		var uvHeight = height / __textureHeight;
 		#else
 		var uvWidth = 1;
 		var uvHeight = 1;


### PR DESCRIPTION
`__textureWidth` and `__textureHeight` should be available by the time this method will be called, so there is no need to make these calculations