### PR TITLE
Fixing issue where fields in generated classes where not populated.

### DIFF
--- a/src/openfl/_internal/symbols/timeline/SymbolTimeline.hx
+++ b/src/openfl/_internal/symbols/timeline/SymbolTimeline.hx
@@ -256,7 +256,7 @@ class SymbolTimeline extends Timeline
 		}
 
 		#if (!openfljs && (!openfl_dynamic || haxe_ver >= "4.0.0"))
-		__instanceFields = Type.getInstanceFields(Type.getClass(this));
+		__instanceFields = Type.getInstanceFields(Type.getClass(movieClip));
 		#end
 
 		enterFrame(1);


### PR DESCRIPTION
After the logic for populating fields where moved from  `Movieclip` to `SymbolTimeline` fields for generated classes where no longer populated. 

The code used to work as all generated classes where extending Movieclip but stopped working when the logic was moved outside the class. updating the logic in SymbolTimeline to  get instance fields from the Movieclip it belongs to fixes this issue.