### PR TITLE
Openfl9.0.2:TextField setTextFormat’s beginIndex and endIndex default value is -1.

### DIFF
--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -1426,7 +1426,7 @@ class TextField extends InteractiveObject
 		@throws RangeError The `beginIndex` or `endIndex`
 						   specified is out of range.
 	**/
-	public function setTextFormat(format:TextFormat, beginIndex:Int = 0, endIndex:Int = 0):Void
+	public function setTextFormat(format:TextFormat, beginIndex:Int = -1, endIndex:Int = -1):Void
 	{
 		var max = text.length;
 		var range;


### PR DESCRIPTION
TextField setTextFormat’s beginIndex and endIndex default value is -1.