### PR TITLE
Fix for letter placements with small font sizes

### DIFF
--- a/src/openfl/text/_internal/TextLayout.hx
+++ b/src/openfl/text/_internal/TextLayout.hx
@@ -119,7 +119,7 @@ class TextLayout
 
 				if (autoHint)
 				{
-					__hbFont.loadFlags = FT_LOAD_FORCE_AUTOHINT | FT_LOAD_TARGET_LIGHT;
+					__hbFont.loadFlags = FT_LOAD_TARGET_LIGHT;
 				}
 			}
 			else


### PR DESCRIPTION
ShallowMallow found the line causing the issue with weird letter spacing on non-mono-spaced fonts. its in line 112 in `TextLayout.hx`:

```haxe
__hbFont.loadFlags = /* FT_LOAD_FORCE... is causing the issue */ FT_LOAD_FORCE_AUTOHINT | FT_LOAD_TARGET_LIGHT;
```

This PR fixes it. full credit goes to ShallowMallow, he just has another pr going with rtl support.

Fix works (& tested) on:
Mac
Linux
Windows
Android (big & small screens, probably not needed tho)