### PR TITLE
fix gl_stats (missing import)

### DIFF
--- a/src/openfl/display/_internal/Context3DBitmapData.hx
+++ b/src/openfl/display/_internal/Context3DBitmapData.hx
@@ -1,5 +1,10 @@
 package openfl.display._internal;
 
+#if gl_stats
+import openfl.display._internal.stats.Context3DStats;
+import openfl.display._internal.stats.DrawCallContext;
+#end
+
 #if !openfl_debug
 @:fileXml(' tags="haxe,release" ')
 @:noDebug


### PR DESCRIPTION
There is a missing import that prevents compiling with `gl_stats` flag.

Should fix https://github.com/openfl/openfl/issues/2485