### PR TITLE
pass supplied width/height args on html5

### DIFF
--- a/src/openfl/utils/_internal/AssetsMacro.hx
+++ b/src/openfl/utils/_internal/AssetsMacro.hx
@@ -46,7 +46,7 @@ class AssetsMacro
 			var constructor = macro
 				{
 					#if html5
-					super(0, 0, transparent, fillRGBA);
+					super(width, height, transparent, fillRGBA);
 
 					if (preload != null)
 					{


### PR DESCRIPTION
In html5, when instantiating bitmap classes defined using `@:bitmap` the width and height are 0x0 until the data is fetched asynchronously.  this is true even when a width and height are passed into the constructor. This change allows devs to pass in default dimension args if the code needs the image to have a non-zero size, immediately after construction.

Related to https://github.com/HaxeFlixel/flixel/pull/2402