### PR TITLE
Text Renderer fixes for text selection

### DIFF
--- a/packages/renderer-cairo/src/openfl/display/_internal/CairoTextField.hx
+++ b/packages/renderer-cairo/src/openfl/display/_internal/CairoTextField.hx
@@ -324,7 +324,7 @@ class CairoTextField
 							if (start != null && end != null)
 							{
 								cairo.setSourceRGB(0, 0, 0);
-								cairo.rectangle(scrollX + start.x, start.y + scrollY, end.x - start.x, group.height);
+								cairo.rectangle(scrollX + start.x - bounds.x, start.y + scrollY, end.x - start.x, group.height);
 								cairo.fill();
 								cairo.setSourceRGB(1, 1, 1);
 

--- a/packages/renderer-canvas/src/openfl/display/_internal/CanvasTextField.hx
+++ b/packages/renderer-canvas/src/openfl/display/_internal/CanvasTextField.hx
@@ -256,12 +256,12 @@ class CanvasTextField
 								if (start != null && end != null)
 								{
 									context.fillStyle = "#000000";
-									context.fillRect(start.x + scrollX, start.y + scrollY, end.x - start.x, group.height);
+									context.fillRect(start.x + scrollX - bounds.x, start.y + scrollY, end.x - start.x, group.height);
 									context.fillStyle = "#FFFFFF";
 
 									// TODO: fill only once
 
-									context.fillText(text.substring(selectionStart, selectionEnd), scrollX + start.x, group.offsetY + group.ascent + scrollY);
+									context.fillText(text.substring(selectionStart, selectionEnd), scrollX + start.x - bounds.x, group.offsetY + group.ascent + scrollY);
 								}
 							}
 						}


### PR DESCRIPTION
Fixes for text selection when aligned center or right. Previously, contrast bar was offset.