### PR TITLE
Assigning a colorTransform shall flag the displayObject as dirty

### DIFF
--- a/src/openfl/geom/Transform.hx
+++ b/src/openfl/geom/Transform.hx
@@ -207,7 +207,7 @@ class Transform
 			__displayObject.__setRenderDirty();
 		}
 
-		return value;
+		return __colorTransform;
 	}
 
 	@:noCompletion private function get_concatenatedMatrix():Matrix

--- a/src/openfl/geom/Transform.hx
+++ b/src/openfl/geom/Transform.hx
@@ -199,19 +199,15 @@ class Transform
 
 	@:noCompletion private function set_colorTransform(value:ColorTransform):ColorTransform
 	{
-		if (!__colorTransform.__equals(value, false))
+		if (value != null)
 		{
 			__colorTransform.__copyFrom(value);
 
-			if (value != null)
-			{
-				__displayObject.alpha = value.alphaMultiplier;
-			}
-
+			__displayObject.alpha = value.alphaMultiplier;
 			__displayObject.__setRenderDirty();
 		}
 
-		return __colorTransform;
+		return value;
 	}
 
 	@:noCompletion private function get_concatenatedMatrix():Matrix


### PR DESCRIPTION
Assigning displayObject.transform.colorTransform flags the display object as dirty.

This is a way to enable typical color adjustment method - https://books.openfl.org/openfl-developers-guide/display-programming/manipulating-display-objects/adjusting-displayobject-colors.html