### PR TITLE
adding the CapLockcheck to work when the capLock works

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1545,8 +1545,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		{
 			var keyLocation = Keyboard.__getKeyLocation(keyCode);
 			var keyCode = Keyboard.__convertKeyCode(keyCode);
-			var capLockCheck = modifier.capsLock ? !modifier.shiftKey : modifier.shiftKey;
-			var charCode = Keyboard.__getCharCode(keyCode, capLockCheck);
+			var charCode = Keyboard.__getCharCode(keyCode, modifier.shiftKey, modifier.capsLock);
 
 			if (type == KeyboardEvent.KEY_UP && (keyCode == Keyboard.SPACE || keyCode == Keyboard.ENTER) && (__focus is Sprite))
 			{

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1545,7 +1545,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		{
 			var keyLocation = Keyboard.__getKeyLocation(keyCode);
 			var keyCode = Keyboard.__convertKeyCode(keyCode);
-			var charCode = Keyboard.__getCharCode(keyCode, modifier.shiftKey);
+			var capLockCheck = modifier.capsLock ? !modifier.shiftKey : modifier.shiftKey;
+			var charCode = Keyboard.__getCharCode(keyCode, capLockCheck);
 
 			if (type == KeyboardEvent.KEY_UP && (keyCode == Keyboard.SPACE || keyCode == Keyboard.ENTER) && (__focus is Sprite))
 			{

--- a/src/openfl/ui/Keyboard.hx
+++ b/src/openfl/ui/Keyboard.hx
@@ -811,8 +811,25 @@ import lime.ui.KeyCode;
 	}
 	#end
 
-	@:noCompletion private static function __getCharCode(key:Int, shift:Bool = false):Int
+	@:noCompletion private static function __getCharCode(key:Int, shift:Bool = false, capLock:Bool = false):Int
 	{
+		if (capLock)
+		{
+			if (!shift)
+			{
+				if (key >= Keyboard.A && key <= Keyboard.Z)
+				{
+					return key;
+				}
+			}
+			else
+			{
+				if (key >= Keyboard.A && key <= Keyboard.Z)
+				{
+					return key + 32;
+				}
+			}
+		}
 		if (!shift)
 		{
 			switch (key)
@@ -858,7 +875,7 @@ import lime.ui.KeyCode;
 
 			if (key >= Keyboard.A && key <= Keyboard.Z)
 			{
-				return key - Keyboard.A + 97;
+				return key + 32;
 			}
 		}
 		else
@@ -911,7 +928,7 @@ import lime.ui.KeyCode;
 
 			if (key >= Keyboard.A && key <= Keyboard.Z)
 			{
-				return key - Keyboard.A + 65;
+				return key;
 			}
 		}
 


### PR DESCRIPTION
When I was looking into keyboard stuff cos I had problems with adding fancy stuff like a ~ on top of a N or vowels with accents and stuff like that.

When I discovered that the CapLock thing doesn't work when inputting text in-game.

This makes a small fix.

(Small feature but it inputs well when inspecting and also good when adding textboxes lol)