### PR TITLE
Allow Stage constructor to use existing HTMLElement, if specified

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1018,7 +1018,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			var resizable = (width == 0 && width == 0);
 
 			#if (js && html5)
-			element = Browser.document.createElement("div");
+			if (windowAttributes.element != null) element = Browser.document.createElement("div");
 
 			if (resizable)
 			{


### PR DESCRIPTION
This is particularly handy when designing for multiple windows where each one can be assigned to an existing container element.