### PR TITLE
Performance improvement, Use the queue method to update the objects that need to be updated.

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1738,7 +1738,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		__updateTransforms();
 
 		#if (queue_experimental_optimization && !dom)
-		__updateFlag(false);
 		transformOnly = false;
 		#end
 

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1735,6 +1735,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 		#if (queue_experimental_optimization && !dom)
 		__updateFlag(false);
+		transformOnly = false;
 		#end
 
 		// if (updateChildren && __transformDirty) {

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1672,17 +1672,21 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 	}
 
 	#if (queue_experimental_optimization && !dom)
+	@:noCompletion private var _flag:Bool = false;
+
 	@:noCompletion private function __updateFlag(add:Bool = true):Void
 	{
 		if (add)
 		{
-			if (DisplayObject.queue.indexOf(this) == -1)
+			if (!_flag)
 			{
+				_flag = true;
 				DisplayObject.queue.push(this);
 			}
 		}
 		else
 		{
+			_flag = false;
 			DisplayObject.queue.remove(this);
 		}
 	}

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1733,6 +1733,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		__renderable = (__visible && __scaleX != 0 && __scaleY != 0 && !__isMask && (renderParent == null || !renderParent.__isMask));
 		__updateTransforms();
 
+		#if (queue_experimental_optimization && !dom)
+		__updateFlag(false);
+		#end
+
 		// if (updateChildren && __transformDirty) {
 
 		__transformDirty = false;

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -181,6 +181,10 @@ import js.html.CSSStyleDeclaration;
 @:access(openfl.geom.Transform)
 class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (openfl_dynamic && haxe_ver < "4.0.0") implements Dynamic<DisplayObject> #end
 {
+	#if (queue_experimental_optimization && !dom)
+	@:noCompletion private static var queue:Array<DisplayObject> = [];
+	#end
+
 	@:noCompletion private static var __broadcastEvents:Map<String, Array<DisplayObject>> = new Map();
 	@:noCompletion private static var __initStage:Stage;
 	@:noCompletion private static var __instanceCount:Int = 0;
@@ -1667,6 +1671,23 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		}
 	}
 
+	#if (queue_experimental_optimization && !dom)
+	@:noCompletion private function __updateFlag(add:Bool = true):Void
+	{
+		if (add)
+		{
+			if (DisplayObject.queue.indexOf(this) == -1)
+			{
+				DisplayObject.queue.push(this);
+			}
+		}
+		else
+		{
+			DisplayObject.queue.remove(this);
+		}
+	}
+	#end
+
 	@:noCompletion private inline function __setRenderDirty():Void
 	{
 		if (!__renderDirty)
@@ -1674,6 +1695,9 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 			__renderDirty = true;
 			__setParentRenderDirty();
 		}
+		#if (queue_experimental_optimization && !dom)
+		__updateFlag();
+		#end
 	}
 
 	@:noCompletion private function __setStageReference(stage:Stage):Void
@@ -1690,6 +1714,9 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 			__setWorldTransformInvalid();
 			__setParentRenderDirty();
 		}
+		#if (queue_experimental_optimization && !dom)
+		__updateFlag();
+		#end
 	}
 
 	@:noCompletion private function __setWorldTransformInvalid():Void
@@ -1737,15 +1764,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 					var worldVisible = (renderParent.__worldVisible && __visible);
 					__worldVisibleChanged = (__worldVisible != worldVisible);
 					__worldVisible = worldVisible;
-
-					var worldAlpha = alpha * renderParent.__worldAlpha;
-					__worldAlphaChanged = (__worldAlpha != worldAlpha);
-					__worldAlpha = worldAlpha;
 				}
