### PR TITLE
fast copy transform matrix (avoids clone in matrix getter)

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -190,6 +190,7 @@ import js.html.CSSStyleDeclaration;
 @:access(openfl.geom.ColorTransform)
 @:access(openfl.geom.Matrix)
 @:access(openfl.geom.Rectangle)
+@:access(openfl.geom.Transform)
 class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (openfl_dynamic && haxe_ver < "4.0.0") implements Dynamic<DisplayObject> #end
 {
 	@:noCompletion private static var __broadcastEvents:Map<String, Array<DisplayObject>> = new Map();
@@ -3007,7 +3008,11 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		}
 
 		__setTransformDirty();
-		__objectTransform.matrix = value.matrix;
+		
+		if(value.__hasMatrix) 
+		{
+			__objectTransform.__copyMatrix(value.__displayObject.__transform);
+		}
 
 		if (!__objectTransform.colorTransform.__equals(value.colorTransform, true)
 			|| (!cacheAsBitmap && __objectTransform.colorTransform.alphaMultiplier != value.colorTransform.alphaMultiplier))

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -3009,9 +3009,14 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 		__setTransformDirty();
 		
-		if(value.__hasMatrix) 
+		if (value.__hasMatrix)
 		{
-			__objectTransform.__copyMatrix(value.__displayObject.__transform);
+			var other = value.__displayObject.__transform;
+			__objectTransform.__setTransform(other.a, other.b, other.c, other.d, other.tx, other.ty);
+		}
+		else
+		{
+			__objectTransform.__hasMatrix = false;
 		}
 
 		if (!__objectTransform.colorTransform.__equals(value.colorTransform, true)

--- a/src/openfl/geom/Transform.hx
+++ b/src/openfl/geom/Transform.hx
@@ -249,6 +249,10 @@ class Transform
 
 		return value;
 	}
+	@:noCompletion private function __copyMatrix(value:Matrix):Void
+	{
+			__setTransform(value.a, value.b, value.c, value.d, value.tx, value.ty);
+	}
 
 	@:noCompletion private function get_matrix3D():Matrix3D
 	{

--- a/src/openfl/geom/Transform.hx
+++ b/src/openfl/geom/Transform.hx
@@ -249,10 +249,6 @@ class Transform
 
 		return value;
 	}
-	@:noCompletion private function __copyMatrix(value:Matrix):Void
-	{
-			__setTransform(value.a, value.b, value.c, value.d, value.tx, value.ty);
-	}
 
 	@:noCompletion private function get_matrix3D():Matrix3D
 	{


### PR DESCRIPTION
Avoids  `Transform`'s matrix getter so we dont have to execute unnecessary matrix clone operations.
Should be safe as its private and only accessed by `DisplayObject`.

(will hopefully reduce CPU and memory operations when doing a lot of transformations.) 