### PR TITLE
TextEngine: better restrict

### DIFF
--- a/src/openfl/text/_internal/TextEngine.hx
+++ b/src/openfl/text/_internal/TextEngine.hx
@@ -167,7 +167,7 @@ class TextEngine
 
 	private function createRestrictRegexp(restrict:String):EReg
 	{
-		var declinedRange = ~/\^(.-.|.)/gu;
+		var declinedRange = ~/\^(.+)/gu;
 		var declined = "";
 
 		var accepted = declinedRange.map(restrict, function(ereg)


### PR DESCRIPTION

In flash every character is excluded after '^'.

