### PR TITLE
Add public functions for retrieving lists of cached assets.

### DIFF
--- a/src/openfl/utils/AssetCache.hx
+++ b/src/openfl/utils/AssetCache.hx
@@ -79,11 +79,22 @@ class AssetCache implements IAssetCache
 	**/
 	public function clear(prefix:String = null):Void
 	{
+		clearBitmapData(prefix);
+		clearFonts(prefix);
+		clearSounds(prefix);
+	}
+
+	/**
+		Clears all cached Bitmap assets, or all assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function clearBitmapData(prefix:String = null):Void
+	{
 		if (prefix == null)
 		{
 			bitmapData = new Map<String, BitmapData>();
-			font = new Map<String, Font>();
-			sound = new Map<String, Sound>();
 		}
 		else
 		{
@@ -91,12 +102,44 @@ class AssetCache implements IAssetCache
 			{
 				removeBitmapData(key);
 			}
+		}
+	}
 
+	/**
+		Clears all cached Font assets, or all assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function clearFonts(prefix:String = null):Void
+	{
+		if (prefix == null)
+		{
+			font = new Map<String, Font>();
+		}
+		else
+		{
 			for (key in getFontKeys(prefix))
 			{
 				removeFont(key);
 			}
+		}
+	}
 
+	/**
+		Clears all cached Sound assets, or all assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function clearSounds(prefix:String = null):Void
+	{
+		if (prefix == null)
+		{
+			sound = new Map<String, Sound>();
+		}
+		else
+		{
 			for (key in getSoundKeys(prefix))
 			{
 				removeSound(key);
@@ -137,7 +180,7 @@ class AssetCache implements IAssetCache
 
 		@param	prefix	A ID prefix
 	**/
