### PR TITLE
Fix Flash compilation when using Tilemap

### DIFF
--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -117,9 +117,6 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	{
 		super();
 
-		#if !flash
-		__drawableType = TILEMAP;
-		#end
 		__tileset = tileset;
 		this.smoothing = smoothing;
 
@@ -130,6 +127,7 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 		__group = new TileContainer();
 		__group.tileset = tileset;
 		#if !flash
+		__drawableType = TILEMAP;
 		__width = width;
 		__height = height;
 		#else

--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -117,7 +117,9 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	{
 		super();
 
+		#if !flash
 		__drawableType = TILEMAP;
+		#end
 		__tileset = tileset;
 		this.smoothing = smoothing;
 


### PR DESCRIPTION
This PR fences `__drawableType` properly and fixes #2454.