### PR TITLE
Fix for the position of the cursor

### DIFF
--- a/src/openfl/_internal/renderer/cairo/CairoTextField.hx
+++ b/src/openfl/_internal/renderer/cairo/CairoTextField.hx
@@ -356,7 +356,7 @@ class CairoTextField
 		}
 		else if (textField.__caretIndex > -1 && textEngine.selectable && textField.__showCursor)
 		{
-			var scrollX = -textField.scrollH;
+			var scrollX = (textField.__textFormat.align == CENTER) ? textEngine.width / 2 : ((textField.__textFormat.align == RIGHT) ? textEngine.width - 4 : 0);
 			var scrollY = 0.0;
 
 			for (i in 0...textField.scrollV - 1)


### PR DESCRIPTION
When there is no text in the text field, the blinking cursor should be positioned according to the alignment setting of the text field. Without this fix, the cursor is blinking on the left regardless of the alignment setting.