### PR TITLE
CUSTOM_RENDER_OBJECT: a new type in DisplayObjectType

### DIFF
--- a/src/openfl/_internal/renderer/DisplayObjectType.hx
+++ b/src/openfl/_internal/renderer/DisplayObjectType.hx
@@ -11,6 +11,7 @@ enum DisplayObjectType
 	TEXTFIELD;
 	TILEMAP;
 	VIDEO;
+	CUSTOM_RENDER_OBJECT;
 	#if draft
 	GL_GRAPHICS;
 	GEOMETRY;

--- a/src/openfl/_internal/renderer/DisplayObjectType.hx
+++ b/src/openfl/_internal/renderer/DisplayObjectType.hx
@@ -11,7 +11,7 @@ enum DisplayObjectType
 	TEXTFIELD;
 	TILEMAP;
 	VIDEO;
-	CUSTOM_RENDER_OBJECT;
+	CUSTOM;
 	#if draft
 	GL_GRAPHICS;
 	GEOMETRY;


### PR DESCRIPTION
``DisplayObjectType::CUSTOM_RENDER_OBJECT``: a new type of object is added so that no other rendering methods are called during custom rendering.
For example, if a custom object is inherited from ``DisplayObject``, it may not need to call the ``__renderShape`` method before calling ``RenderEvent``.