### PR TITLE
Performance improvement for rendering TileContainer

### DIFF
--- a/packages/renderer-stage3d/src/openfl/display/_internal/Context3DTilemap.hx
+++ b/packages/renderer-stage3d/src/openfl/display/_internal/Context3DTilemap.hx
@@ -76,7 +76,7 @@ class Context3DTilemap
 
 	private static function buildBufferTileContainer(tilemap:Tilemap, group:TileContainer, renderer:OpenGLRenderer, parentTransform:Matrix,
 			defaultTileset:Tileset, alphaEnabled:Bool, worldAlpha:Float, colorTransformEnabled:Bool, defaultColorTransform:ColorTransform,
-			cacheBitmapData:BitmapData, rect:Rectangle, matrix:Matrix):Void
+			cacheBitmapData:BitmapData, rect:Rectangle, matrix:Matrix, isTopLevel:Bool = true):Void
 	{
 		var tileTransform = Matrix.__pool.get();
 		var roundPixels = renderer.__roundPixels;
@@ -84,7 +84,20 @@ class Context3DTilemap
 		var tiles = group.__tiles;
 		var length = group.__length;
 
-		resizeBuffer(tilemap, numTiles + length);
+		function getLength(_group:TileContainer):Int{
+			var _tiles = _group.__tiles;
+			var totalLength = 0;
+			for (tile in _tiles){				
+				if (tile.__length > 0) totalLength+= getLength(cast tile);
+				else totalLength++;
+			}
+			return totalLength;
+		}
+
+		if (isTopLevel) resizeBuffer(tilemap, numTiles + getLength(group));
+
+		//Todo: Merge recursive length lookup with for tiles loop to avoid iterating over tiles twice
+		//resizeBuffer(tilemap, numTiles + length);
 
 		var tile,
 			tileset,
@@ -158,7 +171,7 @@ class Context3DTilemap
 			if (tile.__length > 0)
 			{
 				buildBufferTileContainer(tilemap, cast tile, renderer, tileTransform, tileset, alphaEnabled, alpha, colorTransformEnabled, colorTransform,
-					cacheBitmapData, rect, matrix);
+					cacheBitmapData, rect, matrix, false);
 			}
 			else
 			{


### PR DESCRIPTION
Greatly improve performance of drawing populated TileContainers by retrieving total length recursively before resizing the vertex buffer to avoid resizing it for every nested Tile.