### PR TITLE
fixed UncaughtErrorEvents not working (#2574)

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -56,7 +56,7 @@
 
 	<section unless="custom-backend">
 
-		<define name="openfl-disable-handle-error" unless="openfl-enable-handle-error" if="debug" />
+		<define name="openfl-disable-handle-error" if="debug" />
 
 		<section if="native">
 

--- a/src/openfl/events/UncaughtErrorEvents.hx
+++ b/src/openfl/events/UncaughtErrorEvents.hx
@@ -39,7 +39,7 @@ import openfl.events.UncaughtErrorEvent;
 #end
 class UncaughtErrorEvents extends EventDispatcher
 {
-	@:noCompletion private var __enabled:Bool;
+	@:noCompletion private var __enabled:Bool = #if (openfl_enable_handle_error || !openfl_disable_handle_error) true #else false #end;
 
 	/**
 		Creates an UncaughtErrorEvents instance. Developer code shouldn't
@@ -60,7 +60,7 @@ class UncaughtErrorEvents extends EventDispatcher
 	{
 		super.addEventListener(type, listener, useCapture, priority, useWeakReference);
 
-		#if !openfl_disable_handle_error
+		#if (openfl_enable_handle_error || !openfl_disable_handle_error)
 		if (__eventMap.exists(UncaughtErrorEvent.UNCAUGHT_ERROR))
 		{
 			__enabled = true;


### PR DESCRIPTION
I found that there are two separate causes of issue #2574:
- commit cde0386f6f70728854084b19b37fadf380f86aef made it impossible to enable uncaught error handling, because the try/catch in ApplicationMain is run only if the user had already added an event listener - but that is not possible, as ApplicationMain is the first code run by the application;

- commit 6b58d04cecadde99f46e847d610d0dd3640f7faa made it impossible to enable uncaught error handling in debug mode. This line in `include.xml`:
```xml
<define name="openfl-disable-handle-error" unless="openfl-enable-handle-error" if="debug" />
```
... seems to only work when `openfl_enable_handle_error` is defined explicitly via the build command line (e.g. `-D  openfl_enable_handle_error`), but it doesn't have any effect if is defined in the local `Project.xml`. Probably because definitions in `Project.xml` are executed later than `include.xml`. That means that there is no way to configure a project to activate uncaught error handling in debug mode.

This PR moves the "unless enable" logic from `include.xml` to the class `UncaughtErrorEvents`, by initializing the static var `__enabled` to true if  `openfl_enable_handle_error || !openfl_disable_handle_error` is defined. This fixes both issues.

After the PR, the logic becomes:
- in debug mode: error handling disabled by default, enabled by defining `openfl-enable-handle-error`;
- in non-debug mode: enabled by default, disabled by defining `openfl-disable-handle-error`.

The logic of "disable the error handling if there are no listeners" remains untouched.

This seems to me to be the intention behind the two original commits.