### PR TITLE
Restore precision hint in HTML5.

### DIFF
--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -482,7 +482,7 @@ class Shader
 			var gl = __context.gl;
 
 			#if (js && html5)
-			var prefix = "";
+			var prefix = (precisionHint == FULL ? "precision mediump float;\n" : "precision lowp float;\n");
 			#else
 			var prefix = "#ifdef GL_ES\n"
 				+ (precisionHint == FULL ? "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"


### PR DESCRIPTION
e0a3822 broke my HTML5 builds with the following message:

```text
[openfl.display.Shader] ERROR: Error compiling fragment shader
ERROR: 0:1: '' : No precision specified for (float)
ERROR: 0:2: '' : No precision specified for (float)
ERROR: 0:3: '' : No precision specified for (float)
ERROR: 0:4: '' : No precision specified for (float)
ERROR: 0:8: '' : No precision specified for (float)
ERROR: 0:12: '' : No precision specified for (float)
ERROR: 0:22: '' : No precision specified for (float)

varying float openfl_Alphav;
		varying vec4 openfl_ColorMultiplierv;
		varying vec4 openfl_ColorOffsetv;
		varying vec2 openfl_TextureCoordv;

		uniform bool openfl_HasColorTransform;
		uniform sampler2D openfl_Texture;
		uniform vec2 openfl_TextureSize;

		void main(void) {

			vec4 color = texture2D (openfl_Texture, openfl_TextureCoordv);

		if (color.a == 0.0) {

			gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0);

		} else if (openfl_HasColorTransform) {

			color = vec4 (color.rgb / color.a, color.a);

			mat4 colorMultiplier = mat4 (0);
			colorMultiplier[0][0] = openfl_ColorMultiplierv.x;
			colorMultiplier[1][1] = openfl_ColorMultiplierv.y;
			colorMultiplier[2][2] = openfl_ColorMultiplierv.z;
			colorMultiplier[3][3] = 1.0; // openfl_ColorMultiplierv.w;

			color = clamp (openfl_ColorOffsetv + (color * colorMultiplier), 0.0, 1.0);

			if (color.a > 0.0) {

				gl_FragColor = vec4 (color.rgb * color.a * openfl_Alphav, color.a * openfl_Alphav);

			} else {

				gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0);

			}

		} else {

			gl_FragColor = color * openfl_Alphav;

		}

		}
```

This might not be the only way to fix it, but it's one way.