### PR TITLE
Enumerate device fonts

### DIFF
--- a/src/openfl/text/Font.hx
+++ b/src/openfl/text/Font.hx
@@ -76,6 +76,19 @@ class Font #if lime extends LimeFont #end
 	**/
 	public static function enumerateFonts(enumerateDeviceFonts:Bool = false):Array<Font>
 	{
+		#if native
+		if(enumerateDeviceFonts)
+		{
+			var _deviceFonts = [];
+			var files = sys.FileSystem.readDirectory(lime.system.System.fontsDirectory);
+			for(file in files)
+			{
+				if(file.toLowerCase().indexOf('.ttf') != -1)
+					_deviceFonts.push(fromFile(lime.system.System.fontsDirectory + file));
+			}
+			return _deviceFonts;
+		}
+		#end
 		return __registeredFonts;
 	}
 

--- a/src/openfl/text/Font.hx
+++ b/src/openfl/text/Font.hx
@@ -79,14 +79,14 @@ class Font #if lime extends LimeFont #end
 		#if native
 		if(enumerateDeviceFonts)
 		{
-			var _deviceFonts = [];
+			var _allFonts = __registeredFonts.copy();
 			var files = sys.FileSystem.readDirectory(lime.system.System.fontsDirectory);
 			for(file in files)
 			{
 				if(file.toLowerCase().indexOf('.ttf') != -1)
-					_deviceFonts.push(fromFile(lime.system.System.fontsDirectory + file));
+					_allFonts.push(fromFile(lime.system.System.fontsDirectory + file));
 			}
-			return _deviceFonts;
+			return _allFonts;
 		}
 		#end
 		return __registeredFonts;


### PR DESCRIPTION
`Font.enumerateFonts(true) `should enumerate device fonts (like in C:\Windows\Fonts). It outputs only TTF fonts.
Windows, neko and Hashlink work! I have not tested Mac and Linux yet.

There is room for improvement for the future, for e.g: cache all the fonts for next time enumerateFonts(true) is called.