### PR TITLE
Fixes rendering of non-ASCII characters on Hashlink target.

### DIFF
--- a/src/openfl/_internal/text/TextLayout.hx
+++ b/src/openfl/_internal/text/TextLayout.hx
@@ -140,10 +140,12 @@ class TextLayout
 			__hbBuffer.script = script.toHBScript();
 			__hbBuffer.language = new HBLanguage(language);
 			__hbBuffer.clusterLevel = HBBufferClusterLevel.CHARACTERS;
-			#if (neko || mac || hl)
+			#if (neko || mac)
 			// other targets still uses dummy positions to make UTF8 work
 			// TODO: confirm
 			__hbBuffer.addUTF8(text, 0, -1);
+			#elseif (hl)
+			__hbBuffer.addUTF16(text, text.length, 0, -1);
 			#else
 			__hbBuffer.addUTF16(untyped __cpp__('(uintptr_t){0}', text.wc_str()), text.length, 0, -1);
 			#end


### PR DESCRIPTION
What the title says.
Haxe 4.1.0
OS Debian Sid GNU/Linux amd64
OpenFL git develop
Lime 7.7.0
Hashlink git master