### PR TITLE
Use lighter weight Shape instead of Sprite for DefaultPreloader parts

### DIFF
--- a/packages/application/src/openfl/display/Preloader.hx
+++ b/packages/application/src/openfl/display/Preloader.hx
@@ -105,8 +105,8 @@ class Preloader
 @:dox(hide) class DefaultPreloader extends Sprite
 {
 	@:noCompletion private var endAnimation:Int;
-	@:noCompletion private var outline:Sprite;
-	@:noCompletion private var progress:Sprite;
+	@:noCompletion private var outline:Shape;
+	@:noCompletion private var progress:Shape;
 	@:noCompletion private var startAnimation:Int;
 
 	public function new()
@@ -132,7 +132,7 @@ class Preloader
 
 		var padding = 2;
 
-		outline = new Sprite();
+		outline = new Shape();
 		outline.graphics.beginFill(color, 0.07);
 		outline.graphics.drawRect(0, 0, width, height);
 		outline.x = x;
@@ -140,7 +140,7 @@ class Preloader
 		outline.alpha = 0;
 		addChild(outline);
 
-		progress = new Sprite();
+		progress = new Shape();
 		progress.graphics.beginFill(color, 0.35);
 		progress.graphics.drawRect(0, 0, width - padding * 2, height - padding * 2);
 		progress.x = x + padding;
@@ -258,8 +258,7 @@ class Preloader
 		if (percent < 0) percent = 0;
 		if (percent > 1) percent = 1;
 
-		outline.alpha = percent;
-		progress.alpha = percent;
+		outline.alpha = progress.alpha = percent;
 	}
 
 	@:noCompletion private function this_onProgress(event:ProgressEvent):Void


### PR DESCRIPTION
Cleaned this up from an earlier closed PR.