### PR TITLE
Make sure rotation is within -180 and +180

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -2079,6 +2079,9 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 	{
 		if (value != __rotation)
 		{
+			while (value > 180) value -= 360;
+            		while (value < -180) value += 360;
+			
 			__rotation = value;
 			var radians = __rotation * (Math.PI / 180);
 			__rotationSine = Math.sin(radians);

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -2079,8 +2079,15 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 	{
 		if (value != __rotation)
 		{
-			while (value > 180) value -= 360;
-            		while (value < -180) value += 360;
+			value = value % 360.0;
+			if (value > 180.0) 
+			{
+				value -= 360.0;
+			}
+			else if (value < -180.0) 
+			{
+				value += 360.0;
+			}
 			
 			__rotation = value;
 			var radians = __rotation * (Math.PI / 180);


### PR DESCRIPTION
As per flash docs for DisplayObject.rotation

> Indicates the rotation of the DisplayObject instance, in degrees, from its original orientation. Values from 0 to 180 represent clockwise rotation; values from 0 to -180 represent counterclockwise rotation. Values outside this range are added to or subtracted from 360 to obtain a value within the range. For example, the statement my_video.rotation = 450 is the same as my_video.rotation = 90.