### PR TITLE
O(1) to O(reasonable) text insertions

### DIFF
--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -2031,7 +2031,7 @@ class TextField extends InteractiveObject
 			}
 		}
 
-		__textEngine.placementIndex = 0; // TODO: temporary, should be beginIndex
+		__textEngine.placementIndex = beginIndex;
 		__updateText(__text.substring(0, beginIndex) + newText + __text.substring(endIndex));
 
 		var offset = newText.length - (endIndex - beginIndex);

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -963,24 +963,15 @@ class TextField extends InteractiveObject
 	{
 		if (charIndex < 0 || charIndex > text.length) return -1;
 
-		var index = __textEngine.getLineBreakIndex();
-		var startIndex = 0;
-
-		while (index > -1)
+		for (i in 0...__textEngine.lineBreaks.length)
 		{
-			if (index < charIndex)
+			if (charIndex <= __textEngine.lineBreaks[i])
 			{
-				startIndex = index + 1;
+				return i == 0 ? 0 : __textEngine.lineBreaks[i - 1] + 1;
 			}
-			else if (index >= charIndex)
-			{
-				break;
-			}
-
-			index = __textEngine.getLineBreakIndex(index + 1);
 		}
 
-		return startIndex;
+		return __textEngine.lineBreaks[__textEngine.lineBreaks.length - 1] + 1;
 	}
 
 	/**

--- a/packages/textfield/src/openfl/text/TextField.hx
+++ b/packages/textfield/src/openfl/text/TextField.hx
@@ -864,6 +864,7 @@ class TextField extends InteractiveObject
 		__layoutDirty = true;
 		__setRenderDirty();
 
+		__textEngine.placementIndex = __text.length;
 		__updateText(__text + text);
 
 		__textEngine.textFormatRanges[__textEngine.textFormatRanges.length - 1].end = __text.length;
@@ -2039,6 +2040,7 @@ class TextField extends InteractiveObject
 			}
 		}
 
+		__textEngine.placementIndex = 0; // TODO: temporary, should be beginIndex
 		__updateText(__text.substring(0, beginIndex) + newText + __text.substring(endIndex));
 
 		var offset = newText.length - (endIndex - beginIndex);
@@ -2607,6 +2609,7 @@ class TextField extends InteractiveObject
 		}
 
 		__isHTML = true;
+		__textEngine.placementIndex = 0;
 
 		#if (js && html5)
 		__rawHtmlText = value;
@@ -2871,6 +2874,7 @@ class TextField extends InteractiveObject
 		range.end = utfValue.length;
 
 		__isHTML = false;
+		__textEngine.placementIndex = 0;
 
 		__updateText(value);
 		setSelection(0, 0);

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -1310,7 +1310,8 @@ class TextEngine
 		}
 		
 		if (placementIndex > 0) {
-			// all of this is typically less expensive than re-laying out text before placementIndex
+			// all of this is typically less expensive than re-laying out the text before placementIndex
+			// TODO: better way of getting the state of layout at any index (is this paragraph/line change?)
 			
 			for (lg in layoutGroups)
 			{
@@ -1318,10 +1319,12 @@ class TextEngine
 				else layoutGroup = lg;
 			}
 			
-			if (placementIndex < text.length)
+			if (placementIndex < layoutGroups[layoutGroups.length - 1].endIndex)
 			{
 				// if we need to interrupt the existing layout groups
-				layoutGroups.length = layoutGroups.indexOf(layoutGroup);
+				//trace(layoutGroups.length);
+				//trace(layoutGroup.startIndex, layoutGroup.endIndex);
+				layoutGroups.length = layoutGroups.indexOf(layoutGroup) + 1;
 				
 				var gp;
 				while (layoutGroup.endIndex > placementIndex)
@@ -1329,9 +1332,12 @@ class TextEngine
 					gp = layoutGroup.positions.pop();
 					if (#if (js && html5) gp #else gp.advance.x #end > 0.0) layoutGroup.endIndex--;
 				}
+				//trace(layoutGroups.length);
+				//trace(layoutGroup.startIndex, layoutGroup.endIndex);
+				
+				layoutGroup.width = getPositionsWidth(layoutGroup.positions);
 			}
 			
-			layoutGroup.width = getPositionsWidth(layoutGroup.positions);
 			// TODO: need abl or something here in case a larger height/ascent format was deleted
 			
 			for (lineBreak in lineBreaks)

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -67,6 +67,7 @@ class TextEngine
 	public var maxScrollV(get, null):Int;
 	public var multiline:Bool;
 	public var numLines(default, null):Int;
+	public var placementIndex:Int;
 	public var restrict(default, set):UTF8String;
 	public var scrollH:Int;
 	@:isVar public var scrollV(get, set):Int;
@@ -124,6 +125,7 @@ class TextEngine
 		maxChars = 0;
 		multiline = false;
 		numLines = 1;
+		placementIndex = 0;
 		sharpness = 0;
 		scrollH = 0;
 		scrollV = 1;
@@ -737,7 +739,7 @@ class TextEngine
 
 	private function getLayoutGroups():Void
 	{
-		layoutGroups.length = 0;
+		if (placementIndex <= 0) layoutGroups.length = 0;
 
 		if (text == null || text == "") return;
 
@@ -767,8 +769,8 @@ class TextEngine
 		var widthValue = 0.0, heightValue = 0, maxHeightValue = 0;
 		var previousSpaceIndex = -2; // -1 equals not found, -2 saves extra comparison in `breakIndex == previousSpaceIndex`
 		var previousBreakIndex = -1;
-		var spaceIndex = text.indexOf(" ");
-		var breakIndex = getLineBreakIndex();
+		var spaceIndex = text.indexOf(" ", placementIndex);
+		var breakIndex = getLineBreakIndex(placementIndex);
 
 		var offsetX = 0.0;
 		var offsetY = 0.0;
@@ -1279,6 +1281,22 @@ class TextEngine
 			}
 
 			placeFormattedText(endIndex);
+		}
+		
+		if (placementIndex > 0) {
+			// TODO: confirm all
+			rangeIndex = textFormatRanges.length - 2;
+			textIndex = placementIndex;
+			
+			layoutGroup = layoutGroups[layoutGroups.length - 1];
+			offsetX = layoutGroup.offsetX + layoutGroup.width - GUTTER;
+			offsetY = layoutGroup.offsetY - GUTTER;
+			lineIndex = layoutGroup.lineIndex;
+			maxAscent = layoutGroup.ascent;
+			maxHeightValue = Std.int(layoutGroup.height);
+			// leading = layoutGroup.leading; // TODO: if maxLeading is necessary
+			
+			// TODO: more?
 		}
 
 		nextFormatRange();

--- a/packages/textfield/src/openfl/text/_internal/TextEngine.hx
+++ b/packages/textfield/src/openfl/text/_internal/TextEngine.hx
@@ -1319,27 +1319,6 @@ class TextEngine
 				else layoutGroup = lg;
 			}
 			
-			if (placementIndex < layoutGroups[layoutGroups.length - 1].endIndex)
-			{
-				// if we need to interrupt the existing layout groups
-				//trace(layoutGroups.length);
-				//trace(layoutGroup.startIndex, layoutGroup.endIndex);
-				layoutGroups.length = layoutGroups.indexOf(layoutGroup) + 1;
-				
-				var gp;
-				while (layoutGroup.endIndex > placementIndex)
-				{
-					gp = layoutGroup.positions.pop();
-					if (#if (js && html5) gp #else gp.advance.x #end > 0.0) layoutGroup.endIndex--;
-				}
-				//trace(layoutGroups.length);
-				//trace(layoutGroup.startIndex, layoutGroup.endIndex);
-				
-				layoutGroup.width = getPositionsWidth(layoutGroup.positions);
-			}
-			
-			// TODO: need abl or something here in case a larger height/ascent format was deleted
-			
 			for (lineBreak in lineBreaks)
 			{
 				if (lineBreak < placementIndex) previousBreakIndex = placementIndex;
@@ -1353,7 +1332,25 @@ class TextEngine
 				space = text.indexOf(" ", space + 1);
 			}
 			
+			if (previousSpaceIndex + 1 > previousBreakIndex) placementIndex = previousSpaceIndex + 1;
 			textIndex = placementIndex;
+			
+			if (placementIndex < layoutGroups[layoutGroups.length - 1].endIndex)
+			{
+				// if we need to interrupt the existing layout groups
+				layoutGroups.length = layoutGroups.indexOf(layoutGroup) + 1;
+				
+				var gp;
+				while (layoutGroup.endIndex > placementIndex)
+				{
+					gp = layoutGroup.positions.pop();
+					if (#if (js && html5) gp #else gp.advance.x #end > 0.0) layoutGroup.endIndex--;
+				}
+				
+				layoutGroup.width = getPositionsWidth(layoutGroup.positions);
+			}
+			
+			// TODO: need abl or something here in case a larger height/ascent format was deleted
 			
 			for (i in 0...textFormatRanges.length)
 			{
@@ -1593,8 +1590,6 @@ class TextEngine
 							offsetX += widthValue;
 
 							textIndex = endIndex;
-							
-							trace("K");
 						}
 						else if (layoutGroup == null || align == JUSTIFY)
 						{


### PR DESCRIPTION
This is a naïve text-layout-reduction PR: only laying out text after a "placement index" aka the insertion point. There are a couple of unfinished edge cases, but I may leave it since you typically don't have aggressive text formatting when you also are inserting text frequently. More people complain about input text being unbearable, and this helps especially if the cursor is near the end of the text.

It's a little hard to evaluate the "state" of text layout at any index, so it's harder to resume from that state. There are some bigger changes I have planned that address this, but those are a ways away.

Related to #2377, #2229. I'll decide if the latter can be closed when I merge.