### PR TITLE
Text layout and scroll fixes

### DIFF
--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -1556,7 +1556,7 @@ class TextField extends InteractiveObject
 					range.start = endIndex;
 					break;
 				}
-				else if (range.start < beginIndex && range.end >= endIndex)
+				else if (range.start < beginIndex && range.end <= endIndex)
 				{
 					// set format range is within the second part of the range
 					newRange = new TextFormatRange(range.format.clone(), beginIndex, endIndex);
@@ -1567,8 +1567,9 @@ class TextField extends InteractiveObject
 				}
 				else
 				{
-					// should never happen...
+					// should never happen, throw an error
 					index++;
+					Log.warn("You found a bug in OpenFL's text code! Please save a copy of your project and contact Joshua Granick (@singmajesty) so we can fix this.");
 				}
 			}
 		}

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -1479,8 +1479,6 @@ class TextField extends InteractiveObject
 		if (beginIndex == 0 && endIndex == max)
 		{
 			// set text format for the whole textfield
-			__textFormat.__merge(format);
-
 			__textEngine.textFormatRanges.length = 1;
 			
 			range = __textEngine.textFormatRanges[0];
@@ -1511,6 +1509,7 @@ class TextField extends InteractiveObject
 					if (range.start == beginIndex && range.end == endIndex)
 					{
 						// set format range matches an existing range exactly
+						range.format = range.format.clone();
 						range.format.__merge(format);
 						break;
 					}
@@ -1553,9 +1552,9 @@ class TextField extends InteractiveObject
 					if (range.start == beginIndex)
 					{
 						// deleted range would disappear and not be replaced in this case
-						__textEngine.textFormatRanges[index].format.__merge(format);
-						__textEngine.textFormatRanges[index].start = beginIndex;
-						__textEngine.textFormatRanges[index].end = endIndex;
+						range.format = range.format.clone();
+						range.format.__merge(format);
+						range.end = endIndex;
 					}
 					else
 					{
@@ -2209,7 +2208,19 @@ class TextField extends InteractiveObject
 			
 			if (beginIndex == endIndex)
 			{
-				if (range.end < beginIndex)
+				if (range.start == range.end)
+				{
+					// this should only ever be true if there is no text (start == end == 0)
+					if (range.start != 0)
+					{
+						Log.warn("You found a bug in OpenFL's text code! Please save a copy of your project and contact Joshua Granick (@singmajesty) so we can fix this.");
+					}
+					else
+					{
+						range.end += offset;
+					}
+				}
+				else if (range.end < beginIndex)
 				{
 					// do nothing, range is completely before insertion point
 				}
@@ -2269,17 +2280,17 @@ class TextField extends InteractiveObject
 		if (__textEngine.textFormatRanges.length == 0)
 		{
 			// add DTF, all format ranges were deleted
-			__textEngine.textFormatRanges.push(new TextFormatRange(defaultTextFormat, 0, newText.length));
+			__textEngine.textFormatRanges.push(new TextFormatRange(defaultTextFormat.clone(), 0, newText.length));
 		}
 		else if (beginIndex == endIndex && __textEngine.textFormatRanges[0].start > 0)
 		{
 			// prefix DTF, text was inserted without a format
-			__textEngine.textFormatRanges.unshift(new TextFormatRange(defaultTextFormat, 0, __textEngine.textFormatRanges[0].start));
+			__textEngine.textFormatRanges.unshift(new TextFormatRange(defaultTextFormat.clone(), 0, __textEngine.textFormatRanges[0].start));
 		}
 		else if (beginIndex != endIndex && __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end < __text.length)
 		{
 			// append DTF, text was replaced without a format
-			__textEngine.textFormatRanges.push(new TextFormatRange(defaultTextFormat, __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end, __text.length));
+			__textEngine.textFormatRanges.push(new TextFormatRange(defaultTextFormat.clone(), __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end, __text.length));
 		}
 		
 		setSelection(beginIndex + newText.length, beginIndex + newText.length);

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -2132,35 +2132,83 @@ class TextField extends InteractiveObject
 		{
 			range = __textEngine.textFormatRanges[i];
 
-			if (range.start <= beginIndex && range.end >= endIndex)
+			if (beginIndex == endIndex)
 			{
-				range.end += offset;
-				i++;
-			}
-			else if (range.start >= beginIndex && range.end <= endIndex)
-			{
-				if (i > 0)
+				if (range.end < beginIndex)
 				{
-					__textEngine.textFormatRanges.splice(i, 1);
+					// do nothing, range is completely before insertion point
+				}
+				else if (range.start > endIndex)
+				{
+					// shift range, range is after insertion point
+					range.start += offset;
+					range.end += offset;
 				}
 				else
 				{
-					range.start = 0;
-					range.end = beginIndex + newText.length;
-					i++;
+					if (range.start < range.end && range.end == beginIndex && i < __textEngine.textFormatRanges.length - 1)
+					{
+						// do nothing, insertion point is between two ranges, so it belongs to the next range
+						// unless there are no more ranges after this one (inserting at the end of the text)
+					}
+					else
+					{
+						// add to range, insertion point is within range
+						range.end += offset;
+					}
 				}
-
-				offset -= (range.end - range.start);
-			}
-			else if (range.start > beginIndex && range.start <= endIndex)
-			{
-				range.start += offset;
-				i++;
 			}
 			else
 			{
-				i++;
+				if (range.end < beginIndex)
+				{
+					// do nothing, range is before selection
+				}
+				else if (range.start >= endIndex)
+				{
+					// shift range, range is completely after selection
+					range.start += offset;
+					range.end += offset;
+				}
+				else if (range.start >= beginIndex && range.end <= endIndex)
+				{
+					// delete range, range is encompassed by selection
+					if (__textEngine.textFormatRanges.length > 1)
+
+					{
+						__textEngine.textFormatRanges.splice(i, 1);
+					}
+					else
+					{
+						// don't delete if it's the last range though, just modify properties
+						range.start = 0;
+						range.end = newText.length;
+					}
+				}
+				else if (range.start <= beginIndex)
+				{
+					if (range.end < endIndex)
+					{
+						// modify range, range ends before the selection ends
+						range.end = beginIndex;
+					}
+					else
+					{
+						// modify range, range ends where or after the selection ends
+						range.end += offset;
+					}
+				}
+				else
+				{
+					// modify range, selection begins before the range
+					// for deletion: entire range shifts leftward
+					// for addition: added text gains the format of endIndex
+					range.start = beginIndex;
+					range.end += offset;
+				}
 			}
+
+			i++;
 		}
 
 		__updateScrollV();

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -2087,11 +2087,6 @@ class TextField extends InteractiveObject
 
 		__replaceText(startIndex, endIndex, value, restrict);
 
-		var i = startIndex + cast(value, UTF8String).length;
-		if (i > __text.length) i = __text.length;
-
-		setSelection(i, i);
-
 		// TODO: Solution where this is not run twice (run inside replaceText above)
 		__updateScrollH();
 	}
@@ -2163,8 +2158,9 @@ class TextField extends InteractiveObject
 			}
 		}
 
