### PR TITLE
Fix issue where non-integer sized graphic objects are cropped

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -1475,11 +1475,11 @@ import js.html.CanvasRenderingContext2D;
 		{
 			if (joints == JointStyle.MITER)
 			{
-				if (thickness > __strokePadding) __strokePadding = thickness;
+				if (thickness > __strokePadding) __strokePadding = Math.ceil(thickness);
 			}
 			else
 			{
-				if (thickness / 2 > __strokePadding) __strokePadding = thickness / 2;
+				if (thickness / 2 > __strokePadding) __strokePadding = Math.ceil(thickness / 2);
 			}
 		}
 


### PR DESCRIPTION
See: [http://community.openfl.org/t/circle-shapes-from-swf-being-cropped-slightly/12694](http://community.openfl.org/t/circle-shapes-from-swf-being-cropped-slightly/12694)

