### PR TITLE
Fullfill ShowGlyphs TODO near line 335

### DIFF
--- a/packages/renderer-cairo/src/openfl/display/_internal/CairoTextField.hx
+++ b/packages/renderer-cairo/src/openfl/display/_internal/CairoTextField.hx
@@ -330,10 +330,14 @@ class CairoTextField
 
 								// TODO: draw only once
 
-								cairo.moveTo(scrollX + start.x, group.offsetY + group.ascent + scrollY);
+								var selectedGylphs = [];								
 
-								// TODO: Use `showGlyphs` not `showText`
-								cairo.showText(text.substring(selectionStart, selectionEnd));
+								selectionStart -= group.startIndex;
+								selectionEnd -= group.startIndex;
+								for (i in selectionStart...selectionEnd) selectedGylphs.push(glyphs[i]);
+								cairo.showGlyphs(selectedGylphs);
+
+								// TODO: Avoid creating glyph array every time.	
 							}
 						}
 					}


### PR DESCRIPTION
Draw selected text using Cairo's ShowGlyphs method instead of using Cairo's toy text. This resolves the difference in appearance between selected glyphs and non-selected glyphs.