### PR TITLE
Load external shader file at compile time via @:glFragmentSourceFile and @:glVertexSourceFile

### DIFF
--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -27,6 +27,9 @@ class ShaderMacro
 		var glFragmentSource = null;
 		var glVertexSource = null;
 
+		var glFragmentSourceFile = null;
+		var glVertexSourceFile = null;
+
 		for (field in fields)
 		{
 			for (meta in field.meta)
@@ -37,6 +40,12 @@ class ShaderMacro
 						glFragmentSource = meta.params[0].getValue();
 
 					case "glVertexSource", ":glVertexSource":
+						glVertexSource = meta.params[0].getValue();
+
+					case "glFragmentSourceFile", ":glFragmentSourceFile":
+						glFragmentSourceFile = meta.params[0].getValue();
+
+					case "glVertexSourceFile", ":glVertexSourceFile":
 						glVertexSource = meta.params[0].getValue();
 
 					case "glFragmentHeader", ":glFragmentHeader":
@@ -78,6 +87,12 @@ class ShaderMacro
 						case "glVertexSource", ":glVertexSource":
 							if (glVertexSource == null) glVertexSource = meta.params[0].getValue();
 
+						case "glFragmentSourceFile", ":glFragmentSourceFile":
+							if (glFragmentSourceFile == null) glFragmentSourceFile = meta.params[0].getValue();
+
+						case "glVertexSourceFile", ":glVertexSourceFile":
+							if (glVertexSourceFile == null) glVertexSourceFile = meta.params[0].getValue();
+
 						case "glFragmentHeader", ":glFragmentHeader":
 							glFragmentHeader = meta.params[0].getValue() + "\n" + glFragmentHeader;
 
@@ -96,6 +111,30 @@ class ShaderMacro
 			}
 
 			parent = parent.superClass != null ? parent.superClass.t.get() : null;
+		}
+
+		if (glVertexSourceFile != null)
+		{
+			try
+			{
+				glVertexSource = sys.io.File.getContent(glVertexSourceFile);
+			}
+			catch (e:Dynamic)
+			{
+				Context.fatalError('Cannot load shader from file: ${e}', Context.currentPos());
+			}
+		}
+
+		if (glFragmentSourceFile != null)
+		{
+			try
+			{
+				glFragmentSource = sys.io.File.getContent(glFragmentSourceFile);
+			}
+			catch (e:Dynamic)
+			{
+				Context.fatalError('Cannot load shader from file: ${e}', Context.currentPos());
+			}
 		}
 
 		if (glVertexSource != null || glFragmentSource != null)


### PR DESCRIPTION
This PR adds a way to load an external file to be used as a shader (fragment or vertex).

Usage:
```hx
class MyShader extends Shader
{
// ...
@:glFragmentSourceFile("./shaders/myShader.frag")
// ...
}
```

This could help separate the actual GLSL code from its OpenFL management. Most IDEs can correctly highlight/format the syntax of an external shader file, while long strings (as the `@:glFragmentSource()` argument) are usually rendered as a uniform color and must be formatted by hand; so this could be a nice quality of life change.

This PR is changing the `ShaderMacro.build()` function so that:
- it would check for the metas `glFragmentSourceFile`, `:glFragmentSourceFile`, `glVertexSourceFile`, and `:glVertexSourceFile`;
- if one of the metas is found and the argument file exists, its content will be set as the `glFragmentSource`/`glVertexSource`, overriding the `@:glFragmentSource`/`@:glVertexSource` argument (if defined).
- if the file does not exist or cannot be read, an error is returned at compile time.