### PR TITLE
Fix for rightMargin with center-justified text.

### DIFF
--- a/src/openfl/_internal/text/TextEngine.hx
+++ b/src/openfl/_internal/text/TextEngine.hx
@@ -1640,6 +1640,7 @@ class TextEngine
 			if (group.lineIndex != lineIndex)
 			{
 				lineIndex = group.lineIndex;
+				totalWidth = this.width - GUTTER * 2 - group.format.rightMargin;
 
 				switch (group.format.align)
 				{


### PR DESCRIPTION
I wrote this after only skimming the code and getting a basic understanding. It seems `leftMargin` isn't needed here because it's later accounted for by the calls to `getBaseX()` in `placeFormattedText()`. Without this, center-justified text is off-center when a right margin is specified.