### PR TITLE
Fix TextEngine segfault in HashLink.

### DIFF
--- a/src/openfl/text/_internal/TextEngine.hx
+++ b/src/openfl/text/_internal/TextEngine.hx
@@ -1427,7 +1427,7 @@ class TextEngine
 						var i = layoutGroups.length - 1;
 						var offsetCount = 0;
 
-						while (true)
+						while (#if hl i >= 0 #else true #end)
 						{
 							layoutGroup = layoutGroups[i];
 


### PR DESCRIPTION
HashLink crashes if you try to access a negative array index, while other platforms are fine.

You can easily reproduce this using FeathersUI:

```haxe
var textArea = new feathers.controls.TextArea();
textArea.width = 50;
textArea.text = "Enough for word wrap";
textArea.validateNow();
```