### PR TITLE
Fix TextField behaviour wrt stopPropagation()

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -3123,9 +3123,9 @@ class TextField extends InteractiveObject
 	{
 		if (stage == null) return;
 
-		stage.removeEventListener(Event.ENTER_FRAME, this_onEnterFrame);
-		stage.removeEventListener(MouseEvent.MOUSE_MOVE, stage_onMouseMove);
-		stage.removeEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp);
+		stage.removeEventListener(Event.ENTER_FRAME, this_onEnterFrame, true);
+		stage.removeEventListener(MouseEvent.MOUSE_MOVE, stage_onMouseMove, true);
+		stage.removeEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp, true);
 
 		if (stage.focus == this)
 		{
@@ -3238,10 +3238,10 @@ class TextField extends InteractiveObject
 		}
 		#if !notextselectscroll
 		// Todo: Add flag and implementation for flash scrolling behavior.
-		stage.addEventListener(Event.ENTER_FRAME, this_onEnterFrame);
+		stage.addEventListener(Event.ENTER_FRAME, this_onEnterFrame, true);
 		#end
-		stage.addEventListener(MouseEvent.MOUSE_MOVE, stage_onMouseMove);
-		stage.addEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp);
+		stage.addEventListener(MouseEvent.MOUSE_MOVE, stage_onMouseMove, true);
+		stage.addEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp, true);
 	}
 
 	@:noCompletion private function this_onMouseWheel(event:MouseEvent):Void


### PR DESCRIPTION
TextFields should listen to stage events at the capture phase to ensure correct behaviour of text inputs when user code calls stopPropagation() in the event's target phase.

This PR is ready to be merged if this makes sense to you. It fixes the common situation where the parent of a text input stops the propagation of mouse up events, leading the text to be continuously in "selection mode", whereas in Flash it would still catch mouse inputs.