### PR TITLE
Enable crisp text rendering for pixel fonts

### DIFF
--- a/src/openfl/display/_internal/CanvasTextField.hx
+++ b/src/openfl/display/_internal/CanvasTextField.hx
@@ -92,7 +92,9 @@ class CanvasTextField
 
 		if (textField.__dirty || graphics.__softwareDirty)
 		{
-			#if (openfl_disable_hdpi || openfl_disable_hdpi_textfield)
+            #if openfl_pixel_font
+            var pixelRatio = 3;
+			#elseif (openfl_disable_hdpi || openfl_disable_hdpi_textfield)
 			var pixelRatio = 1;
 			#else
 			var pixelRatio = renderer.__pixelRatio;

--- a/src/openfl/display/_internal/CanvasTextField.hx
+++ b/src/openfl/display/_internal/CanvasTextField.hx
@@ -92,8 +92,8 @@ class CanvasTextField
 
 		if (textField.__dirty || graphics.__softwareDirty)
 		{
-            #if openfl_pixel_font
-            var pixelRatio = 3;
+			#if openfl_pixel_font
+			var pixelRatio = 3;
 			#elseif (openfl_disable_hdpi || openfl_disable_hdpi_textfield)
 			var pixelRatio = 1;
 			#else


### PR DESCRIPTION
Pixel fonts render with artifacts around the edges of text for devices with high pixel ratios and also for Chromium-based browsers. This compiler flag forces a 3x pixel ratio, eliminating the ghosting effect on both sides of text. Fixes #2568, which has more information on the issue.