### PR TITLE
add missing import to Lib.hx

### DIFF
--- a/lib/openfl/Lib.hx
+++ b/lib/openfl/Lib.hx
@@ -1,5 +1,7 @@
 package openfl;
 
+import haxe.Constraints;
+
 // import openfl.display.Application;
 import openfl.display.MovieClip;
 import openfl.net.URLRequest;


### PR DESCRIPTION
Function type requires import haxe.Constraints; in haxe 4.1.4