-	public function getBitmapKeys(prefix:String):Array<String>
+	public function getBitmapKeys(prefix:String = null):Array<String>
 	{
 		var result = [];
 		if (prefix == null)
@@ -166,7 +209,7 @@ class AssetCache implements IAssetCache
 
 		@param	prefix	A ID prefix
 	**/
-	public function getFontKeys(prefix:String):Array<String>
+	public function getFontKeys(prefix:String = null):Array<String>
 	{
 		var result = [];
 		if (prefix == null)
@@ -195,7 +238,7 @@ class AssetCache implements IAssetCache
 
 		@param	prefix	A ID prefix
 	**/
-	public function getSoundKeys(prefix:String):Array<String>
+	public function getSoundKeys(prefix:String = null):Array<String>
 	{
 		var result = [];
 		if (prefix == null)

--- a/src/openfl/utils/AssetCache.hx
+++ b/src/openfl/utils/AssetCache.hx
@@ -87,36 +87,135 @@ class AssetCache implements IAssetCache
 		}
 		else
 		{
-			var keys = bitmapData.keys();
-
-			for (key in keys)
+			for (key in getBitmapKeys(prefix))
 			{
-				if (StringTools.startsWith(key, prefix))
-				{
-					removeBitmapData(key);
-				}
+				removeBitmapData(key);
 			}
 
-			var keys = font.keys();
-
-			for (key in keys)
+			for (key in getFontKeys(prefix))
 			{
-				if (StringTools.startsWith(key, prefix))
-				{
-					removeFont(key);
-				}
+				removeFont(key);
 			}
 
-			var keys = sound.keys();
+			for (key in getSoundKeys(prefix))
+			{
+				removeSound(key);
+			}
+		}
+	}
 
-			for (key in keys)
+	/**
+		Returns the IDs of all assets with an ID that
+		matches an optional prefix.
+
+		For example:
+
+		```haxe
+		Assets.setBitmapData("image1", image1);
+		Assets.setBitmapData("assets/image2", image2);
+
+		Assets.getKeys("assets"); // will return ["assets/image2"]
+		Assets.getKeys("image"); // will return ["image1"]
+		```
+
+		@param	prefix	A ID prefix
+	**/
+	public function getKeys(prefix:String = null):Array<String>
+	{
+		var result = [];
+
+		result = result.concat(getBitmapKeys(prefix));
+		result = result.concat(getFontKeys(prefix));
+		result = result.concat(getSoundKeys(prefix));
+
+		return result;
+	}
+
+	/**
+		Returns the IDs of all BitmapData assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function getBitmapKeys(prefix:String):Array<String>
+	{
+		var result = [];
+		if (prefix == null)
+		{
+			for (key in bitmapData.keys())
+			{
+				result.push(key);
+			}
+		}
+		else
+		{
+			for (key in bitmapData.keys())
 			{
 				if (StringTools.startsWith(key, prefix))
 				{
-					removeSound(key);
+					result.push(key);
 				}
 			}
 		}
+		return result;
+	}
+
+	/**
+		Returns the IDs of all Font assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function getFontKeys(prefix:String):Array<String>
+	{
+		var result = [];
+		if (prefix == null)
+		{
+			for (key in font.keys())
+			{
+				result.push(key);
+			}
+		}
+		else
+		{
+			for (key in font.keys())
+			{
+				if (StringTools.startsWith(key, prefix))
+				{
+					result.push(key);
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+		Returns the IDs of all Sound assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function getSoundKeys(prefix:String):Array<String>
+	{
+		var result = [];
+		if (prefix == null)
+		{
+			for (key in sound.keys())
+			{
+				result.push(key);
+			}
+		}
+		else
+		{
+			for (key in sound.keys())
+			{
+				if (StringTools.startsWith(key, prefix))
+				{
+					result.push(key);
+				}
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/src/openfl/utils/AssetCache.hx
+++ b/src/openfl/utils/AssetCache.hx
@@ -165,7 +165,7 @@ class AssetCache implements IAssetCache
 	**/
 	public function getKeys(prefix:String = null):Array<String>
 	{
-		var result = [];
+		var result:Array<String> = [];
 
 		result = result.concat(getBitmapKeys(prefix));
 		result = result.concat(getFontKeys(prefix));
@@ -182,7 +182,7 @@ class AssetCache implements IAssetCache
 	**/
 	public function getBitmapKeys(prefix:String = null):Array<String>
 	{
-		var result = [];
+		var result:Array<String> = [];
 		if (prefix == null)
 		{
 			for (key in bitmapData.keys())
@@ -211,7 +211,7 @@ class AssetCache implements IAssetCache
 	**/
 	public function getFontKeys(prefix:String = null):Array<String>
 	{
-		var result = [];
+		var result:Array<String> = [];
 		if (prefix == null)
 		{
 			for (key in font.keys())
@@ -240,7 +240,7 @@ class AssetCache implements IAssetCache
 	**/
 	public function getSoundKeys(prefix:String = null):Array<String>
 	{
-		var result = [];
+		var result:Array<String> = [];
 		if (prefix == null)
 		{
 			for (key in sound.keys())

--- a/src/openfl/utils/IAssetCache.hx
+++ b/src/openfl/utils/IAssetCache.hx
@@ -35,6 +35,72 @@ interface IAssetCache
 	public function clear(prefix:String = null):Void;
 
 	/**
+		Clears all cached Bitmap assets, or all assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function clearBitmapData(prefix:String = null):Void;
+
+	/**
+		Clears all cached Font assets, or all assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function clearFonts(prefix:String = null):Void;
+
+	/**
+		Clears all cached Sound assets, or all assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function clearSounds(prefix:String = null):Void;
+
+	/**
+		Returns the IDs of all assets with an ID that
+		matches an optional prefix.
+
+		For example:
+
+		```haxe
+		Assets.setBitmapData("image1", image1);
+		Assets.setBitmapData("assets/image2", image2);
+
+		Assets.getKeys("assets"); // will return ["assets/image2"]
+		Assets.getKeys("image"); // will return ["image1"]
+		```
+
+		@param	prefix	A ID prefix
+	**/
+	public function getKeys(prefix:String = null):Array<String>;
+
+	/**
+		Returns the IDs of all BitmapData assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function getBitmapKeys(prefix:String = null):Array<String>;
+
+	/**
+		Returns the IDs of all Font assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function getFontKeys(prefix:String = null):Array<String>;
+
+	/**
+		Returns the IDs of all Sound assets with an ID that
+		matches an optional prefix.
+
+		@param	prefix	A ID prefix
+	**/
+	public function getSoundKeys(prefix:String = null):Array<String>;
+
+	/**
 		Retrieves a cached BitmapData.
 
 		@param	id	The ID of the cached BitmapData


### PR DESCRIPTION
This PR adds the following functions to the AssetCache:

- `getKeys(prefix:String = null):Array<String>`
- `getBitmapKeys(prefix:String = null):Array<String>`
- `getFontKeys(prefix:String = null):Array<String>`
- `getSoundKeys(prefix:String = null):Array<String>`
- `clearBitmapData(prefix:String = null):Void`
- `clearFonts(prefix:String = null):Void`
- `clearSounds(prefix:String = null):Void`

These functions should allow for applications to better manage and cleanup any cached assets they wish to explicitly unload.