### PR TITLE
Fix for issue #2535 "TypeError: this.text.indexOf is not a function"

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2962,6 +2962,10 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function set_text(value:String):String
 	{
+#if (js && html5)
+		value += "";		// cast to string (fix for #2535 'TypeError: this.text.indexOf is not a function')
+#end
+
 		if (__styleSheet != null)
 		{
 			return set_htmlText(value);


### PR DESCRIPTION
"TypeError: this.text.indexOf is not a function" exception occurs for js/html5 targets if value consists of numbers only - so clearly cast to string.

Haxe code to reproduce:
smth. like this
```
private function setValue(strNumber:String):Void {
	textField.text = strNumber;
}
```