### PR TITLE
Fix socket problem when debugging  cpp targets

### DIFF
--- a/src/openfl/net/Socket.hx
+++ b/src/openfl/net/Socket.hx
@@ -1087,10 +1087,19 @@ class Socket extends EventDispatcher implements IDataInput implements IDataOutpu
 			}
 			catch (e:Error)
 			{
-				if (e != Error.Blocked)
+				switch  (e)
 				{
-					doClose = true;
+					case Error.Custom(type):
+						if(type != "EOF")
+						{
+							doClose = true;
+						}
+					case Error.Blocked:
+					// ignore
+					default:
+						doClose = true;
 				}
+
 			}
 			catch (e:Dynamic)
 			{


### PR DESCRIPTION
 Fix socket problem when debugging  cpp targets, error.Custom(EOF) would cause the connection to be closed when it should have been ignored.

`NativeSocket.socket_recv(__s, buf.getData(), pos, len);` will return "EOF"  when there is no more data when you build your code for cpp/windows. This is then wrapped  and thrown as  `Error.Custom(EOF)` and so  just ignoring `haxe.io.Eof` with the `catch (e:Eof)`  block in socket.hx wont be enough to handle end of file scenarios.
```
