### PR TITLE
Address performance of line breaks in text

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -961,7 +961,8 @@ class TextField extends InteractiveObject
 	public function getFirstCharInParagraph(charIndex:Int):Int
 	{
 		if (charIndex < 0 || charIndex > text.length) return -1;
-
+		if (__textEngine.lineBreaks.length == 0) return 0;
+		
 		for (i in 0...__textEngine.lineBreaks.length)
 		{
 			if (charIndex <= __textEngine.lineBreaks[i])

--- a/src/openfl/text/_internal/TextEngine.hx
+++ b/src/openfl/text/_internal/TextEngine.hx
@@ -791,7 +791,8 @@ class TextEngine
 		var previousSpaceIndex = -2; // -1 equals not found, -2 saves extra comparison in `breakIndex == previousSpaceIndex`
 		var previousBreakIndex = -1;
 		var spaceIndex = text.indexOf(" ");
-		var breakIndex = getLineBreakIndex();
+		var breakCount = 0;
+		var breakIndex = breakCount < lineBreaks.length ? lineBreaks[breakCount] : -1;
 
 		var offsetX = 0.0;
 		var offsetY = 0.0;
@@ -1348,7 +1349,8 @@ class TextEngine
 
 				textIndex = breakIndex + 1;
 				previousBreakIndex = breakIndex;
-				breakIndex = getLineBreakIndex(textIndex);
+				breakCount++;
+				breakIndex = breakCount < lineBreaks.length ? lineBreaks[breakCount] : -1;
 
 				setParagraphMetrics();
 			}

--- a/src/openfl/text/_internal/TextEngine.hx
+++ b/src/openfl/text/_internal/TextEngine.hx
@@ -574,8 +574,8 @@ class TextEngine
 		var cr = -1, lf = -1;
 		while (index < text.length)
 		{
-			cr = text.indexOf("\n", index + 1);
-			lf = text.indexOf("\r", index + 1);
+			lf = text.indexOf("\n", index + 1);
+			cr = text.indexOf("\r", index + 1);
 			
 			index = 
 				if (cr == -1) lf;


### PR DESCRIPTION
Since text layout occurs in order, there is no need to search for line breaks if they are cached ahead of time, you just get the next one. This PR fixes a performance issue with searching within the line break cache, since it's slower than `string.indexOf()` in the ideal case, which is the average case in this situation.

@Dimensionscape 