### PR TITLE
Added ability to turn off off-screen rendering

### DIFF
--- a/src/openfl/display/Tile.hx
+++ b/src/openfl/display/Tile.hx
@@ -53,6 +53,13 @@ class Tile
 	@:beta public var colorTransform(get, set):ColorTransform;
 
 	/**
+		Disabling this property disables the rendering of off-screen tile.
+
+		This property is supported in all renderers except the dom.
+	**/
+	public var offscreenRendering(default, default):Bool;
+
+	/**
 		An additional field for custom user-data
 	**/
 	@SuppressWarnings("checkstyle:Dynamic") public var data:Dynamic;
@@ -190,6 +197,7 @@ class Tile
 	@:noCompletion private var __alpha:Float;
 	@:noCompletion private var __blendMode:BlendMode;
 	@:noCompletion private var __colorTransform:ColorTransform;
+	@:noCompletion private var __render:Bool;
 	@:noCompletion private var __dirty:Bool;
 	@:noCompletion private var __id:Int;
 	@:noCompletion private var __length:Int;
@@ -293,6 +301,7 @@ class Tile
 		if (scaleY != 1) this.scaleY = scaleY;
 		if (rotation != 0) this.rotation = rotation;
 
+		offscreenRendering = true;
 		__dirty = true;
 		__length = 0;
 		__originX = originX;

--- a/src/openfl/display/_internal/CairoTilemap.hx
+++ b/src/openfl/display/_internal/CairoTilemap.hx
@@ -44,7 +44,7 @@ class CairoTilemap
 		rect.setTo(0, 0, tilemap.__width, tilemap.__height);
 		renderer.__pushMaskRect(rect, tilemap.__renderTransform);
 
