### PR TITLE
Basic rTL and arabic ligatures

### DIFF
--- a/src/openfl/display/_internal/CairoTextField.hx
+++ b/src/openfl/display/_internal/CairoTextField.hx
@@ -279,7 +279,15 @@ class CairoTextField
 					for (position in group.positions)
 					{
 						if (position == null || position.glyph == 0) continue;
-						glyphs.push(new CairoGlyph(position.glyph, x + position.offset.x + 0.5, y - position.offset.y + 0.5));
+						if (textEngine.rTL)
+						{
+							glyphs.push(new CairoGlyph(position.glyph, x - position.offset.x + 0.5, y - position.offset.y + 0.5));
+						}
+						else
+						{
+							glyphs.push(new CairoGlyph(position.glyph, x + position.offset.x + 0.5, y - position.offset.y + 0.5));
+						}
+
 						x += position.advance.x;
 						y -= position.advance.y;
 					}
@@ -296,11 +304,19 @@ class CairoTextField
 								&& group.endIndex >= textField.__caretIndex)
 							{
 								advance = 0.0;
+								if (textField.rTL) advance = group.width;
 
 								for (i in 0...(textField.__caretIndex - group.startIndex))
 								{
 									if (group.positions.length <= i) break;
-									advance += group.getAdvance(i);
+									if (textField.rTL)
+									{
+										advance -= group.getAdvance(group.positions.length - 1 - i);
+									}
+									else
+									{
+										advance += group.getAdvance(i);
+									}
 								}
 
 								var scrollY = 0.0;
@@ -351,7 +367,8 @@ class CairoTextField
 
 								if (end != null)
 								{
-									end.x += end.width + 2;
+									if (!textField.rTL) end.x += end.width + 2;
+									if (textField.rTL) end.x -= group.getAdvance(0); // group.positions.length - 1);
 								}
 							}
 							else
@@ -373,7 +390,16 @@ class CairoTextField
 								selectionStart -= group.startIndex;
 								selectionEnd -= group.startIndex;
 								for (i in selectionStart...selectionEnd)
-									selectedGylphs.push(glyphs[i]);
+								{
+									if (textEngine.rTL)
+									{
+										selectedGylphs.push(glyphs[glyphs.length - 1 - i]);
+									}
+									else
+									{
+										selectedGylphs.push(glyphs[i]);
+									}
+								}
 								cairo.showGlyphs(selectedGylphs);
 
 								// TODO: Avoid creating glyph array every time.

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -7,6 +7,7 @@ import openfl.text._internal.TextEngine;
 import openfl.text._internal.TextFormatRange;
 import openfl.text._internal.TextLayoutGroup;
 import openfl.text._internal.UTF8String;
+import openfl.text._internal.TextLayout;
 import openfl.utils._internal.Log;
 import openfl.display.DisplayObject;
 import openfl.display.Graphics;
@@ -663,6 +664,9 @@ class TextField extends InteractiveObject
 		have word wrap. The default value is `false`.
 	**/
 	public var wordWrap(get, set):Bool;
+	public var rTL(get, set):Null<Bool>;
+	public var script(get, set):TextScript;
+	public var language(get, set):String;
 
 	@:noCompletion private var __bounds:Rectangle;
 	@:noCompletion private var __caretIndex:Int;
@@ -795,6 +799,21 @@ class TextField extends InteractiveObject
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_wordWrap (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_wordWrap (v); }")
 			},
+			"rTL":
+				{
+					get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_rTL (); }"),
+					set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_rTL (v); }")
+				},
+			"script":
+				{
+					get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_script(); }"),
+					set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_script (v); }")
+				},
+			"language":
+				{
+					get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_language (); }"),
+					set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_language (v); }")
+				},
 		});
 	}
 	#end
@@ -817,6 +836,9 @@ class TextField extends InteractiveObject
 		__displayAsPassword = false;
 		__graphics = new Graphics(this);
 		__textEngine = new TextEngine(this);
