### PR TITLE
Haxe 3 support

### DIFF
--- a/src/openfl/utils/Object.hx
+++ b/src/openfl/utils/Object.hx
@@ -5,6 +5,7 @@ import openfl.display.DisplayObjectContainer;
 
 @:transitive
 @:callable
+#if !haxe4 @:forward #end
 abstract Object(ObjectType) from ObjectType from Dynamic to Dynamic
 {
 	public inline function new()


### PR DESCRIPTION
These changes are required to compile DisplayingABitmap in Haxe 3.4.7.

At some point - not necessarily now - we could consider dropping Haxe 3 support, allowing for cleaner code. Looking through the forums, it seems there were [only three references to "Haxe 3" within 2021](https://community.openfl.org/search?q=%22haxe%203%22%20order%3Alatest). Not a whole lot, though admittedly still greater than zero.

Note: the latest released version of OpenFL works in Haxe 3, because everything broken was added more recently than that.