-		__updateScrollV();
-		__updateScrollH();
+		setSelection(beginIndex + newText.length, beginIndex + newText.length);
+
+		__updateScrollH(); // TODO: add to setSelection
 
 		__dirty = true;
 		__layoutDirty = true;

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -1572,6 +1572,26 @@ class TextField extends InteractiveObject
 					Log.warn("You found a bug in OpenFL's text code! Please save a copy of your project and contact Joshua Granick (@singmajesty) so we can fix this.");
 				}
 			}
+			
+			// robust catchers for myriad edge cases
+			if (__textEngine.textFormatRanges.length == 0)
+			{
+				newRange = new TextFormatRange(defaultTextFormat.clone(), 0, endIndex);
+				newRange.format.__merge(format);
+				__textEngine.textFormatRanges.push(newRange);
+			}
+			else if (__textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end < __text.length)
+			{
+				newRange = new TextFormatRange(defaultTextFormat.clone(), __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end, __text.length);
+				newRange.format.__merge(format);
+				__textEngine.textFormatRanges.push(newRange);
+			}
+			else if (__textEngine.textFormatRanges[0].start > 0)
+			{
+				newRange = new TextFormatRange(defaultTextFormat.clone(), 0, __textEngine.textFormatRanges[0].start);
+				newRange.format.__merge(format);
+				__textEngine.textFormatRanges.unshift(newRange);
+			}
 		}
 
 		__dirty = true;
