### PR TITLE
Text Renderer fixes for text selection

### DIFF
--- a/packages/renderer-cairo/src/openfl/display/_internal/CairoTextField.hx
+++ b/packages/renderer-cairo/src/openfl/display/_internal/CairoTextField.hx
@@ -32,7 +32,7 @@ class CairoTextField
 	{
 		#if lime_cairo
 		var textEngine = textField.__textEngine;
-		var bounds = (textEngine.background || textEngine.border) ? textEngine.bounds : textEngine.textBounds;
+		var bounds = textEngine.bounds;
 		var graphics = textField.__graphics;
 		var cairo = graphics.__cairo;
 

--- a/packages/renderer-canvas/src/openfl/display/_internal/CanvasTextField.hx
+++ b/packages/renderer-canvas/src/openfl/display/_internal/CanvasTextField.hx
@@ -31,7 +31,7 @@ class CanvasTextField
 	{
 		#if (js && html5)
 		var textEngine = textField.__textEngine;
-		var bounds = (textEngine.background || textEngine.border) ? textEngine.bounds : textEngine.textBounds;
+		var bounds = textEngine.bounds;
 		var graphics = textField.__graphics;
 
 		if (textField.__dirty)


### PR DESCRIPTION
This fixes an issue where text, without background or border, does not render selection appropriately when aligned to right or center.