### PR TITLE
Fix UTF16 on Linux

### DIFF
--- a/src/openfl/_internal/text/TextLayout.hx
+++ b/src/openfl/_internal/text/TextLayout.hx
@@ -140,7 +140,7 @@ class TextLayout
 			__hbBuffer.script = script.toHBScript();
 			__hbBuffer.language = new HBLanguage(language);
 			__hbBuffer.clusterLevel = HBBufferClusterLevel.CHARACTERS;
-			#if (neko || mac || linux || hl)
+			#if (neko || mac || hl)
 			// other targets still uses dummy positions to make UTF8 work
 			// TODO: confirm
 			__hbBuffer.addUTF8(text, 0, -1);


### PR DESCRIPTION
Confirmed with two people that Linux should be using the UTF16 fix from #2300 