@@ -2229,7 +2249,8 @@ class TextField extends InteractiveObject
 
 			i++;
 		}
-
+		
+		// robust catchers for myriad edge cases
 		if (__textEngine.textFormatRanges.length == 0)
 		{
 			// add DTF, all format ranges were deleted
@@ -2240,10 +2261,10 @@ class TextField extends InteractiveObject
 			// prefix DTF, text was inserted without a format
 			__textEngine.textFormatRanges.unshift(new TextFormatRange(defaultTextFormat, 0, __textEngine.textFormatRanges[0].start));
 		}
-		else if (beginIndex != endIndex && __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end < __text.length + offset)
+		else if (beginIndex != endIndex && __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end < __text.length)
 		{
 			// append DTF, text was replaced without a format
-			__textEngine.textFormatRanges.push(new TextFormatRange(defaultTextFormat, __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end, __text.length + offset));
+			__textEngine.textFormatRanges.push(new TextFormatRange(defaultTextFormat, __textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end, __text.length));
 		}
 		
 		setSelection(beginIndex + newText.length, beginIndex + newText.length);

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -2279,51 +2279,88 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function __updateScrollH():Void
 	{
-		if (!multiline && type == INPUT)
+		__updateLayout();
+
+		if (textWidth <= width - 4)
 		{
-			__layoutDirty = true;
-			__updateLayout();
-
-			var offsetX = __textEngine.textWidth - __textEngine.width + 4;
-
-			if (offsetX > 0)
+			scrollH = 0;
+			return;
+		}
+		
+		var tempScrollH = scrollH;
+		
+		// margins are ignored here
+		
+		if (__caretIndex == 0 || getLineOffset(getLineIndexOfChar(__caretIndex)) == __caretIndex)
+		{
+			// first index in a line is always at 0 scrollH
+			tempScrollH = 0;
+		}
+		else
+		{
+			var caret = Rectangle.__pool.get();
+			var written = false;
+			
+			if (__caretIndex < __text.length)
 			{
-				// TODO: Handle __selectionIndex on drag select?
-				// TODO: Update scrollH by one character width at a time when able
-
-				if (__caretIndex >= text.length)
-				{
-					scrollH = Math.ceil(offsetX);
-				}
-				else
-				{
-					var caret = Rectangle.__pool.get();
-					__getCharBoundaries(__caretIndex, caret);
-
-					if (caret.x < scrollH)
-					{
-						scrollH = Math.floor(caret.x - 2);
-					}
-					else if (caret.x > scrollH + __textEngine.width)
-					{
-						scrollH = Math.ceil(caret.x - __textEngine.width - 2);
-					}
-
-					Rectangle.__pool.release(caret);
-				}
+				written = __getCharBoundaries(__caretIndex, caret);
 			}
-			else
+			if (!written) 
 			{
-				scrollH = 0;
+				// \n and \r don't have character boundaries, as well as when caretIndex == text.length
+				// written doesn't need to be checked again, covered earlier
+				__getCharBoundaries(__caretIndex - 1, caret);
+				caret.x += caret.width; // shift rectangle to where the caret is
+			}
+			
+			while (caret.x < tempScrollH && tempScrollH > 0)
+			{
+				tempScrollH -= 24;
+			}
+			while (caret.x > tempScrollH + width - 4)
+			{
+				tempScrollH += 24;
+			}
+			
+			Rectangle.__pool.release(caret);
+		}
+		
+		if (tempScrollH > 0 && type != INPUT)
+		{
+			// input text leaves some room after scrolling to the last character in a line. dynamic text does not
+			var lineLength = getLineLength(getLineIndexOfChar(__caretIndex));
+			if (scrollH + width - 4 > lineLength)
+			{
+				scrollH = Math.ceil(lineLength - width + 4);
 			}
 		}
+		
+		if (tempScrollH < 0)
+		{
+			scrollH = 0;
+		}
+		else if (tempScrollH > maxScrollH)
+		{
+			scrollH = maxScrollH;
+		}
+		else
+		{
+			scrollH = tempScrollH;
+		}
+		
+		// TODO: Handle drag select
 	}
 
 	@:noCompletion private function __updateScrollV():Void
 	{
-		__layoutDirty = true;
 		__updateLayout();
 
+		if (textHeight <= height - 4)
+		{
+			scrollV = 1;
+			return;
+		}
+		
 		var lineIndex = getLineIndexOfChar(__caretIndex);
 
 		if (lineIndex == -1 && __caretIndex > 0)

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -883,8 +883,7 @@ class TextField extends InteractiveObject
 
 		__textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end = __text.length;
 
-		__updateScrollV();
-		__updateScrollH();
+		setSelection(__text.length, __text.length);
 	}
 
 	// function copyRichText() : String;
