### PR TITLE
Added pan to lime AudioSources, so use that for pan instead of position

### DIFF
--- a/src/openfl/media/Sound.hx
+++ b/src/openfl/media/Sound.hx
@@ -646,11 +646,7 @@ class Sound extends EventDispatcher
 		if (loops > 1) source.loops = loops - 1;
 
 		source.gain = volume;
-
-		var position = source.position;
-		position.x = pan;
-		position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
-		source.position = position;
+		if(pan != 0) source.pan = pan;
 
 		return new SoundChannel(source, sndTransform);
 		#else

--- a/src/openfl/media/SoundChannel.hx
+++ b/src/openfl/media/SoundChannel.hx
@@ -187,12 +187,11 @@ import lime.media.AudioSource;
 			{
 				#if lime
 				__source.gain = volume;
-
-				var position = __source.position;
-				position.x = pan;
-				position.z = -1 * Math.sqrt(1 - Math.pow(pan, 2));
-				__source.position = position;
-
+				if(pan != 0 || __source.pan != null)
+				{
+					__source.pan = pan;
+				}
+				
 				return value;
 				#end
 			}


### PR DESCRIPTION
This PR is based on potential lime changes found here: https://github.com/openfl/lime/pull/1557

Since OpenFL, being based on the Flash API, only deals with sound panning and not full-on spatialized audio, this switches us to using Lime AudioSource's new "pan" property, which is more natural and also fixes the HTML5 sound playback issues mentioned in the accompanying lime PR.