### PR TITLE
Do not create image clone when it has power of 2 dimensions

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -2328,7 +2328,7 @@ class BitmapData implements IBitmapDrawable
 			var textureImage = image;
 
 			#if (js && html5)
-			if (#if openfl_power_of_two true || #end (!TextureBase.__supportsBGRA && textureImage.format != RGBA32))
+			if (#if openfl_power_of_two !textureImage.powerOfTwo || #end (!TextureBase.__supportsBGRA && textureImage.format != RGBA32))
 			{
 				textureImage = textureImage.clone();
 				textureImage.format = RGBA32;


### PR DESCRIPTION
This change should help to generate less garbage when `openfl_power_of_two` is set