### PR TITLE
Bitmap should use width/height getters of DisplayObject

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -132,16 +132,19 @@ class Bitmap extends DisplayObject
 
 	@:noCompletion private override function __getBounds(rect:Rectangle, matrix:Matrix):Void
 	{
+		var bounds = Rectangle.__pool.get();
 		if (__bitmapData != null)
 		{
-			var bounds = Rectangle.__pool.get();
 			bounds.setTo(0, 0, __bitmapData.width, __bitmapData.height);
-			bounds.__transform(bounds, matrix);
-
-			rect.__expand(bounds.x, bounds.y, bounds.width, bounds.height);
-
-			Rectangle.__pool.release(bounds);
 		}
+		else
+		{
+			bounds.setTo(0, 0, 0, 0);
+		}
+
+		bounds.__transform(bounds, matrix);
+		rect.__expand(bounds.x, bounds.y, bounds.width, bounds.height);
+		Rectangle.__pool.release(bounds);
 	}
 
 	@:noCompletion private override function __hitTest(x:Float, y:Float, shapeFlag:Bool, stack:Array<DisplayObject>, interactiveOnly:Bool,
@@ -217,7 +220,7 @@ class Bitmap extends DisplayObject
 	{
 		if (__bitmapData != null)
 		{
-			scaleY = value / __bitmapData.height;
+			scaleY = value / get_height();
 		}
 		else
 		{
@@ -230,7 +233,7 @@ class Bitmap extends DisplayObject
 	{
 		if (__bitmapData != null)
 		{
-			scaleX = value / __bitmapData.width;
+			scaleX = value / get_width();
 		}
 		else
 		{

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -213,15 +213,6 @@ class Bitmap extends DisplayObject
 		return __bitmapData;
 	}
 
-	@:noCompletion private override function get_height():Float
-	{
-		if (__bitmapData != null)
-		{
-			return __bitmapData.height * Math.abs(scaleY);
-		}
-		return 0;
-	}
-
 	@:noCompletion private override function set_height(value:Float):Float
 	{
 		if (__bitmapData != null)
@@ -233,15 +224,6 @@ class Bitmap extends DisplayObject
 			scaleY = 0;
 		}
 		return value;
-	}
-
-	@:noCompletion private override function get_width():Float
-	{
-		if (__bitmapData != null)
-		{
-			return __bitmapData.width * Math.abs(__scaleX);
-		}
-		return 0;
 	}
 
 	@:noCompletion private override function set_width(value:Float):Float


### PR DESCRIPTION
This fixes the case when Bitmap is rotated with 90/270 degrees, which leads to "swap" between Bitmap's width and height values