@@ -1391,6 +1390,7 @@ class TextField extends InteractiveObject
 		__caretIndex = endIndex;
 
 		__updateScrollV();
+		__updateScrollH();
 
 		__stopCursorTimer();
 		__startCursorTimer();
@@ -2134,9 +2134,6 @@ class TextField extends InteractiveObject
 		if (startIndex < 0) startIndex = 0;
 
 		__replaceText(startIndex, endIndex, value, restrict);
-
-		// TODO: Solution where this is not run twice (run inside replaceText above)
-		__updateScrollH();
 	}
 
 	@:noCompletion private function __replaceText(beginIndex:Int, endIndex:Int, newText:String, restrict:Bool):Void
@@ -2255,8 +2252,6 @@ class TextField extends InteractiveObject
 		}
 
 		setSelection(beginIndex + newText.length, beginIndex + newText.length);
-
-		__updateScrollH(); // TODO: add to setSelection
 
 		__dirty = true;
 		__layoutDirty = true;
@@ -2751,7 +2746,7 @@ class TextField extends InteractiveObject
 		#else
 		__updateText(value);
 		#end
-		__updateScrollV();
+		setSelection(length, length);
 
 		return value;
 	}
@@ -2980,7 +2975,7 @@ class TextField extends InteractiveObject
 		__isHTML = false;
 
 		__updateText(value);
-		__updateScrollV();
+		setSelection(utfValue.length, utfValue.length);
 
 		return value;
 	}
@@ -3397,7 +3392,6 @@ class TextField extends InteractiveObject
 					__selectionIndex = __caretIndex;
 				}
 
-				__updateScrollH(); // TODO: move into setSelection
 				setSelection(__selectionIndex, __caretIndex);
 
 			case RIGHT if (selectable):
@@ -3415,7 +3409,6 @@ class TextField extends InteractiveObject
 					__selectionIndex = __caretIndex;
 				}
 
-				__updateScrollH();
 				setSelection(__selectionIndex, __caretIndex);
 
 			case DOWN if (selectable):
@@ -3433,7 +3426,6 @@ class TextField extends InteractiveObject
 					__selectionIndex = __caretIndex;
 				}
 				
-				// __updateScrollH();
 				setSelection(__selectionIndex, __caretIndex);
 
 			case UP if (selectable):
@@ -3451,7 +3443,6 @@ class TextField extends InteractiveObject
 					__selectionIndex = __caretIndex;
 				}
 				
