### PR TITLE
Fixes for bottomScrollV and maxScrollV, reiterated

### DIFF
--- a/src/openfl/_internal/text/TextEngine.hx
+++ b/src/openfl/_internal/text/TextEngine.hx
@@ -1784,18 +1784,19 @@ class TextEngine
 		else
 		{
 			var tempHeight = 0.0;
-			var ret = numLines;
+			var ret = scrollV;
 			var firstVisible = scrollV - 1;
 			
 			for (i in firstVisible...lineHeights.length)
 			{
-				if (tempHeight + lineHeights[i] < height - 4)
+				if (tempHeight + lineHeights[i] <= height - 4)
 				{
 					tempHeight += lineHeights[i];
+					ret = i + 1;
 				}
 				else
 				{
-					return (i + 1);
+					break;
 				}
 			}
 			
@@ -1812,20 +1813,20 @@ class TextEngine
 		}
 		else
 		{
-			var i = numLines - 1, tempHeight = 0.0;
+			var ret = numLines, tempHeight = 0.0;
 
-			while (i > 0)
+			for (i in lineHeights.length - 1...0)
 			{
-				if (tempHeight + lineHeights[i] < height - 4)
+				if (tempHeight + lineHeights[i] <= height - 4)
 				{
 					tempHeight += lineHeights[i];
-					i--;
+					ret = i + 1;
 				}
 				else
 					break;
 			}
 
-			return (i + 1);
+			return ret;
 		}
 	}
 

--- a/src/openfl/_internal/text/TextEngine.hx
+++ b/src/openfl/_internal/text/TextEngine.hx
@@ -1814,7 +1814,7 @@ class TextEngine
 		{
 			var i = numLines - 1, tempHeight = 0.0;
 
-			while (i >= 0)
+			while (i > 0)
 			{
 				if (tempHeight + lineHeights[i] < height - 4)
 				{

--- a/src/openfl/_internal/text/TextEngine.hx
+++ b/src/openfl/_internal/text/TextEngine.hx
@@ -1777,29 +1777,28 @@ class TextEngine
 	private function get_bottomScrollV():Int
 	{
 		// TODO: only update when dirty
-		if (numLines == 1 || lineHeights == null)
+		if (numLines == 1 || lineHeights == null || scrollV == 0 || scrollV > lineHeights.length)
 		{
 			return 1;
 		}
 		else
 		{
 			var tempHeight = 0.0;
-			var ret = lineHeights.length;
-
-			for (i in ret - 1...lineHeights.length)
+			var ret = numLines;
+			var firstVisible = scrollV - 1;
+			
+			for (i in firstVisible...lineHeights.length)
 			{
-				if (tempHeight + lineHeights[i] <= height - 4)
+				if (tempHeight + lineHeights[i] < height - 4)
 				{
 					tempHeight += lineHeights[i];
 				}
 				else
 				{
-					ret = i;
-					break;
+					return (i + 1);
 				}
 			}
-
-			if (ret < 1) return 1;
+			
 			return ret;
 		}
 	}
@@ -1815,12 +1814,9 @@ class TextEngine
 		{
 			var i = numLines - 1, tempHeight = 0.0;
 
-			if (text.charCodeAt(text.length - 1) == '\n'.code) i--; // trailing newlines do not contribute to maxScrollV
-			var j = i;
-
 			while (i >= 0)
 			{
-				if (tempHeight + lineHeights[i] <= height - 4)
+				if (tempHeight + lineHeights[i] < height - 4)
 				{
 					tempHeight += lineHeights[i];
 					i--;
@@ -1829,13 +1825,7 @@ class TextEngine
 					break;
 			}
 
-			if (i == j) i = numLines; // maxScrollV defaults to numLines if the height - 4 is less than the line's height
-			// TODO: check if it's based on the first or last line's height
-			else
-				i += 2;
-
-			if (i < 1) return 1;
-			return i;
+			return (i + 1);
 		}
 	}
 


### PR DESCRIPTION
1. bottomScrollV: according to the Flash specs, this value is a 1-based line number, so the 0-based 'i' from the loop must be incremented by 1 to become a 1-based line number. Also '<' vs. '<=' - the first line that partially crosses the 'height - 4' boundary should be deemed bottomScrollV, that's why there should be a '<' instead of a '<='.
2. maxScrollV: this is basically just the reverse of the above algorithm. The same is applicable to the 1-based line number and the '<'. Also, there was a code that was removing a trailing line feed. Not sure what was the logic behind this, but if I had, for example, a multiline editable control with the text having a trailing line feed and the text height exceeding the text field height, I would never be able to scroll down enough to reach the line feed and edit it because of this code, which is wrong. Also, that code was removing only 1 trailing line feed, so if there were more than one trailing line feeds, only the last one would be removed, while the other one(s) would remain anyway.