### PR TITLE
Fix mask rendering in canvas mode

### DIFF
--- a/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -1462,6 +1462,8 @@ class CanvasGraphics
 		{
 			context = cast renderer.context;
 
+			context.beginPath();
+
 			var positionX = 0.0;
 			var positionY = 0.0;
 
@@ -1526,9 +1528,9 @@ class CanvasGraphics
 
 					case DRAW_RECT:
 						var c = data.readDrawRect();
-						context.beginPath();
+						// context.beginPath();
 						context.rect(c.x - offsetX, c.y - offsetY, c.width, c.height);
-						context.closePath();
+						// context.closePath();
 
 					case DRAW_ROUND_RECT:
 						var c = data.readDrawRoundRect();
@@ -1550,6 +1552,8 @@ class CanvasGraphics
 						data.skip(type);
 				}
 			}
+
+			context.closePath();
 
 			data.destroy();
 		}


### PR DESCRIPTION
This pull requests fixes cases when graphics in mask object contains multiple commands (drawRect, drawCirce, etc.). If you call `context.beginPath()` and `context.endPath()` between those commands, then only the last one will be used as a mask