-				// __updateScrollH();
 				setSelection(__selectionIndex, __caretIndex);
 
 			case HOME if (selectable):

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -1445,34 +1445,45 @@ class TextField extends InteractiveObject
 	{
 		var max = text.length;
 		var range;
-
-		if (beginIndex < 0) beginIndex = 0;
-		if (endIndex < 0) endIndex = 0;
-
-		if (endIndex == 0)
+		
+		if (beginIndex == -1)
 		{
-			if (beginIndex == 0)
-			{
-				endIndex = max;
-			}
-			else
-			{
-				endIndex = beginIndex + 1;
-			}
+			if (endIndex == -1) endIndex = max;
+			beginIndex = 0;
 		}
+		
+		else if (endIndex == -1)
+		{
+			endIndex = beginIndex + 1;
+		}
+		
+		if (beginIndex == endIndex) return;
+		if (beginIndex < 0 || endIndex <= 0 || endIndex < beginIndex || beginIndex >= max || endIndex > max) throw new RangeError();
 
-		if (endIndex < beginIndex) return;
-
-		if (beginIndex == 0 && endIndex >= max)
+		// there are 10 cases that have to be handled
+		// the order and logic of cases really matters!!
+		//	beginIndex == 0 && endIndex == max -> replace all format ranges with new one
+		//	existing range.end < beginIndex -> continue
+		//	existing range.start >= endIndex -> done
+		//	existing range encompassed by beginIndex...endIndex -> 
+		//		existing range == new range -> merge new format into existing
+		//		range.start == beginIndex -> existing.start = endIndex, insert new before existing
+		//		range.end == endIndex -> existing.end = beginIndex, insert new after existing
+		//		else -> split existing into two (existing.end = beginIndex; newExisting.start = endIndex), insert new in between
+		//	existing range completely encompasses beginIndex...endIndex -> delete existing
+		//	existing range encompasses beginIndex but not endIndex -> existing.start = endIndex
+		//	existing range encompasses endIndex but not beginIndex -> existing.end = beginIndex, insert new
+		
+		if (beginIndex == 0 && endIndex == max)
 		{
 			// set text format for the whole textfield
 			__textFormat.__merge(format);
 
-			for (i in 0...__textEngine.textFormatRanges.length)
-			{
-				range = __textEngine.textFormatRanges[i];
-				range.format.__merge(format);
-			}
+			__textEngine.textFormatRanges.length = 1;
+			
+			range = __textEngine.textFormatRanges[0];
+			range.start = 0; range.end = max;
+			range.format.__merge(format);
 		}
 		else
 		{
@@ -1483,38 +1494,82 @@ class TextField extends InteractiveObject
 			{
 				range = __textEngine.textFormatRanges[index];
 
-				if (range.start == beginIndex && range.end == endIndex)
+				if (range.end <= beginIndex)
 				{
-					// set format range matches an existing range exactly
-					range.format.__merge(format);
+					// skip until relevant format ranges
+					index++;
+				}
+				else if (range.start >= endIndex)
+				{
+					// stop iterating if set format range has been handled
 					break;
+				}
+				else if (range.start <= beginIndex && range.end >= endIndex)
+				{
+					if (range.start == beginIndex && range.end == endIndex)
+					{
+						// set format range matches an existing range exactly
+						range.format.__merge(format);
+						break;
+					}
+					else if (range.start == beginIndex)
+					{
+						// existing range encompasses set format range, with start == beginIndex
+						newRange = new TextFormatRange(range.format.clone(), beginIndex, endIndex);
+						newRange.format.__merge(format);
+						__textEngine.textFormatRanges.insertAt(index, newRange);
+						range.start = endIndex;
+						index += 2;
+					}
+					else if (range.end == endIndex)
+					{
+						// existing range encompasses set format range, with end == endIndex
+						newRange = new TextFormatRange(range.format.clone(), beginIndex, endIndex);
+						newRange.format.__merge(format);
+						__textEngine.textFormatRanges.insertAt(index + 1, newRange);
+						
+						range.end = beginIndex;
+						break;
+					}
+					else
+					{
+						// existing range completely encompasses set format range
+						newRange = new TextFormatRange(range.format.clone(), beginIndex, endIndex);
+						newRange.format.__merge(format);
+						__textEngine.textFormatRanges.insertAt(index + 1, newRange);
+						
+						newRange = new TextFormatRange(range.format.clone(), endIndex, range.end);
+						__textEngine.textFormatRanges.insertAt(index + 2, newRange);
+						
+						range.end = beginIndex;
+						break;
+					}
 				}
 				else if (range.start >= beginIndex && range.end <= endIndex)
 				{
 					// set format range completely encompasses this existing range
-					range.format.__merge(format);
+					__textEngine.textFormatRanges.removeAt(index);
 				}
-				else if (range.start >= beginIndex && range.start < endIndex && range.end > beginIndex)
+				else if (range.start > beginIndex && range.end > beginIndex)
 				{
 					// set format range is within the first part of the range
-					newRange = new TextFormatRange(range.format.clone(), range.start, endIndex);
-					newRange.format.__merge(format);
-					__textEngine.textFormatRanges.insertAt(index, newRange);
 					range.start = endIndex;
-					index++;
+					break;
 				}
-				else if (range.start < beginIndex && range.end > beginIndex && range.end >= endIndex)
+				else if (range.start < beginIndex && range.end >= endIndex)
 				{
 					// set format range is within the second part of the range
-					newRange = new TextFormatRange(range.format.clone(), beginIndex, range.end);
+					newRange = new TextFormatRange(range.format.clone(), beginIndex, endIndex);
 					newRange.format.__merge(format);
 					__textEngine.textFormatRanges.insertAt(index + 1, newRange);
 					range.end = beginIndex;
+					index += 2;
+				}
+				else
+				{
+					// should never happen...
 					index++;
 				}
-
-				index++;
-				// TODO: Remove duplicates?
 			}
 		}
 

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -3013,7 +3013,7 @@ class TextField extends InteractiveObject
 		__isHTML = false;
 
 		__updateText(value);
-		setSelection(utfValue.length, utfValue.length);
+		setSelection(0, 0);
 
 		return value;
 	}

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -1786,7 +1786,7 @@ class TextEngine
 			var tempHeight = 0.0;
 			var ret = lineHeights.length;
 
