### PR TITLE
Adding weakReference support for EventListeners when targeting native.

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1145,25 +1145,34 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		{
 			var dispatchers = DisplayObject.__broadcastEvents.get(event.type);
 
-			for (dispatcher in dispatchers)
+			for (referenceProxy in dispatchers)
 			{
-				// TODO: Way to resolve dispatching occurring if object not on stage
-				// and there are multiple stage objects running in HTML5?
-
-				if (dispatcher.stage == this || dispatcher.stage == null)
+				
+				if(referenceProxy.get() == null) 
 				{
-					#if !openfl_disable_handle_error
-					try
+					dispatchers.remove(referenceProxy);
+				}
+				else 
+				{
+					var dispatcher = referenceProxy.get();
+					
+					// TODO: Way to resolve dispatching occurring if object not on stage
+					// and there are multiple stage objects running in HTML5?
+					if (dispatcher.stage == this || dispatcher.stage == null)
 					{
+						#if !openfl_disable_handle_error
+						try
+						{
+							dispatcher.__dispatch(event);
+						}
+						catch (e:Dynamic)
+						{
+							__handleError(e);
+						}
+						#else
 						dispatcher.__dispatch(event);
+						#end
 					}
-					catch (e:Dynamic)
-					{
-						__handleError(e);
-					}
-					#else
-					dispatcher.__dispatch(event);
-					#end
 				}
 			}
 		}

--- a/src/openfl/events/EventDispatcher.hx
+++ b/src/openfl/events/EventDispatcher.hx
@@ -1,6 +1,7 @@
 package openfl.events;
 
 #if !flash
+import openfl.utils.ReferenceProxy;
 /**
 	The EventDispatcher class is the base class for all classes that dispatch
 	events. The EventDispatcher class implements the IEventDispatcher interface
@@ -187,7 +188,7 @@ class EventDispatcher implements IEventDispatcher
 		if (!__eventMap.exists(type))
 		{
 			var list = new Array<Listener>();
-			list.push(new Listener(listener, useCapture, priority));
+			list.push(new Listener(listener, useCapture, priority, useWeakReference));
 
 			var iterator = new DispatchIterator(list);
 
@@ -213,7 +214,7 @@ class EventDispatcher implements IEventDispatcher
 				}
 			}
 
-			__addListenerByPriority(list, new Listener(listener, useCapture, priority));
+			__addListenerByPriority(list, new Listener(listener, useCapture, priority, useWeakReference));
 		}
 	}
 
@@ -394,12 +395,12 @@ class EventDispatcher implements IEventDispatcher
 
 		for (listener in iterator)
 		{
-			if (listener == null) continue;
+			if (listener == null || listener.callback.get() == null) continue;
 
 			if (listener.useCapture == capture)
 			{
 				// listener.callback (event.clone ());
-				listener.callback(event);
+				listener.callback.get()(event);
 
 				if (event.__isCanceledNow)
 				{
@@ -536,13 +537,13 @@ class EventDispatcher implements IEventDispatcher
 @SuppressWarnings("checkstyle:FieldDocComment")
 private class Listener
 {
-	public var callback:Dynamic->Void;
+	public var callback:ReferenceProxy<Dynamic->Void>;
 	public var priority:Int;
 	public var useCapture:Bool;
 
-	public function new(callback:Dynamic->Void, useCapture:Bool, priority:Int)
+	public function new(callback:Dynamic->Void, useCapture:Bool, priority:Int, useWeakReference:Bool = false)
 	{
-		this.callback = callback;
+		this.callback = new ReferenceProxy(callback, useWeakReference);
 		this.useCapture = useCapture;
 		this.priority = priority;
 	}
@@ -550,9 +551,9 @@ private class Listener
 	public function match(callback:Dynamic->Void, useCapture:Bool):Bool
 	{
 		#if hl // https://github.com/HaxeFoundation/hashlink/issues/301
-		return ((Reflect.compareMethods(this.callback, callback) || Reflect.compare(this.callback, callback) == 0) && this.useCapture == useCapture);
+		return ((Reflect.compareMethods(this.callback.get(), callback) || Reflect.compare(this.callback.get(), callback) == 0) && this.useCapture == useCapture);
 		#else
-		return (Reflect.compareMethods(this.callback, callback) && this.useCapture == useCapture);
+		return (Reflect.compareMethods(this.callback.get(), callback) && this.useCapture == useCapture);
 		#end
 	}
 }

--- a/src/openfl/utils/ReferenceProxy.hx
+++ b/src/openfl/utils/ReferenceProxy.hx
@@ -1,0 +1,41 @@
+package openfl.utils;
+#if cpp
+class ReferenceProxy<T> 
+{
+	var isWeak:Bool;
+	var strongRef:T;
+	var weakRef:cpp.vm.WeakRef<T>;
+
+	public function new(inObject:T, useWeakRefrence:Bool) 
+	{
+		isWeak = useWeakRefrence;
+		
+		if (isWeak)
+			weakRef = new cpp.vm.WeakRef(inObject);
+		else
+			strongRef = inObject;
+	}
+
+	public function get():T 
+	{
+		return isWeak ? weakRef.get() : strongRef;
+	}
+
+}
+#else
+//Weak refrences currently only supported for cpp target
+class ReferenceProxy<T> 
+{
+	var ref:T;
+
+	public function new(inObject:T, useWeakRefrence:Bool) 
+	{
+		ref = inObject;
+	}
+
+	public function get():T 
+	{
+		return ref;
+	}
+}
+#end


### PR DESCRIPTION
In order to improve GC performance on native targets i have added support for weak references for EventListeners so that the `useWeakReference` flag actually do something.

i kept it simple and only made one class that handle both strong and weak references, if preferred i could change it into  2 distinct classes, WeakReference , StrongReference or do other changes to it.