### PR TITLE
Adding support for streaming vorbis music on native targets.

### DIFF
--- a/src/openfl/utils/Assets.hx
+++ b/src/openfl/utils/Assets.hx
@@ -12,6 +12,10 @@ import lime.app.Promise;
 import lime.utils.AssetLibrary as LimeAssetLibrary;
 import lime.utils.Assets as LimeAssets;
 #end
+#if lime_vorbis
+import lime.media.AudioBuffer;
+import lime.media.vorbis.VorbisFile;
+#end
 
 /**
 	The Assets class provides a cross-platform interface to access
@@ -223,9 +227,16 @@ class Assets
 
 	public static function getMusic(id:String, useCache:Bool = true):Sound
 	{
-		// TODO: Streaming sound
 
+		#if lime_vorbis
+		var path = getPath(id);
+		var vorbisFile = VorbisFile.fromFile(path);
+		var buffer = AudioBuffer.fromVorbisFile(vorbisFile);
+		return Sound.fromAudioBuffer(buffer);
+		#else
+		// TODO: Streaming sound
 		return getSound(id, useCache);
+		#end
 	}
 
 	/**


### PR DESCRIPTION
Note: This PR depends on https://github.com/haxelime/lime/pull/1456 for it to function properly.

This PR adds support for "streaming" music from a file instead of loading all uncompressed audio into memory when targeting native targets. This saves a lot of memory and is very useful on devices with little memory lime mobile devices. 