-			for (i in ret - 1...lineHeights.length)
+			for (i in scrollV - 1...lineHeights.length)
 			{
 				if (tempHeight + lineHeights[i] <= height - 4)
 				{
@@ -1799,7 +1799,7 @@ class TextEngine
 				}
 			}
 
-			if (ret < 1) return 1;
+			if (ret < scrollV) return scrollV;
 			return ret;
 		}
 	}

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -1530,6 +1530,8 @@ class TextEngine
 							if (breakIndex == endIndex) endIndex++;
 
 							textIndex = endIndex;
+							
+							if (endIndex == text.length) alignBaseline();
 						}
 					}
 

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -1037,6 +1037,11 @@ class TextEngine
 			}
 			else if (endIndex <= formatRange.end)
 			{
+				positions = getPositions(text, startIndex, endIndex);
+				widthValue = getPositionsWidth(positions);
+			}
+			else
+			{
 				var tempIndex = startIndex;
 				var tempRangeEnd = formatRange.end;
 				var countRanges = 0;

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -1319,14 +1319,14 @@ class TextEngine
 					layoutGroup = null;
 				}
 
+				alignBaseline();
+				
 				// TODO: is this necessary or already handled by placeText above?
 				if (formatRange.end == breakIndex)
 				{
 					nextFormatRange();
 					setLineMetrics();
 				}
-
-				alignBaseline();
 
 				textIndex = breakIndex + 1;
 				previousBreakIndex = breakIndex;

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -1811,8 +1811,6 @@ class TextEngine
 		else
 		{
 			var i = numLines - 1, tempHeight = 0.0;
-
-			if (text.charCodeAt(text.length - 1) == '\n'.code) i--; // trailing newlines do not contribute to maxScrollV
 			var j = i;
 
 			while (i >= 0)

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -725,7 +725,7 @@ class TextEngine
 
 		if (textWidth > width - 4)
 		{
-			maxScrollH = Std.int(textWidth - width + 4);
+			maxScrollH = Std.int(textWidth - width + 4); // TODO: incorrect
 		}
 		else
 		{

--- a/packages/textfield/src/openfl/text/_internal/TextLayout.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextLayout.hx
@@ -140,10 +140,12 @@ class TextLayout
 			__hbBuffer.script = script.toHBScript();
 			__hbBuffer.language = new HBLanguage(language);
 			__hbBuffer.clusterLevel = HBBufferClusterLevel.CHARACTERS;
-			#if (neko || mac || hl)
+			#if (neko || mac)
 			// other targets still uses dummy positions to make UTF8 work
 			// TODO: confirm
 			__hbBuffer.addUTF8(text, 0, -1);
+			#elseif (hl)
+			__hbBuffer.addUTF16(text, text.length, 0, -1);
 			#else
 			__hbBuffer.addUTF16(untyped __cpp__('(uintptr_t){0}', text.wc_str()), text.length, 0, -1);
 			#end


### PR DESCRIPTION
Fixes LRUD/home/end+modifier navigation, Unicode on HL, `setTextFormat`, `__replaceText`, `alignBaseline` usage, `restrict` in `replaceText`, `scrollV`, `maxScrollV`, `bottomScrollV`, duplicated layout generation on scroll, and scrolling on `set_text`. Implements `leftMargin`, `rightMargin`, `indent`, `blockIndent`, and a more Flash-like `scrollH`. Happens to make RTL easier to implement.

Closes #1854, closes #2315, closes #2318, closes #2399 

The changes are too interrelated at this point to tackle them individually. #2405 contains (hopefully) comprehensive testing for these changes, although it still has to be integrated fully into the codebase.