-		renderTileContainer(tilemap.__group, renderer, tilemap.__renderTransform, tilemap.__tileset, (renderer.__allowSmoothing && tilemap.smoothing),
+		renderTileContainer(tilemap, tilemap.__group, renderer, tilemap.__renderTransform, tilemap.__tileset, (renderer.__allowSmoothing && tilemap.smoothing),
 			tilemap.tileAlphaEnabled, alpha, tilemap.tileBlendModeEnabled, tilemap.__worldBlendMode, null, null, null, rect,
 			#if lime new Matrix3() #else null #end);
 
@@ -55,10 +55,10 @@ class CairoTilemap
 	}
 
 	@SuppressWarnings("checkstyle:Dynamic")
-	private static function renderTileContainer(group:TileContainer, renderer:CairoRenderer, parentTransform:Matrix, defaultTileset:Tileset, smooth:Bool,
+	private static function renderTileContainer(tilemap:Tilemap, group:TileContainer, renderer:CairoRenderer, parentTransform:Matrix, defaultTileset:Tileset, smooth:Bool,
 			alphaEnabled:Bool, worldAlpha:Float, blendModeEnabled:Bool, defaultBlendMode:BlendMode, cacheBitmapData:BitmapData,
 			surface:#if lime CairoSurface #else Dynamic #end, pattern:#if lime CairoPattern #else Dynamic #end, rect:Rectangle,
-			matrix:#if lime Matrix3 #else Dynamic #end):Void
+			matrix:#if lime Matrix3 #else Dynamic #end, containerX:Float = 0.0, containerY:Float = 0.0):Void
 	{
 		#if lime
 		var cairo = renderer.cairo;
@@ -76,17 +76,54 @@ class CairoTilemap
 			tileData,
 			tileRect,
 			bitmapData;
+		var actualTileX, actualTileY, tileWidth, tileHeight;
+
+		var tilemapWidth = tilemap.__width / Math.abs(tilemap.__scaleX);
+		var tilemapHeight = tilemap.__height / Math.abs(tilemap.__scaleY);
 
 		for (tile in tiles)
 		{
+			id = tile.id;
+			tileset = tile.tileset != null ? tile.tileset : defaultTileset;
+			alpha = tile.alpha * worldAlpha;
+			visible = tile.visible;
+
+			if(tile.__length == 0 && !tile.offscreenRendering)
+			{
+				if (id == -1)
+				{
+					tileRect = tile.__rect;
+					if (tileRect == null || tileRect.width <= 0 || tileRect.height <= 0)
+					{
+						continue;
+					}
+
+					tileWidth = tileRect.width;
+					tileHeight = tileRect.height;
+				}else{
+					tileData = tileset.__data[id];
+					if (tileData == null)
+					{
+						continue;
+					}
+
+					tileWidth = tileData.width;
+					tileHeight = tileData.height;
+				}
+
+				actualTileX = containerX + tile.x;
+				actualTileY = containerY + tile.y;
+
+				if(actualTileX + tileWidth < 0 || actualTileX > tilemapWidth || actualTileY + tileHeight < 0 || actualTileY > tilemapHeight)
+				{
+					continue;
+				}
+			}
+
 			tileTransform.setTo(1, 0, 0, 1, -tile.originX, -tile.originY);
 			tileTransform.concat(tile.matrix);
 			tileTransform.concat(parentTransform);
 
-			tileset = tile.tileset != null ? tile.tileset : defaultTileset;
-
-			alpha = tile.alpha * worldAlpha;
-			visible = tile.visible;
 			if (!visible || alpha <= 0) continue;
 
 			if (!alphaEnabled) alpha = 1;
@@ -98,14 +135,12 @@ class CairoTilemap
 
 			if (tile.__length > 0)
 			{
-				renderTileContainer(cast tile, renderer, tileTransform, tileset, smooth, alphaEnabled, alpha, blendModeEnabled, blendMode, cacheBitmapData,
-					surface, pattern, rect, matrix);
+				renderTileContainer(tilemap, cast tile, renderer, tileTransform, tileset, smooth, alphaEnabled, alpha, blendModeEnabled, blendMode, cacheBitmapData,
+					surface, pattern, rect, matrix, containerX + tile.x, containerY + tile.y);
 			}
 			else
 			{
 				if (tileset == null) continue;
-
-				id = tile.id;
 
 				if (id == -1)
 				{

--- a/src/openfl/display/_internal/CanvasTilemap.hx
+++ b/src/openfl/display/_internal/CanvasTilemap.hx
@@ -46,7 +46,7 @@ class CanvasTilemap
 			context.imageSmoothingEnabled = false;
 		}
 
-		renderTileContainer(tilemap.__group, renderer, tilemap.__renderTransform, tilemap.__tileset, (renderer.__allowSmoothing && tilemap.smoothing),
+		renderTileContainer(tilemap, tilemap.__group, renderer, tilemap.__renderTransform, tilemap.__tileset, (renderer.__allowSmoothing && tilemap.smoothing),
 			tilemap.tileAlphaEnabled, alpha, tilemap.tileBlendModeEnabled, tilemap.__worldBlendMode, null, null, rect);
 
 		if (!renderer.__allowSmoothing || !tilemap.smoothing)
@@ -62,9 +62,9 @@ class CanvasTilemap
 	}
 
 	@SuppressWarnings("checkstyle:Dynamic")
-	private static function renderTileContainer(group:TileContainer, renderer:CanvasRenderer, parentTransform:Matrix, defaultTileset:Tileset, smooth:Bool,
+	private static function renderTileContainer(tilemap:Tilemap, group:TileContainer, renderer:CanvasRenderer, parentTransform:Matrix, defaultTileset:Tileset, smooth:Bool,
 			alphaEnabled:Bool, worldAlpha:Float, blendModeEnabled:Bool, defaultBlendMode:BlendMode, cacheBitmapData:BitmapData, source:Dynamic,
-			rect:Rectangle):Void
+			rect:Rectangle, containerX:Float = 0.0, containerY:Float = 0.0):Void
 	{
 		#if (js && html5)
 		var context = renderer.context;
@@ -84,10 +84,51 @@ class CanvasTilemap
 			tileData,
 			tileRect,
 			bitmapData;
+		var actualTileX, actualTileY, tileWidth, tileHeight;
+
+		var tilemapWidth = tilemap.__width / Math.abs(tilemap.__scaleX);
+		var tilemapHeight = tilemap.__height / Math.abs(tilemap.__scaleY);
 
 		for (i in 0...length)
 		{
 			tile = tiles[i];
+
+			id = tile.id;
+			tileset = tile.tileset != null ? tile.tileset : defaultTileset;
+			alpha = tile.alpha * worldAlpha;
+			visible = tile.visible;
+
+			if(tile.__length == 0 && !tile.offscreenRendering)
+			{
+				if (id == -1)
+				{
+					tileRect = tile.__rect;
+					if (tileRect == null || tileRect.width <= 0 || tileRect.height <= 0)
+					{
+						continue;
+					}
+
+					tileWidth = tileRect.width;
+					tileHeight = tileRect.height;
+				}else{
+					tileData = tileset.__data[id];
+					if (tileData == null)
+					{
+						continue;
+					}
+
+					tileWidth = tileData.width;
+					tileHeight = tileData.height;
+				}
+
+				actualTileX = containerX + tile.x;
+				actualTileY = containerY + tile.y;
+
+				if(actualTileX + tileWidth < 0 || actualTileX > tilemapWidth || actualTileY + tileHeight < 0 || actualTileY > tilemapHeight)
+				{
+					continue;
+				}
+			}
 
 			tileTransform.setTo(1, 0, 0, 1, -tile.originX, -tile.originY);
 			tileTransform.concat(tile.matrix);
@@ -99,10 +140,6 @@ class CanvasTilemap
 				tileTransform.ty = Math.round(tileTransform.ty);
 			}
 
-			tileset = tile.tileset != null ? tile.tileset : defaultTileset;
-
-			alpha = tile.alpha * worldAlpha;
-			visible = tile.visible;
 			if (!visible || alpha <= 0) continue;
 
 			if (!alphaEnabled) alpha = 1;
@@ -114,14 +151,12 @@ class CanvasTilemap
 
 			if (tile.__length > 0)
 			{
-				renderTileContainer(cast tile, renderer, tileTransform, tileset, smooth, alphaEnabled, alpha, blendModeEnabled, blendMode, cacheBitmapData,
-					source, rect);
+				renderTileContainer(tilemap, cast tile, renderer, tileTransform, tileset, smooth, alphaEnabled, alpha, blendModeEnabled, blendMode, cacheBitmapData,
+					source, rect, containerX + tile.x, containerY + tile.y);
 			}
 			else
 			{
 				if (tileset == null) continue;
-
-				id = tile.id;
 
 				if (id == -1)
 				{


### PR DESCRIPTION
### What is this?

It is a property that determines whether tiles that are off the screen are drawn or not.

### How can I use this feature?

Offscreen rendering can be set using the tile.offscreenRendering property.
```hx
tile.offscreenRendering = true; //Enables offscreen rendering (default and current behavior)
tile.offscreenRendering = false; //Disable offscreen rendering
```

### Will this affect the behavior of my current project?

It is turned on by default so that existing projects are not affected.

### How does it determine whether it is in the screen or not?

It works according to the width and height of the tilemap, if it overflows the tilemap, it does not render and skips the calculations required for drawing.

It is affected by the tilemap's scaleX and scaleY values, so it always draws exactly the area on the screen.

### Which renderers are supported?

All renderers are supported except the dom renderer.