### PR TITLE
fix BitmapData draw in HardWare mode

### DIFF
--- a/src/openfl/_internal/renderer/context3D/Context3DRenderer.hx
+++ b/src/openfl/_internal/renderer/context3D/Context3DRenderer.hx
@@ -486,7 +486,9 @@ class Context3DRenderer extends Context3DRendererAPI
 		var cacheRTTAntiAlias = context.__state.renderToTextureAntiAlias;
 		var cacheRTTSurfaceSelector = context.__state.renderToTextureSurfaceSelector;
 
+		var prevRenderTarget = __defaultRenderTarget;
 		context.setRenderToTexture(bitmapData.getTexture(context), true);
+		__setRenderTarget(bitmapData);
 
 		__render(source);
 
@@ -498,6 +500,8 @@ class Context3DRenderer extends Context3DRendererAPI
 		{
 			context.setRenderToBackBuffer();
 		}
+
+		__setRenderTarget(prevRenderTarget);
 
 		if (clipRect != null)
 		{

--- a/src/openfl/_internal/renderer/context3D/Context3DRenderer.hx
+++ b/src/openfl/_internal/renderer/context3D/Context3DRenderer.hx
@@ -1306,8 +1306,8 @@ class Context3DRenderer extends Context3DRendererAPI
 		__width = width;
 		__height = height;
 
-		var w = (__defaultRenderTarget == null) ? __stage.stageWidth : __defaultRenderTarget.width;
-		var h = (__defaultRenderTarget == null) ? __stage.stageHeight : __defaultRenderTarget.height;
+		var w = (__defaultRenderTarget == null) ? __stage.stageWidth : __defaultRenderTarget.__textureWidth;
+		var h = (__defaultRenderTarget == null) ? __stage.stageHeight : __defaultRenderTarget.__textureHeight;
 
 		__offsetX = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformX(0, 0)) : 0;
 		__offsetY = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformY(0, 0)) : 0;

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -944,14 +944,8 @@ class BitmapData implements IBitmapDrawable
 		_colorTransform.__copyFrom(source.__worldColorTransform);
 		_colorTransform.__invert();
 
-		if (!readable && __texture != null && __hardwareRenderer != null)
+		if (!readable && __hardwareRenderer != null && getTexture(__hardwareRenderer.context3D) != null)
 		{
-			if (__textureContext == null)
-			{
-				// TODO: Some way to select current GL context for renderer?
-				__textureContext = Application.current.window.context;
-			}
-
 			if (colorTransform != null)
 			{
 				_colorTransform.__combine(colorTransform);
@@ -2304,6 +2298,13 @@ class BitmapData implements IBitmapDrawable
 	@:dox(hide) public function getTexture(context:Context3D):TextureBase
 	{
 		if (!__isValid) return null;
+
+		if (!readable && image == null && (__texture == null || __textureContext != context.__context))
+		{
+			__textureContext = null;
+			__texture = null;
+			return null;
+		}
 
 		if (__texture == null || __textureContext != context.__context)
 		{

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -2309,7 +2309,7 @@ class BitmapData implements IBitmapDrawable
 		if (__texture == null || __textureContext != context.__context)
 		{
 			__textureContext = context.__context;
-			__texture = context.createRectangleTexture(width, height, BGRA, false);
+			__texture = context.createRectangleTexture(__textureWidth, __textureHeight, BGRA, false);
 
 			// context.__bindGLTexture2D (__texture);
 			// gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1240,6 +1240,13 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			__renderer.__stage = this;
 
 			__renderer.__resize(windowWidth, windowHeight);
+
+			if (BitmapData.__hardwareRenderer != null)
+			{
+				BitmapData.__hardwareRenderer.__stage = this;
+				BitmapData.__hardwareRenderer.__worldTransform = __displayMatrix.clone();
+				BitmapData.__hardwareRenderer.__resize(windowWidth, windowHeight);
+			}
 		}
 		#end
 	}


### PR DESCRIPTION
If BitmapData isn't readable then app won't draw it correctly or might crash, these changes make it work