### PR TITLE
Fix UTF16 text on Haxe4

### DIFF
--- a/src/openfl/_internal/text/TextLayout.hx
+++ b/src/openfl/_internal/text/TextLayout.hx
@@ -137,12 +137,13 @@ class TextLayout
 			__hbBuffer.script = script.toHBScript();
 			__hbBuffer.language = new HBLanguage(language);
 			__hbBuffer.clusterLevel = HBBufferClusterLevel.CHARACTERS;
-			// #if ((haxe_ver < "4.0.0") || neko || mac || linux || hl)
+			#if (neko || mac || linux || hl)
+			// other targets still uses dummy positions to make UTF8 work
+			// TODO: confirm
 			__hbBuffer.addUTF8(text, 0, -1);
-			// #else
-			// for (i in 0...text.length)
-			// 	__hbBuffer.add(text.charCodeAt(i), i);
-			// #end
+			#else
+			__hbBuffer.addUTF16(untyped __cpp__('(uintptr_t){0}', text.wc_str()), text.length, 0, -1);
+			#end
 
 			HB.shape(__hbFont, __hbBuffer);
 


### PR DESCRIPTION
Closes #2264, #2237 

Proper UTF16 support via the Harfbuzz API's intended function. I can't easily test Mac, Linux, or HL, so I'm not sure the conditional is still correct, if someone else can check. See #2264 for a good example: the text will render incorrectly if this change is required.