### PR TITLE
Fix scrollRect support for Bitmaps in Canvas mode

### DIFF
--- a/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
@@ -42,7 +42,15 @@ class CanvasBitmap
 			}
 			else
 			{
-				context.drawImage(bitmap.__bitmapData.image.src, scrollRect.x, scrollRect.y, scrollRect.width, scrollRect.height);
+				context.save();
+
+				context.beginPath();
+				context.rect(scrollRect.x, scrollRect.y, scrollRect.width, scrollRect.height);
+				context.clip();
+
+				context.drawImage(bitmap.__bitmapData.image.src, 0, 0, bitmap.__bitmapData.image.width, bitmap.__bitmapData.image.height);
+
+				context.restore();
 			}
 
 			if (!renderer.__allowSmoothing || !bitmap.smoothing)


### PR DESCRIPTION
Rotated Bitmaps had been rendered incorrectly before this change