### PR TITLE
fix setTimeout memory leak

### DIFF
--- a/src/openfl/Lib.hx
+++ b/src/openfl/Lib.hx
@@ -559,7 +559,7 @@ import js.Browser;
 		__timers[id] = Timer.delay(function()
 		{
 			Reflect.callMethod(closure, closure, args == null ? [] : args);
-			clearTimeout(id);
+			__timers.remove(id);
 		}, delay);
 		return id;
 	}

--- a/src/openfl/Lib.hx
+++ b/src/openfl/Lib.hx
@@ -559,6 +559,7 @@ import js.Browser;
 		__timers[id] = Timer.delay(function()
 		{
 			Reflect.callMethod(closure, closure, args == null ? [] : args);
+			clearTimeout(id);
 		}, delay);
 		return id;
 	}

--- a/src/openfl/Lib.hx
+++ b/src/openfl/Lib.hx
@@ -558,8 +558,8 @@ import js.Browser;
 		var id = ++__lastTimerID;
 		__timers[id] = Timer.delay(function()
 		{
-			Reflect.callMethod(closure, closure, args == null ? [] : args);
 			__timers.remove(id);
+			Reflect.callMethod(closure, closure, args == null ? [] : args);
 		}, delay);
 		return id;
 	}


### PR DESCRIPTION
setInterval should be cleared manually, but setTimeout should be cleared automatically.

My pull request fixes leak problem.

Reproduce:

```haxe
class LeakObject {
    private var timeout:UInt;

    public function new() {
        timeout = openfl.Lib.setTimeout(leak, 1000);
    }

    private function leak():Void
    {
        //If clearTimeout not work, a memory leak occurs.
        //openfl.Lib.clearTimeout(timeout);
        trace("LeakObject never released from memory!");
    }
}
```