### PR TITLE
Fix Std.is() deprecation warnings with Haxe 4.2

### DIFF
--- a/assets/templates/haxe/ApplicationMain.hx
+++ b/assets/templates/haxe/ApplicationMain.hx
@@ -190,7 +190,7 @@ class ApplicationMain
 					{
 						var current = stage.getChildAt (0);
 
-						if (current == null || !Std.is(current, openfl.display.DisplayObjectContainer))
+						if (current == null || !(current is openfl.display.DisplayObjectContainer))
 						{
 							current = new openfl.display.MovieClip();
 							stage.addChild(current);

--- a/externs/flash/flash/text/Font.hx
+++ b/externs/flash/flash/text/Font.hx
@@ -21,7 +21,7 @@ extern class Font extends LimeFont
 	{
 		try
 		{
-			if (Std.is(font, Class))
+			if ((font is Class))
 			{
 				__registerFont(cast font);
 			}

--- a/lib/openfl/events/UncaughtErrorEvent.hx
+++ b/lib/openfl/events/UncaughtErrorEvent.hx
@@ -88,7 +88,7 @@ extern class UncaughtErrorEvent extends ErrorEvent
 		| `text` | Text error message. |
 	**/
 	public static inline var UNCAUGHT_ERROR = "uncaughtError";
-	
+
 	/**
 		The error object associated with the uncaught error. Typically, this
 		object's data type is one of the following:
@@ -120,9 +120,9 @@ extern class UncaughtErrorEvent extends ErrorEvent
 		```haxe
 		function uncaughtErrorHandler(event:UncaughtErrorEvent):Void {
 			var message:String;
-			if (Std.is(event.error, Error)) {
+			if ((event.error is Error)) {
 				message = cast(event.error, Error).message;
-			} else if (Std.is(event.error, ErrorEvent)) {
+			} else if ((event.error is ErrorEvent)) {
 				message = cast(event.error, ErrorEvent).text;
 			} else {
 				message = Std.string(event.error);
@@ -150,7 +150,7 @@ extern class UncaughtErrorEvent extends ErrorEvent
 		all runtime versions.
 	**/
 	public var error(default, null):Dynamic;
-	
+
 	/**
 		Creates an UncaughtErrorEvent object that contains information about
 		an `uncaughtError` event.

--- a/lib/openfl/utils/Object.hx
+++ b/lib/openfl/utils/Object.hx
@@ -34,7 +34,9 @@ package openfl.utils;
 
 	public inline function propertyIsEnumerable(name:String):Bool
 	{
-		return (this != null && Reflect.hasField(this, name) && Std.is(Reflect.field(this, name), Iterable_));
+		return (this != null
+			&& Reflect.hasField(this, name)
+			&& #if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (Reflect.field(this, name), Iterable_));
 	}
 
 	public inline function toLocaleString():String

--- a/packages/application/src/openfl/Lib.hx
+++ b/packages/application/src/openfl/Lib.hx
@@ -56,7 +56,7 @@ import js.Browser;
 		#if flash
 		return flash.Lib.as(v, c);
 		#else
-		return Std.is(v, c) ? v : null;
+		return #if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (v, c) ? v : null;
 		#end
 	}
 
@@ -120,12 +120,12 @@ import js.Browser;
 	public static function getQualifiedClassName(value:Dynamic):String
 	{
 		if (value == null) return null;
-		var ref = Std.is(value, Class) ? value : Type.getClass(value);
+		var ref = (value is Class) ? value : Type.getClass(value);
 		if (ref == null)
 		{
-			if (Std.is(value, Bool) || value == Bool) return "Bool";
-			else if (Std.is(value, Int) || value == Int) return "Int";
-			else if (Std.is(value, Float) || value == Float) return "Float";
+			if ((value is Bool) || value == Bool) return "Bool";
+			else if ((value is Int) || value == Int) return "Int";
+			else if ((value is Float) || value == Float) return "Float";
 			// TODO: Array? Map?
 			else
 				return null;
@@ -136,7 +136,7 @@ import js.Browser;
 	public static function getQualifiedSuperclassName(value:Dynamic):String
 	{
 		if (value == null) return null;
-		var ref = Std.is(value, Class) ? value : Type.getClass(value);
+		var ref = (value is Class) ? value : Type.getClass(value);
 		if (ref == null) return null;
 		var parentRef = Type.getSuperClass(ref);
 		if (parentRef == null) return null;

--- a/packages/assets/src/openfl/utils/AssetLibrary.hx
+++ b/packages/assets/src/openfl/utils/AssetLibrary.hx
@@ -66,7 +66,7 @@ class AssetLibrary #if lime extends LimeAssetLibrary #end
 
 		if (library != null)
 		{
-			if (Std.is(library, AssetLibrary))
+			if ((library is AssetLibrary))
 			{
 				return cast library;
 			}

--- a/packages/assets/src/openfl/utils/Assets.hx
+++ b/packages/assets/src/openfl/utils/Assets.hx
@@ -144,7 +144,7 @@ class Assets
 
 		if (limeLibrary != null)
 		{
-			if (Std.is(limeLibrary, AssetLibrary))
+			if ((limeLibrary is AssetLibrary))
 			{
 				var library:AssetLibrary = cast limeLibrary;
 
@@ -432,7 +432,7 @@ class Assets
 
 			if (library != null)
 			{
-				if (Std.is(library, AssetLibrary))
+				if ((library is AssetLibrary))
 				{
 					_library = cast library;
 				}
@@ -505,7 +505,7 @@ class Assets
 
 		if (limeLibrary != null)
 		{
-			if (Std.is(limeLibrary, AssetLibrary))
+			if ((limeLibrary is AssetLibrary))
 			{
 				var library:AssetLibrary = cast limeLibrary;
 

--- a/packages/bitmapdata/src/openfl/display/BitmapData.hx
+++ b/packages/bitmapdata/src/openfl/display/BitmapData.hx
@@ -674,12 +674,12 @@ class BitmapData implements IBitmapDrawable
 			Matrix.__pool.release(matrix);
 		}
 
-		if (Std.is(compressor, PNGEncoderOptions))
+		if ((compressor is PNGEncoderOptions))
 		{
 			byteArray.writeBytes(ByteArray.fromBytes(image.encode(PNG)));
 			return byteArray;
 		}
-		else if (Std.is(compressor, JPEGEncoderOptions))
+		else if ((compressor is JPEGEncoderOptions))
 		{
 			byteArray.writeBytes(ByteArray.fromBytes(image.encode(JPEG, cast(compressor, JPEGEncoderOptions).quality)));
 			return byteArray;
@@ -1579,13 +1579,13 @@ class BitmapData implements IBitmapDrawable
 		if (!readable) return false;
 
 		// #if !openfljs
-		if (Std.is(secondObject, Bitmap))
+		if ((secondObject is Bitmap))
 		{
 			secondObject = cast(secondObject, Bitmap).__bitmapData;
 		}
 		// #end
 
-		if (Std.is(secondObject, Point))
+		if ((secondObject is Point))
 		{
 			var secondPoint:Point = cast secondObject;
 
@@ -1602,7 +1602,7 @@ class BitmapData implements IBitmapDrawable
 				}
 			}
 		}
-		else if (Std.is(secondObject, BitmapData))
+		else if ((secondObject is BitmapData))
 		{
 			var secondBitmapData:BitmapData = cast secondObject;
 			var x, y;
@@ -1668,7 +1668,7 @@ class BitmapData implements IBitmapDrawable
 
 			Rectangle.__pool.release(hitRect);
 		}
-		else if (Std.is(secondObject, Rectangle))
+		else if ((secondObject is Rectangle))
 		{
 			var secondRectangle = Rectangle.__pool.get();
 			secondRectangle.copyFrom(cast secondObject);

--- a/packages/displayobject/src/openfl/display/DisplayObject.hx
+++ b/packages/displayobject/src/openfl/display/DisplayObject.hx
@@ -344,13 +344,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 	public override function dispatchEvent(event:Event):Bool
 	{
-		if (Std.is(event, MouseEvent))
+		if ((event is MouseEvent))
 		{
 			var mouseEvent:MouseEvent = cast event;
 			mouseEvent.stageX = __getRenderTransform().__transformX(mouseEvent.localX, mouseEvent.localY);
 			mouseEvent.stageY = __getRenderTransform().__transformY(mouseEvent.localX, mouseEvent.localY);
 		}
-		else if (Std.is(event, TouchEvent))
+		else if ((event is TouchEvent))
 		{
 			var touchEvent:TouchEvent = cast event;
 			touchEvent.stageX = __getRenderTransform().__transformX(touchEvent.localX, touchEvent.localY);

--- a/packages/draft/src/openfl/_internal/formats/xfl/display/XFLTween.hx
+++ b/packages/draft/src/openfl/_internal/formats/xfl/display/XFLTween.hx
@@ -17,11 +17,11 @@ class XFLTween
 		{
 			return value;
 		}
-		else if (Std.is(value, String))
+		else if ((value is String))
 		{
 			return value;
 		}
-		else if (Std.is(value, Array))
+		else if ((value is Array))
 		{
 			var result:Array<Dynamic> = cast(value, Array<Dynamic>).copy();
 			for (i in 0...result.length)
@@ -78,13 +78,13 @@ class XFLTween
 		tween.object = object;
 		tween.delay = Reflect.hasField(tween, "delay") ? tween.delay : 0.0;
 		tween.duration = duration;
-		if (Std.is(object, DisplayObject) == true)
+		if ((object is DisplayObject) == true)
 		{
 			tween.initFunc = toInitDisplayObject;
 			tween.disposeFunc = toDisposeDisplayObject;
 			tween.handleFunc = tweenToImplDisplayObject;
 		}
-		else if (Std.is(object, SoundChannel) == true)
+		else if ((object is SoundChannel) == true)
 		{
 			tween.initFunc = toInitSoundChannel;
 			tween.disposeFunc = toDisposeSoundChannel;
@@ -392,7 +392,7 @@ class XFLTween
 
 	public static function killChildTweensOf(object:Dynamic):Void
 	{
-		if (Std.is(object, DisplayObjectContainer))
+		if ((object is DisplayObjectContainer))
 		{
 			var displayObjectContainer:DisplayObjectContainer = cast(object, DisplayObjectContainer);
 			for (i in 0...displayObjectContainer.numChildren)

--- a/packages/draft/src/openfl/_internal/formats/xfl/symbol/MovieClip.hx
+++ b/packages/draft/src/openfl/_internal/formats/xfl/symbol/MovieClip.hx
@@ -132,11 +132,11 @@ class MovieClip extends openfl._internal.formats.xfl.display.MovieClip
 
 	private function getFrame(frame:Dynamic):Int
 	{
-		if (Std.is(frame, Int))
+		if ((frame is Int))
 		{
 			return cast frame;
 		}
-		else if (Std.is(frame, String))
+		else if ((frame is String))
 		{
 			for (label in currentLabels)
 			{

--- a/packages/draft/src/openfl/_internal/formats/xfl/symbol/ShapeBase.hx
+++ b/packages/draft/src/openfl/_internal/formats/xfl/symbol/ShapeBase.hx
@@ -110,7 +110,7 @@ class ShapeBase extends openfl.display.Shape
 		});
 		for (fillStyle in domShape.fills)
 		{
-			if (Std.is(fillStyle.data, SolidColor))
+			if ((fillStyle.data is SolidColor))
 			{
 				var color = fillStyle.data.color;
 				var alpha = fillStyle.data.alpha;
@@ -119,7 +119,7 @@ class ShapeBase extends openfl.display.Shape
 					g.beginFill(color, alpha);
 				});
 			}
-			else if (Std.is(fillStyle.data, LinearGradient))
+			else if ((fillStyle.data is LinearGradient))
 			{
 				var data:LinearGradient = cast fillStyle.data;
 				var colors:Array<UInt> = [];
@@ -136,7 +136,7 @@ class ShapeBase extends openfl.display.Shape
 					g.beginGradientFill(GradientType.LINEAR, colors, alphas, ratios, data.matrix);
 				});
 			}
-			else if (Std.is(fillStyle.data, RadialGradient))
+			else if ((fillStyle.data is RadialGradient))
 			{
 				#if !html5
 				var data:RadialGradient = cast fillStyle.data;
@@ -155,7 +155,7 @@ class ShapeBase extends openfl.display.Shape
 				});
 				#end
 			}
-			else if (Std.is(fillStyle.data, Bitmap))
+			else if ((fillStyle.data is Bitmap))
 			{
 				var bitmapData = XFLAssets.getInstance().getXFLBitmapDataAssetByPath(fillStyle.data.bitmapPath);
 				var matrix = fillStyle.data.matrix;
@@ -177,9 +177,9 @@ class ShapeBase extends openfl.display.Shape
 		});
 		for (strokeStyle in domShape.strokes)
 		{
-			if (Std.is(strokeStyle.data, SolidStroke))
+			if ((strokeStyle.data is SolidStroke))
 			{
-				if (Std.is(strokeStyle.data.fill, SolidColor))
+				if ((strokeStyle.data.fill is SolidColor))
 				{
 					var weight = strokeStyle.data.weight;
 					var color = strokeStyle.data.fill.color;

--- a/packages/draft/src/openfl/_internal/formats/xfl/symbol/Shared.hx
+++ b/packages/draft/src/openfl/_internal/formats/xfl/symbol/Shared.hx
@@ -83,7 +83,7 @@ class Shared
 			}
 			for (i in 0...container.numChildren) {
 				var child = container.getChildAt (0);
-				if (Std.is(child, MovieClip)) {
+				if ((child is MovieClip)) {
 					untyped child.stop ();
 				}
 				container.removeChildAt(0);
@@ -120,7 +120,7 @@ class Shared
 				var frameAnonymousObjectId:Int = 0;
 				for (element in frame.elements)
 				{
-					if (Std.is(element, DOMSymbolInstance))
+					if ((element is DOMSymbolInstance))
 					{
 						var symbol:DisplayObject = element.name != null ? container.getChildByName(element.name) : null;
 						if (symbol != null)
@@ -137,7 +137,7 @@ class Shared
 							maskDisplayObjects[layer.index].push(symbol);
 						}
 					}
-					else if (Std.is(element, DOMBitmapInstance))
+					else if ((element is DOMBitmapInstance))
 					{
 						var bitmap:Bitmap = Symbols.createBitmap(xfl, cast element);
 						if (bitmap != null)
@@ -149,7 +149,7 @@ class Shared
 							maskDisplayObjects[layer.index].push(bitmap);
 						}
 					}
-					else if (Std.is(element, DOMComponentInstance))
+					else if ((element is DOMComponentInstance))
 					{
 						var name:String = cast(element, DOMComponentInstance).name;
 						var component:DisplayObject = name != null ? container.getChildByName(name) : null;
@@ -168,7 +168,7 @@ class Shared
 							maskDisplayObjects[layer.index].push(component);
 						}
 					}
-					else if (Std.is(element, DOMShape))
+					else if ((element is DOMShape))
 					{
 						var shape:Shape = Symbols.createShape(xfl, cast element);
 						shape.name = "xfl_anonymous_" + currentLayer + "_" + frame.index + "_" + (frameAnonymousObjectId++);
@@ -177,7 +177,7 @@ class Shared
 						children.push(shape);
 						maskDisplayObjects[layer.index].push(shape);
 					}
-					else if (Std.is(element, DOMRectangle))
+					else if ((element is DOMRectangle))
 					{
 						var rectangle:Rectangle = Symbols.createRectangle(xfl, cast element);
 						rectangle.name = "xfl_anonymous_" + currentLayer + "_" + frame.index + "_" + (frameAnonymousObjectId++);
@@ -186,7 +186,7 @@ class Shared
 						children.push(rectangle);
 						maskDisplayObjects[layer.index].push(rectangle);
 					}
-					else if (Std.is(element, DOMDynamicText))
+					else if ((element is DOMDynamicText))
 					{
 						var text:DisplayObject = element.name != null ? container.getChildByName(element.name) : null;
 						if (text != null)
@@ -203,7 +203,7 @@ class Shared
 							maskDisplayObjects[layer.index].push(text);
 						}
 					}
-					else if (Std.is(element, DOMStaticText))
+					else if ((element is DOMStaticText))
 					{
 						var text:DisplayObject = Symbols.createStaticText(cast element);
 						if (text != null)
@@ -259,7 +259,7 @@ class Shared
 				var frameAnonymousObjectId:Int = 0;
 				for (element in frame.elements)
 				{
-					if (Std.is(element, DOMSymbolInstance))
+					if ((element is DOMSymbolInstance))
 					{
 						var symbol:DisplayObject = element.name != null ? container.getChildByName(element.name) : null;
 						if (symbol != null)
@@ -284,7 +284,7 @@ class Shared
 							children.push(symbol);
 						}
 					}
-					else if (Std.is(element, DOMBitmapInstance))
+					else if ((element is DOMBitmapInstance))
 					{
 						var bitmap:Bitmap = Symbols.createBitmap(xfl, cast element);
 						if (bitmap != null)
@@ -304,7 +304,7 @@ class Shared
 							children.push(bitmap);
 						}
 					}
-					else if (Std.is(element, DOMComponentInstance))
+					else if ((element is DOMComponentInstance))
 					{
 						var name:String = cast(element, DOMComponentInstance).name;
 						var component:DisplayObject = name != null ? container.getChildByName(name) : null;
@@ -331,7 +331,7 @@ class Shared
 							children.push(component);
 						}
 					}
-					else if (Std.is(element, DOMShape))
+					else if ((element is DOMShape))
 					{
 						var shape:Shape = Symbols.createShape(xfl, cast element);
 						if (containerMask == false && layer.parentLayerIndex != -1 && maskDisplayObjects[layer.parentLayerIndex] != null)
@@ -346,7 +346,7 @@ class Shared
 						container.addChild(shape);
 						children.push(shape);
 					}
-					else if (Std.is(element, DOMRectangle))
+					else if ((element is DOMRectangle))
 					{
 						var rectangle:Rectangle = Symbols.createRectangle(xfl, cast element);
 						if (containerMask == false && layer.parentLayerIndex != -1 && maskDisplayObjects[layer.parentLayerIndex] != null)
@@ -361,7 +361,7 @@ class Shared
 						container.addChild(rectangle);
 						children.push(rectangle);
 					}
-					else if (Std.is(element, DOMDynamicText))
+					else if ((element is DOMDynamicText))
 					{
 						var text:DisplayObject = element.name != null ? container.getChildByName(element.name) : null;
 						if (text != null)
@@ -386,7 +386,7 @@ class Shared
 							children.push(text);
 						}
 					}
-					else if (Std.is(element, DOMStaticText))
+					else if ((element is DOMStaticText))
 					{
 						var text = Symbols.createStaticText(cast element);
 						if (text != null)
@@ -437,7 +437,7 @@ class Shared
 				{
 					for (element in frame.elements)
 					{
-						if (Std.is(element, DOMSymbolInstance))
+						if ((element is DOMSymbolInstance))
 						{
 							var movieClip:DisplayObject = element.name != null ? container.getChildByName(element.name) : null;
 							if (movieClip != null)
@@ -451,7 +451,7 @@ class Shared
 								processedObjects.push(movieClip);
 							}
 						}
-						else if (Std.is(element, DOMBitmapInstance))
+						else if ((element is DOMBitmapInstance))
 						{
 							var bitmap:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -466,7 +466,7 @@ class Shared
 								processedObjects.push(bitmap);
 							}
 						}
-						else if (Std.is(element, DOMComponentInstance))
+						else if ((element is DOMComponentInstance))
 						{
 							var component:DisplayObject = element.name != null ? container.getChildByName(element.name) : null;
 							if (component != null)
@@ -480,7 +480,7 @@ class Shared
 								processedObjects.push(component);
 							}
 						}
-						else if (Std.is(element, DOMShape))
+						else if ((element is DOMShape))
 						{
 							var shape:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -495,7 +495,7 @@ class Shared
 								processedObjects.push(shape);
 							}
 						}
-						else if (Std.is(element, DOMRectangle))
+						else if ((element is DOMRectangle))
 						{
 							var rectangle:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -510,7 +510,7 @@ class Shared
 								processedObjects.push(rectangle);
 							}
 						}
-						else if (Std.is(element, DOMDynamicText))
+						else if ((element is DOMDynamicText))
 						{
 							var text:DisplayObject = element.name != null ? container.getChildByName(element.name) : null;
 							if (text != null)
@@ -524,7 +524,7 @@ class Shared
 								processedObjects.push(text);
 							}
 						}
-						else if (Std.is(element, DOMStaticText))
+						else if ((element is DOMStaticText))
 						{
 							var text:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -571,7 +571,7 @@ class Shared
 				{
 					for (element in frame.elements)
 					{
-						if (Std.is(element, DOMSymbolInstance))
+						if ((element is DOMSymbolInstance))
 						{
 							var movieClip:DisplayObject = container.getChildByName(cast(element, DOMSymbolInstance).name);
 							if (movieClip != null)
@@ -579,7 +579,7 @@ class Shared
 								movieClip.visible = invisibleObjects == null || invisibleObjects.indexOf(movieClip) == -1;
 							}
 						}
-						else if (Std.is(element, DOMBitmapInstance))
+						else if ((element is DOMBitmapInstance))
 						{
 							var bitmap:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -588,7 +588,7 @@ class Shared
 								bitmap.visible = invisibleObjects == null || invisibleObjects.indexOf(bitmap) == -1;
 							}
 						}
-						else if (Std.is(element, DOMComponentInstance))
+						else if ((element is DOMComponentInstance))
 						{
 							var component:DisplayObject = container.getChildByName(cast(element, DOMComponentInstance).name);
 							if (component != null)
@@ -596,7 +596,7 @@ class Shared
 								component.visible = invisibleObjects == null || invisibleObjects.indexOf(component) == -1;
 							}
 						}
-						else if (Std.is(element, DOMShape))
+						else if ((element is DOMShape))
 						{
 							var shape:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -605,7 +605,7 @@ class Shared
 								shape.visible = invisibleObjects == null || invisibleObjects.indexOf(shape) == -1;
 							}
 						}
-						else if (Std.is(element, DOMRectangle))
+						else if ((element is DOMRectangle))
 						{
 							var rectangle:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -614,7 +614,7 @@ class Shared
 								rectangle.visible = invisibleObjects == null || invisibleObjects.indexOf(rectangle) == -1;
 							}
 						}
-						else if (Std.is(element, DOMDynamicText))
+						else if ((element is DOMDynamicText))
 						{
 							var text:DisplayObject = container.getChildByName(cast(element, DOMDynamicText).name);
 							if (text != null)
@@ -622,7 +622,7 @@ class Shared
 								text.visible = invisibleObjects == null || invisibleObjects.indexOf(text) == -1;
 							}
 						}
-						else if (Std.is(element, DOMStaticText))
+						else if ((element is DOMStaticText))
 						{
 							var text:DisplayObject = container.getChildByName("xfl_anonymous_" + currentLayer + "_" + frame.index + "_"
 								+ (frameAnonymousObjectId++));
@@ -647,11 +647,11 @@ class Shared
 		while (parent.numChildren > 0)
 		{
 			var child:DisplayObject = parent.getChildAt(0);
-			if (Std.is(child, MovieClip))
+			if ((child is MovieClip))
 			{
 				cast(child, MovieClip).stop();
 			}
-			else if (Std.is(child, XFLMovieClip))
+			else if ((child is XFLMovieClip))
 			{
 				cast(child, XFLMovieClip).stop();
 			}

--- a/packages/draft/src/openfl/_internal/formats/xfl/symbol/Symbols.hx
+++ b/packages/draft/src/openfl/_internal/formats/xfl/symbol/Symbols.hx
@@ -464,7 +464,7 @@ class Symbols
 				component.transform.matrix = matrix;
 			}
 		}
-		if (Std.is(component, DisplayObjectContainer) == true)
+		if ((component is DisplayObjectContainer) == true)
 		{
 			var container:DisplayObjectContainer = cast(component, DisplayObjectContainer);
 			var containerWidth:Float = container.width;
@@ -475,13 +475,13 @@ class Symbols
 			container.scaleY = 1.0;
 			var parametersAreBlocked:Bool = false;
 			var children:Array<DisplayObject> = null;
-			if (Std.is(component, XFLSprite) == true)
+			if ((component is XFLSprite) == true)
 			{
 				var xflSprite:XFLSprite = cast(component, XFLSprite);
 				children = xflSprite.children;
 				parametersAreBlocked = xflSprite.xflSymbolArguments.parametersAreLocked;
 			}
-			else if (Std.is(component, XFLMovieClip) == true)
+			else if ((component is XFLMovieClip) == true)
 			{
 				var xflMovieClip:XFLMovieClip = cast(component, XFLMovieClip);
 				children = xflMovieClip.children;
@@ -505,7 +505,7 @@ class Symbols
 					child.height = child.height * containerScaleY;
 				}
 			}
-			if (Std.is(component, UIComponent) == true)
+			if ((component is UIComponent) == true)
 			{
 				cast(component, UIComponent).setSize(containerWidth * containerScaleX, containerHeight * containerScaleY);
 			}

--- a/packages/draft/src/openfl/fl/containers/BaseScrollPane.hx
+++ b/packages/draft/src/openfl/fl/containers/BaseScrollPane.hx
@@ -157,7 +157,7 @@ class BaseScrollPane extends UIComponent
 			if (_scrollBar.visible == true && getChildAt(numChildren - 1) != _scrollBar) {
 				addChildAt(_scrollBar, numChildren - 1);
 			}
-			if (_source != null && Std.is(_source, DisplayObjectContainer) == true) {
+			if (_source != null && (_source is DisplayObjectContainer) == true) {
 				var container: DisplayObjectContainer = cast(_source, DisplayObjectContainer);
 				for (i in 0...container.numChildren - 1) {
 					var child: DisplayObject = container.getChildAt(i);
@@ -173,7 +173,7 @@ class BaseScrollPane extends UIComponent
 		{
 			addChildAt(_scrollBar, numChildren - 1);
 		}
-		if (_source != null && Std.is(_source, DisplayObjectContainer) == true)
+		if (_source != null && (_source is DisplayObjectContainer) == true)
 		{
 			var container:DisplayObjectContainer = cast(_source, DisplayObjectContainer);
 			for (i in 0...container.numChildren - 1)

--- a/packages/draft/src/openfl/fl/controls/DataGrid.hx
+++ b/packages/draft/src/openfl/fl/controls/DataGrid.hx
@@ -206,7 +206,7 @@ class DataGrid extends BaseScrollPane
 				for (j in 0...columns.length)
 				{
 					var cell:DisplayObject = displayObjects[i].getChildAt(j);
-					if (Std.is(cell, HeaderRenderer))
+					if ((cell is HeaderRenderer))
 					{
 						cast(cell, HeaderRenderer).init();
 						cast(cell, HeaderRenderer).validateNow();
@@ -223,7 +223,7 @@ class DataGrid extends BaseScrollPane
 				for (j in 0...columns.length)
 				{
 					var cell:DisplayObject = displayObjects[i].getChildAt(j);
-					if (Std.is(cell, HeaderRenderer))
+					if ((cell is HeaderRenderer))
 					{
 						cast(cell, HeaderRenderer).setSize(columns[j].width, cellHeight);
 					}
@@ -311,7 +311,7 @@ class DataGrid extends BaseScrollPane
 
 	private function onMouseEvent(event:MouseEvent):Void
 	{
-		if (Std.is(event.target, HeaderRenderer) == true)
+		if ((event.target is HeaderRenderer) == true)
 		{
 			var mouseHeaderRenderer:HeaderRenderer = cast(event.target, HeaderRenderer);
 			for (columnIdx in 0...columns.length)
@@ -341,7 +341,7 @@ class DataGrid extends BaseScrollPane
 
 		// find mouse cell renderer down up the hierarchy
 		var mouseCellRendererCandidate:DisplayObject = event.target;
-		while (mouseCellRendererCandidate != null && Std.is(mouseCellRendererCandidate, CellRenderer) == false)
+		while (mouseCellRendererCandidate != null && (mouseCellRendererCandidate is CellRenderer) == false)
 			mouseCellRendererCandidate = mouseCellRendererCandidate.parent;
 		var mouseCellRenderer:CellRenderer = mouseCellRendererCandidate != null ? cast(mouseCellRendererCandidate, CellRenderer) : null;
 		if (mouseCellRenderer != null)
@@ -361,7 +361,7 @@ class DataGrid extends BaseScrollPane
 
 	private function onMouseEventClick(event:MouseEvent):Void
 	{
-		if (Std.is(cast(event.target, DisplayObject), CellRenderer) == true)
+		if ((cast(event.target, DisplayObject) is CellRenderer) == true)
 		{
 			var cell:CellRenderer = cast(event.target, CellRenderer);
 			var listData:ListData = cell.listData;

--- a/packages/draft/src/openfl/fl/core/UIComponent.hx
+++ b/packages/draft/src/openfl/fl/core/UIComponent.hx
@@ -170,7 +170,7 @@ class UIComponent extends XFLSprite
 
 	public function setStyle(style:String, value:Dynamic):Void
 	{
-		if (Std.is(value, DisplayObject) == true && cast(value, DisplayObject).parent != null)
+		if ((value is DisplayObject) == true && cast(value, DisplayObject).parent != null)
 		{
 			cast(value, DisplayObject).parent.removeChild(value);
 		}

--- a/packages/eventdispatcher/src/openfl/events/Event.hx
+++ b/packages/eventdispatcher/src/openfl/events/Event.hx
@@ -134,7 +134,7 @@ class Event
 		{
 			arg = Reflect.field(this, param);
 
-			if (Std.is(arg, String))
+			if ((arg is String))
 			{
 				output += ' $param="$arg"';
 			}

--- a/packages/filereference/src/openfl/net/FileReference.hx
+++ b/packages/filereference/src/openfl/net/FileReference.hx
@@ -168,7 +168,7 @@ class FileReference extends EventDispatcher
 		if (data == null) return;
 
 		#if desktop
-		if (Std.is(data, ByteArrayData))
+		if ((data is ByteArrayData))
 		{
 			__data = data;
 		}
@@ -183,7 +183,7 @@ class FileReference extends EventDispatcher
 		saveFileDialog.onSelect.add(saveFileDialog_onSelect);
 		saveFileDialog.browse(SAVE, defaultFileName != null ? Path.extension(defaultFileName) : null, defaultFileName);
 		#elseif (js && html5)
-		if (Std.is(data, ByteArrayData))
+		if ((data is ByteArrayData))
 		{
 			__data = data;
 		}
@@ -271,7 +271,7 @@ class FileReference extends EventDispatcher
 	@:noCompletion private function urlLoader_onComplete(event:Event):Void
 	{
 		#if desktop
-		if (Std.is(__urlLoader.data, ByteArrayData))
+		if ((__urlLoader.data is ByteArrayData))
 		{
 			__data = __urlLoader.data;
 		}

--- a/packages/geom/test/RectangleTest.hx
+++ b/packages/geom/test/RectangleTest.hx
@@ -27,7 +27,7 @@ class RectangleTest
 				var rect = new Rectangle(0, 0, 100, 100);
 
 				Assert.notEqual(rect.bottomRight, null);
-				Assert.assert(Std.is(rect.bottomRight, openfl.geom.Point));
+				Assert.assert((rect.bottomRight is openfl.geom.Point));
 
 				Assert.equal(rect.bottomRight.x, 100);
 				Assert.equal(rect.bottomRight.y, 100);
@@ -93,7 +93,7 @@ class RectangleTest
 				var rect = new Rectangle(0, 0, 100, 100);
 
 				Assert.notEqual(rect.size, null);
-				Assert.assert(Std.is(rect.size, openfl.geom.Point));
+				Assert.assert((rect.size is openfl.geom.Point));
 
 				Assert.equal(rect.size.x, 100);
 				Assert.equal(rect.size.y, 100);
@@ -129,7 +129,7 @@ class RectangleTest
 				var rect = new Rectangle(0, 0, 100, 100);
 
 				Assert.notEqual(rect.topLeft, null);
-				Assert.assert(Std.is(rect.topLeft, openfl.geom.Point));
+				Assert.assert((rect.topLeft is openfl.geom.Point));
 
 				Assert.equal(rect.topLeft.x, 0);
 				Assert.equal(rect.topLeft.y, 0);

--- a/packages/loader/src/openfl/display/Loader.hx
+++ b/packages/loader/src/openfl/display/Loader.hx
@@ -314,7 +314,7 @@ class Loader extends DisplayObjectContainer
 				return;
 			}
 
-			if (Std.is(library, AssetLibrary))
+			if ((library is AssetLibrary))
 			{
 				library.load().onComplete(function(_)
 				{

--- a/packages/movieclip/src/openfl/display/Timeline.hx
+++ b/packages/movieclip/src/openfl/display/Timeline.hx
@@ -259,11 +259,11 @@ class Timeline
 
 	@:noCompletion private function __resolveFrameReference(frame:#if (haxe_ver >= "3.4.2") Any #else Dynamic #end):Int
 	{
-		if (Std.is(frame, Int))
+		if ((frame is Int))
 		{
 			return cast frame;
 		}
-		else if (Std.is(frame, String))
+		else if ((frame is String))
 		{
 			var label:String = cast frame;
 

--- a/packages/renderer-flash/src/openfl/display/_internal/FlashGraphics.hx
+++ b/packages/renderer-flash/src/openfl/display/_internal/FlashGraphics.hx
@@ -33,7 +33,7 @@ class FlashGraphics
 		{
 			for (data in graphicsData)
 			{
-				if (Std.is(data, GraphicsQuadPath))
+				if ((data is GraphicsQuadPath))
 				{
 					hasQuadPath = true;
 					break;
@@ -54,28 +54,28 @@ class FlashGraphics
 
 			for (data in graphicsData)
 			{
-				if (Std.is(data, GraphicsSolidFill))
+				if ((data is GraphicsSolidFill))
 				{
 					fill = cast data;
 					graphics.beginFill(fill.color, fill.alpha);
 				}
-				else if (Std.is(data, GraphicsBitmapFill))
+				else if ((data is GraphicsBitmapFill))
 				{
 					bitmapFill = cast data;
 					graphics.beginBitmapFill(bitmapFill.bitmapData, bitmapFill.matrix, bitmapFill.repeat, bitmapFill.smooth);
 				}
-				else if (Std.is(data, GraphicsGradientFill))
+				else if ((data is GraphicsGradientFill))
 				{
 					gradientFill = cast data;
 					graphics.beginGradientFill(gradientFill.type, cast gradientFill.colors, cast gradientFill.alphas, cast gradientFill.ratios,
 						gradientFill.matrix, gradientFill.spreadMethod, gradientFill.interpolationMethod, gradientFill.focalPointRatio);
 				}
-				else if (Std.is(data, GraphicsShaderFill))
+				else if ((data is GraphicsShaderFill))
 				{
 					shaderFill = cast data;
 					graphics.beginShaderFill(shaderFill.shader, shaderFill.matrix);
 				}
-				else if (Std.is(data, GraphicsStroke))
+				else if ((data is GraphicsStroke))
 				{
 					stroke = cast data;
 
@@ -88,26 +88,26 @@ class FlashGraphics
 							thickness = null;
 						}
 
-						if (Std.is(stroke.fill, GraphicsSolidFill))
+						if ((stroke.fill is GraphicsSolidFill))
 						{
 							fill = cast stroke.fill;
 							graphics.lineStyle(thickness, fill.color, fill.alpha, stroke.pixelHinting, stroke.scaleMode, stroke.caps, stroke.joints,
 								stroke.miterLimit);
 						}
-						else if (Std.is(stroke.fill, GraphicsBitmapFill))
+						else if ((stroke.fill is GraphicsBitmapFill))
 						{
 							bitmapFill = cast stroke.fill;
 							graphics.lineStyle(thickness, 0, 1, stroke.pixelHinting, stroke.scaleMode, stroke.caps, stroke.joints, stroke.miterLimit);
 							graphics.lineBitmapStyle(bitmapFill.bitmapData, bitmapFill.matrix, bitmapFill.repeat, bitmapFill.smooth);
 						}
-						else if (Std.is(stroke.fill, GraphicsGradientFill))
+						else if ((stroke.fill is GraphicsGradientFill))
 						{
 							gradientFill = cast stroke.fill;
 							graphics.lineStyle(thickness, 0, 1, stroke.pixelHinting, stroke.scaleMode, stroke.caps, stroke.joints, stroke.miterLimit);
 							graphics.lineGradientStyle(gradientFill.type, cast gradientFill.colors, cast gradientFill.alphas, cast gradientFill.ratios,
 								gradientFill.matrix, gradientFill.spreadMethod, gradientFill.interpolationMethod, gradientFill.focalPointRatio);
 						}
-						else if (Std.is(stroke.fill, GraphicsShaderFill))
+						else if ((stroke.fill is GraphicsShaderFill))
 						{
 							shaderFill = cast stroke.fill;
 							graphics.lineStyle(thickness, 0, 1, stroke.pixelHinting, stroke.scaleMode, stroke.caps, stroke.joints, stroke.miterLimit);
@@ -119,21 +119,21 @@ class FlashGraphics
 						graphics.lineStyle();
 					}
 				}
-				else if (Std.is(data, GraphicsPath))
+				else if ((data is GraphicsPath))
 				{
 					path = cast data;
 					graphics.drawPath(path.commands, path.data, path.winding);
 				}
-				else if (Std.is(data, GraphicsTrianglePath))
+				else if ((data is GraphicsTrianglePath))
 				{
 					trianglePath = cast data;
 					graphics.drawTriangles(trianglePath.vertices, trianglePath.indices, trianglePath.uvtData, trianglePath.culling);
 				}
-				else if (Std.is(data, GraphicsEndFill))
+				else if ((data is GraphicsEndFill))
 				{
 					graphics.endFill();
 				}
-				else if (Std.is(data, GraphicsQuadPath))
+				else if ((data is GraphicsQuadPath))
 				{
 					quadPath = cast data;
 					graphics.drawQuads(quadPath.rects, quadPath.indices, quadPath.transforms);

--- a/packages/socket/src/openfl/net/Socket.hx
+++ b/packages/socket/src/openfl/net/Socket.hx
@@ -1009,7 +1009,7 @@ class Socket extends EventDispatcher implements IDataInput implements IDataOutpu
 			__input.clear();
 		}
 
-		if (Std.is(msg.data, String))
+		if ((msg.data is String))
 		{
 			__input.position = __input.length;
 			var cachePosition = __input.position;

--- a/packages/stage/src/openfl/display/Stage.hx
+++ b/packages/stage/src/openfl/display/Stage.hx
@@ -1479,7 +1479,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			var keyCode = Keyboard.__convertKeyCode(keyCode);
 			var charCode = Keyboard.__getCharCode(keyCode, modifier.shiftKey);
 
-			if (type == KeyboardEvent.KEY_UP && (keyCode == Keyboard.SPACE || keyCode == Keyboard.ENTER) && Std.is(__focus, Sprite))
+			if (type == KeyboardEvent.KEY_UP && (keyCode == Keyboard.SPACE || keyCode == Keyboard.ENTER) && (__focus is Sprite))
 			{
 				var sprite = cast(__focus, Sprite);
 				if (sprite.buttonMode && sprite.focusRect == true)
@@ -1584,7 +1584,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 									while (modifier.shiftKey ? (i >= 0) : (i < currentParent.numChildren))
 									{
 										var sibling = currentParent.getChildAt(i);
-										if (Std.is(sibling, InteractiveObject))
+										if ((sibling is InteractiveObject))
 										{
 											var interactiveSibling = cast(sibling, InteractiveObject);
 											index = tabStack.indexOf(interactiveSibling);

--- a/packages/stage3d/src/openfl/display3D/Context3D.hx
+++ b/packages/stage3d/src/openfl/display3D/Context3D.hx
@@ -2399,19 +2399,19 @@ import lime.math.Vector2;
 			var width = 0, height = 0;
 
 			// TODO: Avoid use of Std.is
-			if (Std.is(__state.renderToTexture, Texture))
+			if ((__state.renderToTexture is Texture))
 			{
 				var texture2D:Texture = cast __state.renderToTexture;
 				width = texture2D.__width;
 				height = texture2D.__height;
 			}
-			else if (Std.is(__state.renderToTexture, RectangleTexture))
+			else if ((__state.renderToTexture is RectangleTexture))
 			{
 				var rectTexture:RectangleTexture = cast __state.renderToTexture;
 				width = rectTexture.__width;
 				height = rectTexture.__height;
 			}
-			else if (Std.is(__state.renderToTexture, CubeTexture))
+			else if ((__state.renderToTexture is CubeTexture))
 			{
 				var cubeTexture:CubeTexture = cast __state.renderToTexture;
 				width = cubeTexture.__size;

--- a/packages/textfield/src/openfl/text/StaticText.hx
+++ b/packages/textfield/src/openfl/text/StaticText.hx
@@ -17,7 +17,7 @@ import openfl.display.Graphics;
 	```haxe
 	for (i in 0...numChildren) {
 		var displayitem = getChildAt(i);
-		if (Std.is(displayitem, StaticText)) {
+		if ((displayitem is StaticText)) {
 			trace("a static text field is item " + i + " on the display list");
 			var myFieldLabel:StaticText = cast displayitem;
 			trace("and contains the text: " + myFieldLabel.text);

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -3113,7 +3113,7 @@ class TextField extends InteractiveObject
 
 		// TODO: Better system
 
-		if (event.relatedObject == null || !Std.is(event.relatedObject, TextField))
+		if (event.relatedObject == null || !(event.relatedObject is TextField))
 		{
 			__stopTextInput();
 		}

--- a/packages/textfield/test/TextFieldTest.hx
+++ b/packages/textfield/test/TextFieldTest.hx
@@ -158,7 +158,7 @@ class TextFieldTest
 				bitmapData2.draw(textField2);
 				bitmapData3.draw(textField3);
 
-				Assert.assert(Std.is(bitmapData2.compare(bitmapData), BitmapData));
+				Assert.assert((bitmapData2.compare(bitmapData) is BitmapData));
 				Assert.equal(bitmapData2.compare(bitmapData3), 0);
 			});
 

--- a/packages/tilemap/src/openfl/display/Tile.hx
+++ b/packages/tilemap/src/openfl/display/Tile.hx
@@ -214,8 +214,10 @@ class Tile
 	@:noCompletion private static function __init__()
 	{
 		untyped Object.defineProperties(Tile.prototype, {
-			"alpha": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_alpha (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_alpha (v); }")},
+			"alpha": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_alpha (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_alpha (v); }")
+			},
 			"blendMode": {
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_blendMode (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_blendMode (v); }")
@@ -224,10 +226,14 @@ class Tile
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_colorTransform (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_colorTransform (v); }")
 			},
-			"id": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_id (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_id (v); }")},
-			"matrix": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_matrix (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_matrix (v); }")},
+			"id": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_id (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_id (v); }")
+			},
+			"matrix": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_matrix (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_matrix (v); }")
+			},
 			"originX": {
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_originX (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_originX (v); }")
@@ -236,18 +242,26 @@ class Tile
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_originY (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_originY (v); }")
 			},
-			"rect": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_rect (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_rect (v); }")},
+			"rect": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_rect (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_rect (v); }")
+			},
 			"rotation": {
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_rotation (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_rotation (v); }")
 			},
-			"scaleX": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_scaleX (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_scaleX (v); }")},
-			"scaleY": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_scaleY (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_scaleY (v); }")},
-			"shader": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_shader (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_shader (v); }")},
+			"scaleX": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_scaleX (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_scaleX (v); }")
+			},
+			"scaleY": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_scaleY (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_scaleY (v); }")
+			},
+			"shader": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_shader (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_shader (v); }")
+			},
 			"tileset": {
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_tileset (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_tileset (v); }")
@@ -256,10 +270,14 @@ class Tile
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_visible (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_visible (v); }")
 			},
-			"x": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_x (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_x (v); }")},
-			"y": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_y (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_y (v); }")},
+			"x": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_x (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_x (v); }")
+			},
+			"y": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_y (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_y (v); }")
+			},
 		});
 	}
 	#end
@@ -480,7 +498,7 @@ class Tile
 		// TODO: Avoid Std.is
 
 		if (tileset != null) return tileset;
-		if (Std.is(parent, Tilemap)) return parent.tileset;
+		if ((parent is Tilemap)) return parent.tileset;
 		if (parent == null) return null;
 		return parent.__findTileset();
 	}

--- a/packages/urlloader/src/openfl/net/URLLoader.hx
+++ b/packages/urlloader/src/openfl/net/URLLoader.hx
@@ -361,7 +361,7 @@ class URLLoader extends EventDispatcher
 					__httpRequest.formData.set(field, Reflect.field(request.data, field));
 				}
 			}
-			else if (Std.is(request.data, Bytes))
+			else if ((request.data is Bytes))
 			{
 				__httpRequest.data = request.data;
 			}

--- a/packages/urlrequest/src/openfl/net/URLVariables.hx
+++ b/packages/urlrequest/src/openfl/net/URLVariables.hx
@@ -85,13 +85,16 @@ abstract URLVariables(Dynamic) from Dynamic to Dynamic
 		for (f in fields)
 		{
 			var value:Dynamic = Reflect.field(this, f);
-			if (f.indexOf("[]") > -1 && Std.is(value, Array)) {
-				var arrayValue:String = Lambda.map(value, function(v:String) {
+			if (f.indexOf("[]") > -1 && (value is Array))
+			{
+				var arrayValue:String = Lambda.map(value, function(v:String)
+				{
 					return StringTools.urlEncode(v);
 				}).join('&amp;${f}=');
 				result.push(StringTools.urlEncode(f) + "=" + arrayValue);
 			}
-			else {
+			else
+			{
 				result.push(StringTools.urlEncode(f) + "=" + StringTools.urlEncode(value));
 			}
 		}

--- a/packages/utils/src/openfl/utils/ByteArray.hx
+++ b/packages/utils/src/openfl/utils/ByteArray.hx
@@ -313,7 +313,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		#if display
 		return null;
 		#else
-		if (Std.is(bytes, ByteArrayData))
+		if ((bytes is ByteArrayData))
 		{
 			return cast bytes;
 		}

--- a/packages/utils/src/openfl/utils/Object.hx
+++ b/packages/utils/src/openfl/utils/Object.hx
@@ -35,7 +35,9 @@ package openfl.utils;
 
 	public inline function propertyIsEnumerable(name:String):Bool
 	{
-		return (this != null && Reflect.hasField(this, name) && Std.is(Reflect.field(this, name), Iterable_));
+		return (this != null
+			&& Reflect.hasField(this, name)
+			&& #if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (Reflect.field(this, name), Iterable_));
 	}
 
 	public inline function toLocaleString():String

--- a/packages/video/src/openfl/net/NetStream.hx
+++ b/packages/video/src/openfl/net/NetStream.hx
@@ -1620,7 +1620,7 @@ class NetStream extends EventDispatcher
 		if (__video == null) return;
 
 		__video.volume = SoundMixer.__soundTransform.volume * __soundTransform.volume;
-		if (Std.is(url, String))
+		if ((url is String))
 		{
 			__video.src = url;
 		}

--- a/test/haxelib/integration/src/text/TextFieldRenderTest.hx
+++ b/test/haxelib/integration/src/text/TextFieldRenderTest.hx
@@ -89,7 +89,7 @@ class TextFieldRenderTest
 		bitmapData2.draw(textField2);
 		bitmapData3.draw(textField3);
 
-		Assert.isTrue(Std.is(bitmapData2.compare(bitmapData), BitmapData));
+		Assert.isTrue((bitmapData2.compare(bitmapData) is BitmapData));
 		Assert.areEqual(0, bitmapData2.compare(bitmapData3));
 	}
 


### PR DESCRIPTION
`Std.is()` has been deprecated in Haxe 4.2: https://github.com/HaxeFoundation/haxe/commit/8ef3be1ae80fe4361572100fe7988518bc59c9ed

Rather than using `Std.isOfType()`, it's cleaner to use the `is` syntax with mandatory parens if possible* - it's already available since Haxe 3.4, so it doesn't require conditional compilation (afaik that's the oldest version still supported by OpenFL anyway).

<sup>*possible whenever the RHS is a type rather than an expression</sup>