+		__textEngine.rTL = rTL;
+		__textEngine.language = language;
+		__textEngine.script = script;
 		__layoutDirty = true;
 		__offsetX = 0;
 		__offsetY = 0;
@@ -913,7 +935,9 @@ class TextField extends InteractiveObject
 
 		__updateLayout();
 
-		x += scrollH;
+		if (rTL) x -= scrollH;
+		else
+			x += scrollH;
 
 		for (i in 0...scrollV - 1)
 		{
@@ -1793,14 +1817,20 @@ class TextField extends InteractiveObject
 				try
 				{
 					var x = group.offsetX;
+					if (rTL) x += group.width;
 
 					for (i in 0...(charIndex - group.startIndex))
 					{
-						x += group.getAdvance(i);
+						if (!rTL) x += group.getAdvance(i);
+						else x -= group.getAdvance(group.positions.length - 1 - i);
 					}
 
 					// TODO: Is this actually right for combining characters?
 					var lastPosition = group.getAdvance(charIndex - group.startIndex);
+					if (rTL)
+					{
+						lastPosition = group.offsetX - group.width;
+					}
 
 					rect.setTo(x, group.offsetY, lastPosition, group.ascent + group.descent);
 					return true;
@@ -1869,7 +1899,9 @@ class TextField extends InteractiveObject
 	{
 		__updateLayout();
 
-		x += scrollH;
+		if (rTL) x -= scrollH;
+		else
+			x += scrollH;
 
 		for (i in 0...scrollV - 1)
 		{
@@ -1897,7 +1929,8 @@ class TextField extends InteractiveObject
 			if (firstGroup)
 			{
 				if (y < group.offsetY) y = group.offsetY;
-				if (x < group.offsetX) x = group.offsetX;
+				if (x < group.offsetX && !rTL) x = group.offsetX;
+				if (x > group.offsetX && rTL) x = group.offsetX;
 				firstGroup = false;
 			}
 
@@ -1905,6 +1938,10 @@ class TextField extends InteractiveObject
 			{
 				if ((x >= group.offsetX && x <= group.offsetX + group.width)
 					|| (!precise && (nextGroup == null || nextGroup.lineIndex != group.lineIndex)))
+				{
+					return group;
+				}
+				else if ((rTL && x <= group.offsetX + group.width) || (!precise && (nextGroup == null || nextGroup.lineIndex != group.lineIndex)))
 				{
 					return group;
 				}
@@ -1927,17 +1964,35 @@ class TextField extends InteractiveObject
 
 		for (i in 0...group.positions.length)
 		{
-			advance += group.getAdvance(i);
-
-			if (x <= group.offsetX + advance)
+			if (rTL)
 			{
-				if (x <= group.offsetX + (advance - group.getAdvance(i)) + (group.getAdvance(i) / 2))
+				advance -= group.getAdvance(i);
+				if (x > group.offsetX + group.width + advance + (group.getAdvance(i) / 2))
 				{
-					return group.startIndex + i;
+					var limitX = group.offsetX + group.width + advance;
+					if (x > limitX)
+					{
+						return group.startIndex + i;
+					}
+					else
+					{
+						return group.endIndex;
+					}
 				}
-				else
+			}
+			else
+			{
+				advance += group.getAdvance(i);
+				if (x <= group.offsetX + advance)
 				{
-					return (group.startIndex + i < group.endIndex) ? group.startIndex + i + 1 : group.endIndex;
+					if (x <= group.offsetX + (advance - group.getAdvance(i)) + (group.getAdvance(i) / 2))
+					{
+						return group.startIndex + i;
+					}
+					else
+					{
+						return (group.startIndex + i < group.endIndex) ? group.startIndex + i + 1 : group.endIndex;
+					}
 				}
 			}
 		}
@@ -2262,11 +2317,15 @@ class TextField extends InteractiveObject
 
 			while (caret.x < tempScrollH && tempScrollH > 0)
 			{
-				tempScrollH -= 24;
+				if (rTL) tempScrollH += 24
+				else
+					tempScrollH -= 24;
 			}
 			while (caret.x > tempScrollH + width - 4)
 			{
-				tempScrollH += 24;
+				if (rTL) tempScrollH -= 24
+				else
+					tempScrollH += 24;
 			}
 
 			Rectangle.__pool.release(caret);
@@ -2282,17 +2341,24 @@ class TextField extends InteractiveObject
 			}
 		}
 
-		if (tempScrollH < 0)
+		if (!rTL)
 		{
-			scrollH = 0;
-		}
-		else if (tempScrollH > maxScrollH)
-		{
-			scrollH = maxScrollH;
+			if (tempScrollH < 0)
+			{
+				scrollH = 0;
+			}
+			else if (tempScrollH > maxScrollH)
+			{
+				scrollH = maxScrollH;
+			}
+			else
+			{
+				scrollH = tempScrollH;
+			}
 		}
 		else
 		{
-			scrollH = tempScrollH;
+			// TODO : Handle RTL
 		}
 
 		// TODO: Handle drag select
@@ -2357,13 +2423,25 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function __updateMouseDrag():Void
 	{
-		if (mouseX > this.width - 1)
-		{
-			scrollH += Std.int(Math.max(Math.min((mouseX - this.width) * .1, 10), 1));
+		if (!rTL) {
+			if (mouseX > this.width - 1)
+			{
+				scrollH += Std.int(Math.max(Math.min((mouseX - this.width) * .1, 10), 1));
+			}
+			else if (mouseX < 1)
+			{
+				scrollH -= Std.int(Math.max(Math.min(mouseX * -.1, 10), 1));
+			}
 		}
-		else if (mouseX < 1)
-		{
-			scrollH -= Std.int(Math.max(Math.min(mouseX * -.1, 10), 1));
+		else {
+			if (mouseX < 0)
+			{
+				scrollH += Std.int(Math.max(Math.min((mouseX - this.width) * .1, 10), 1));
+			}
+			else if (mouseX > this.width - 1)
+			{
+				scrollH -= Std.int(Math.max(Math.min(mouseX * -.1, 10), 1));
+			}
 		}
 
 		__mouseScrollVCounter++;
@@ -3058,6 +3136,60 @@ class TextField extends InteractiveObject
 		return __textEngine.wordWrap = value;
 	}
 
+	@:noCompletion private function get_rTL():Bool
+	{
+		return __textEngine.rTL;
+	}
+
+	@:noCompletion private function set_rTL(value:Bool):Bool
+	{
+		if (value != __textEngine.rTL)
+		{
+			__setTransformDirty();
+			__dirty = true;
+			__layoutDirty = true;
+			__setRenderDirty();
+		}
+
+		return __textEngine.rTL = value;
+	}
+
+	@:noCompletion private function get_script():Null<TextScript>
+	{
+		return __textEngine.script;
+	}
+
+	@:noCompletion private function set_script(value:Null<TextScript>):Null<TextScript>
+	{
+		if (value != __textEngine.script)
+		{
+			__setTransformDirty();
+			__dirty = true;
+			__layoutDirty = true;
+			__setRenderDirty();
+		}
+
+		return __textEngine.script = value;
+	}
+
+	@:noCompletion private function get_language():String
+	{
+		return __textEngine.language;
+	}
+
+	@:noCompletion private function set_language(value:String):String
+	{
+		if (value != __textEngine.language)
+		{
+			__setTransformDirty();
+			__dirty = true;
+			__layoutDirty = true;
+			__setRenderDirty();
+		}
+
+		return __textEngine.language = value;
+	}
+
 	@:noCompletion private override function get_x():Float
 	{
 		return __transform.tx + __offsetX;
@@ -3089,7 +3221,7 @@ class TextField extends InteractiveObject
 		{
 			__updateLayout();
 
-			var position = __getPosition(mouseX + scrollH, mouseY);
+			var position = __getPosition(mouseX + (rTL ? -scrollH : scrollH), mouseY);
 
 			if (position != __caretIndex)
 			{
@@ -3130,7 +3262,7 @@ class TextField extends InteractiveObject
 			__getWorldTransform();
 			__updateLayout();
 
-			var upPos:Int = __getPosition(mouseX + scrollH, mouseY);
+			var upPos:Int = __getPosition(mouseX + (rTL ? -scrollH : scrollH), mouseY);
 			var leftPos:Int;
 			var rightPos:Int;
 
@@ -3226,7 +3358,7 @@ class TextField extends InteractiveObject
 
 		__updateLayout();
 
-		__caretIndex = __getPosition(mouseX + scrollH, mouseY);
+		__caretIndex = __getPosition(mouseX + (rTL ? -scrollH : scrollH), mouseY);
 		__selectionIndex = __caretIndex;
 
 		if (!DisplayObject.__supportDOM)

--- a/src/openfl/text/_internal/TextLayout.hx
+++ b/src/openfl/text/_internal/TextLayout.hx
@@ -171,7 +171,7 @@ class TextLayout
 					{
 						// TODO: Handle differently?
 
-						positions.push(new GlyphPosition(0, new Vector2(0, 0), new Vector2(0, 0)));
+						// positions.push(new GlyphPosition(0, new Vector2(0, 0), new Vector2(0, 0)));
 					}
 
 					positions.push(new GlyphPosition(info.codepoint, new Vector2(position.xAdvance / 64 + letterSpacing, position.yAdvance / 64),
@@ -481,10 +481,7 @@ class TextLayout
 	#if lime
 	@:to public inline function toHBScript():HBScript
 	{
-		return switch (this)
-		{
-			default: HBScript.COMMON;
-		}
+		return this.charCodeAt(0) << 24 | this.charCodeAt(1) << 16 | this.charCodeAt(2) << 8 | this.charCodeAt(3);
 	}
 	#end
 


### PR DESCRIPTION

https://github.com/openfl/openfl/issues/2505

So here are some basic rTL  for the textField .How does it work ? ( I wanted to follow flash way of doin it, but flash doesn't work on my computer, and it seems people needed to use some special libraries)

I have added the rTL,language and script attribute to the textAttribute.
Which mean you can some normal text written left to right.
```
	var textNormal = new TextField ();
		textNormal.x = 50;
		textNormal.y = 150;
		textNormal.embedFonts = true;
		textNormal.width = 500;
		textNormal.selectable = true;
		textNormal.text = "1234 567 12";
		textNormal.background = true;
		textNormal.rTL = true;
textNormal.backgroundColor = 0x00FF00;
textNormal.type = openfl.text.TextFieldType.INPUT;
```

You can also have some arabic, for example

```
		var format = new TextFormat (openfl.Assets.getFont("assets/NotoArabicUI.ttf").name, 30, 0x7A0026);
		textField = new TextField ();

textField.script = ARABIC;
textField.language = "ar";
		
		textField.defaultTextFormat = format;
		textField.embedFonts = true;
		textField.x = 50;
		textField.y = 50;
		textField.width = 500;
		textField.wordWrap = false;
		//textField.autoSize = openfl.text.TextFieldAutoSize.RIGHT;
textField.rTL = true;
```

I haven't tested on HTML5
What works:
  - ligatures
  - showing textfields left to right
  - selections

What still needs to be done
  - paragraphs
  - cutting long words
  - accepting some special unicode character which means lefttorigt or righttoleft ( so that you can easily have some arabic with numbers written ltr)
  
Noticed bugs:
- when you click  on a  character,, the caret goes to the right,  it shouldn't be the case.



