### PR TITLE
Render TextField at correct canvas pixelRatio

### DIFF
--- a/src/openfl/display/CanvasRenderer.hx
+++ b/src/openfl/display/CanvasRenderer.hx
@@ -14,6 +14,9 @@ import openfl.geom.Rectangle;
 #if lime
 import lime.graphics.Canvas2DRenderContext;
 #end
+#if (js && html5)
+import js.Browser;
+#end
 
 /**
 	**BETA**
@@ -49,6 +52,10 @@ class CanvasRenderer extends DisplayObjectRenderer
 		super();
 
 		this.context = context;
+    
+        #if (js && html5 && !openfl_disable_hdpi)
+        __pixelRatio = Math.floor(Browser.window.devicePixelRatio);
+        #end
 
 		__tempMatrix = new Matrix();
 

--- a/src/openfl/display/_internal/CanvasTextField.hx
+++ b/src/openfl/display/_internal/CanvasTextField.hx
@@ -95,7 +95,7 @@ class CanvasTextField
 			#if (openfl_disable_hdpi || openfl_disable_hdpi_textfield)
 			var pixelRatio = 1;
 			#else
-			var pixelRatio = renderer.__pixelRatio;
+			var pixelRatio = (renderer.__pixelRatio > 1) ? (renderer.__pixelRatio * 2) : renderer.__pixelRatio;
 			#end
 
 			var width = Math.round(graphics.__width * pixelRatio);


### PR DESCRIPTION
CanvasTextFields can have a null renderer and are never passed the correct pixelRatio. To achieve crisp graphics on HiDPI screens, the TextField needs to be doubled before being scaled back down. Fixes #2568 