-				else
-				{
-					__worldAlpha = alpha * renderParent.__worldAlpha;
-				}
+				var worldAlpha = alpha * renderParent.__worldAlpha;
+				__worldAlphaChanged = (__worldAlpha != worldAlpha);
+				__worldAlpha = worldAlpha;
 
 				if (__objectTransform != null)
 				{
@@ -1793,9 +1815,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 				{
 					__worldVisibleChanged = (__worldVisible != __visible);
 					__worldVisible = __visible;
-
-					__worldAlphaChanged = (__worldAlpha != alpha);
 				}
+				__worldAlphaChanged = (__worldAlpha != alpha);
 
 				if (__objectTransform != null)
 				{

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1674,7 +1674,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 	#if (queue_experimental_optimization && !dom)
 	@:noCompletion private var _flag:Bool = false;
 
-	@:noCompletion private function __updateFlag(add:Bool = true):Void
+	@:noCompletion inline private function __updateFlag(add:Bool = true):Void
 	{
 		if (add)
 		{

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -964,7 +964,8 @@ class DisplayObjectContainer extends InteractiveObject
 		super.__update(transformOnly, updateChildren);
 
 		#if (queue_experimental_optimization && !dom)
-		updateChildren = true;
+		// Don't!
+		// updateChildren = true;
 		#end
 
 		if (updateChildren)

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -43,6 +43,10 @@ import openfl.Vector;
 @:access(openfl.geom.Rectangle)
 class DisplayObjectContainer extends InteractiveObject
 {
+	#if (queue_experimental_optimization && !dom)
+	public var __updateRequired:Bool = true;
+	#end
+
 	/**
 		Determines whether or not the children of the object are mouse, or user
 		input device, enabled. If an object is enabled, a user can interact with
@@ -962,11 +966,6 @@ class DisplayObjectContainer extends InteractiveObject
 	@:noCompletion private override function __update(transformOnly:Bool, updateChildren:Bool):Void
 	{
 		super.__update(transformOnly, updateChildren);
-
-		#if (queue_experimental_optimization && !dom)
-		// Don't!
-		// updateChildren = true;
-		#end
 
 		if (updateChildren)
 		{

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -43,11 +43,6 @@ import openfl.Vector;
 @:access(openfl.geom.Rectangle)
 class DisplayObjectContainer extends InteractiveObject
 {
-
-	#if (queue_experimental_optimization && !dom)
-	@:noCompletion private var __updateRequired:Bool = true;
-	#end
-
 	/**
 		Determines whether or not the children of the object are mouse, or user
 		input device, enabled. If an object is enabled, a user can interact with

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -43,6 +43,11 @@ import openfl.Vector;
 @:access(openfl.geom.Rectangle)
 class DisplayObjectContainer extends InteractiveObject
 {
+
+	#if (queue_experimental_optimization && !dom)
+	@:noCompletion private var __updateRequired:Bool = true;
+	#end
+
 	/**
 		Determines whether or not the children of the object are mouse, or user
 		input device, enabled. If an object is enabled, a user can interact with

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -963,6 +963,10 @@ class DisplayObjectContainer extends InteractiveObject
 	{
 		super.__update(transformOnly, updateChildren);
 
+		#if (queue_experimental_optimization && !dom)
+		updateChildren = true;
+		#end
+
 		if (updateChildren)
 		{
 			for (child in __children)

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -3220,7 +3220,9 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			}
 
 			displayObject.__update(transformOnly, updateChildren);
-			displayObject.__updateFlag(false);
+			// displayObject.__updateFlag(false);
+			@:privateAccess displayObject._flag = false;
+			DisplayObject.queue.shift();
 		}
 
 		for (i in 0...updateFix.length)

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -3207,10 +3207,25 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	#if (queue_experimental_optimization && !dom)
 	@:noCompletion private function __updateQueue(transformOnly:Bool, updateChildren:Bool):Void
 	{
+		var updateFix:Array<DisplayObjectContainer> = [];
 		while (DisplayObject.queue.length != 0)
 		{
 			var displayObject:DisplayObject = DisplayObject.queue[0];
+			var parentDisplayObject:DisplayObjectContainer = cast displayObject.parent;
+			if (parentDisplayObject != null && parentDisplayObject.__updateRequired == true && parentDisplayObject != this)
+			{
+				parentDisplayObject.__update(transformOnly, false);
+				parentDisplayObject.__updateRequired = false;
+				updateFix.push(parentDisplayObject);
+			}
+
 			displayObject.__update(transformOnly, updateChildren);
+			displayObject.__updateFlag(false);
+		}
+
+		for (i in 0...updateFix.length)
+		{
+			updateFix[i].__updateRequired = true;
 		}
 	}
 	#else

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -3205,34 +3205,15 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	}
 
 	#if (queue_experimental_optimization && !dom)
-
 	@:noCompletion private function __updateQueue(transformOnly:Bool, updateChildren:Bool):Void
 	{
-		var updateFix:Array<DisplayObjectContainer> = [];
 		while (DisplayObject.queue.length != 0)
 		{
 			var displayObject:DisplayObject = DisplayObject.queue[0];
-			if (displayObject.parent != null
-				&& cast(displayObject.parent, DisplayObjectContainer).__updateRequired == true && displayObject.parent != this)
-			{
-				var displayObjectContainer:DisplayObjectContainer = cast displayObject.parent;
-				displayObjectContainer.__update(transformOnly, false);
-				displayObjectContainer.__updateRequired = false;
-				updateFix.push(displayObjectContainer);
-			}
-
 			displayObject.__update(transformOnly, updateChildren);
-			displayObject.__updateFlag(false);
-		}
-
-		for (i in 0...updateFix.length)
-		{
-			updateFix[i].__updateRequired = true;
 		}
 	}
-
 	#else
-
 	@:noCompletion private override function __update(transformOnly:Bool, updateChildren:Bool):Void
 	{
 		if (transformOnly)
@@ -3287,7 +3268,6 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			**/
 		}
 	}
-
 	#end
 
 	// Get & Set Methods


### PR DESCRIPTION
Use the queue method to update the objects that need to be updated.

At present, it is known that there are rendering problems in DOM, so DOM will maintain the original implementation.

Current performance improvement needs to open definition `queue_experimental_optimization` use:

```xml
<haxedef name="queue_experimental_optimization"/>
```