### PR TITLE
Integer line heights + multiline shouldn't do anything

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2733,16 +2733,6 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function set_multiline(value:Bool):Bool
 	{
-		if (value != __textEngine.multiline)
-		{
-			__dirty = true;
-			__layoutDirty = true;
-			__updateText(__text);
-			// __updateScrollV();
-			__updateScrollH();
-			__setRenderDirty();
-		}
-
 		return __textEngine.multiline = value;
 	}
 

--- a/src/openfl/text/_internal/TextEngine.hx
+++ b/src/openfl/text/_internal/TextEngine.hx
@@ -656,7 +656,7 @@ class TextEngine
 				textWidth = currentLineWidth;
 			}
 
-			currentTextHeight = group.offsetY - 2 + group.ascent + group.descent;
+			currentTextHeight = Math.ceil(group.offsetY - 2 + group.ascent + group.descent);
 
 			if (currentTextHeight > textHeight)
 			{
@@ -694,13 +694,13 @@ class TextEngine
 
 			leading = currentFormat.leading;
 
-			heightValue = ascent + descent + leading;
+			heightValue = Math.ceil(ascent + descent + leading);
 
 			currentLineAscent = ascent;
 			currentLineDescent = descent;
 			currentLineLeading = leading;
 
-			currentTextHeight = ascent + descent;
+			currentTextHeight = Math.ceil(ascent + descent);
 			textHeight = currentTextHeight;
 		}
 


### PR DESCRIPTION
Closes #2484 

Non-ceiled line heights were causing off by one errors.

Setting `multiline` currently calls `updateText()` and `updateScrollH()`. The value of `multiline` is checked when you press ENTER or paste text containing line breaks; if it's false, ENTER is prevented or newlines are stripped out. Setting the value shouldn't do anything. See the [AS3 docs](https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/text/TextField.html#multiline). Was causing issues in Flixel.