### PR TITLE
Fix for the wrong behavior of HOME/END keys

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1525,29 +1525,13 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function __caretBeginningOfLine():Void
 	{
-		if (__selectionIndex == __caretIndex || __caretIndex < __selectionIndex)
-		{
-			__caretIndex = getLineOffset(getLineIndexOfChar(__caretIndex));
-		}
-		else
-		{
-			__selectionIndex = getLineOffset(getLineIndexOfChar(__selectionIndex));
-		}
+		__caretIndex = getLineOffset(getLineIndexOfChar(__caretIndex));
 	}
 
 	@:noCompletion private function __caretEndOfLine():Void
 	{
-		var lineIndex;
-
-		if (__selectionIndex == __caretIndex)
-		{
-			lineIndex = getLineIndexOfChar(__caretIndex);
-		}
-		else
-		{
-			lineIndex = getLineIndexOfChar(Std.int(Math.max(__caretIndex, __selectionIndex)));
-		}
-
+		var lineIndex = getLineIndexOfChar(__caretIndex);
+		
 		if (lineIndex < __textEngine.numLines - 1)
 		{
 			__caretIndex = getLineOffset(lineIndex + 1) - 1;
@@ -3513,11 +3497,23 @@ class TextField extends InteractiveObject
 
 			case HOME if (selectable):
 				__caretBeginningOfLine();
+				
+				if (!modifier.shiftKey)
+				{
+					__selectionIndex = __caretIndex;
+				}
+				
 				__stopCursorTimer();
 				__startCursorTimer();
 
 			case END if (selectable):
 				__caretEndOfLine();
+				
+				if (!modifier.shiftKey)
+				{
+					__selectionIndex = __caretIndex;
+				}
+				
 				__stopCursorTimer();
 				__startCursorTimer();
 

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1526,6 +1526,12 @@ class TextField extends InteractiveObject
 	@:noCompletion private function __caretBeginningOfLine():Void
 	{
 		__caretIndex = getLineOffset(getLineIndexOfChar(__caretIndex));
+		
+		if (__caretIndex < 0)
+		{
+			__caretIndex = __text.length;
+			__selectionIndex = __caretIndex;
+		}
 	}
 
 	@:noCompletion private function __caretEndOfLine():Void
@@ -1539,6 +1545,12 @@ class TextField extends InteractiveObject
 		else
 		{
 			__caretIndex = __text.length;
+		}
+		
+		if (__caretIndex < 0)
+		{
+			__caretIndex = __text.length;
+			__selectionIndex = __caretIndex;
 		}
 	}
 
@@ -3503,6 +3515,8 @@ class TextField extends InteractiveObject
 					__selectionIndex = __caretIndex;
 				}
 				
+				__updateScrollH();
+				__updateScrollV();
 				__stopCursorTimer();
 				__startCursorTimer();
 
@@ -3514,6 +3528,8 @@ class TextField extends InteractiveObject
 					__selectionIndex = __caretIndex;
 				}
 				
+				__updateScrollH();
+				__updateScrollV();
 				__stopCursorTimer();
 				__startCursorTimer();
 


### PR DESCRIPTION
Incorrect behavior of HOME and END buttons. Currently, whenever HOME/END is pressed, this results in selecting a fragment of text from the current cursor position to the beginning/end of the line. The correct behavior would be just moving the cursor to the beginning/end of the line without selecting any text, whereas text selection should happen when HOME/END is pressed together with Shift. The proposed change fixes this issue.