### PR TITLE
Use faster unsafe app.window:openfl.display.Window cast

### DIFF
--- a/assets/templates/haxe/ApplicationMain.hx
+++ b/assets/templates/haxe/ApplicationMain.hx
@@ -116,7 +116,7 @@ class ApplicationMain
 			@:privateAccess preloader.start();
 		});
 
-		preloader.onComplete.add(start.bind(cast(app.window, openfl.display.Window).stage));
+		preloader.onComplete.add(start.bind((cast app.window:openfl.display.Window).stage));
 
 		for (library in ManifestResources.preloadLibraries)
 		{


### PR DESCRIPTION
Faster unsafe cast here is fine as we know it's an openfl window.