### PR TITLE
Set deafult blendMode for ShaderFilter

### DIFF
--- a/src/openfl/filters/ShaderFilter.hx
+++ b/src/openfl/filters/ShaderFilter.hx
@@ -56,7 +56,7 @@ import openfl.display.Shader;
 class ShaderFilter extends BitmapFilter
 {
 	@:dox(hide) @:noCompletion @:beta @SuppressWarnings("checkstyle:FieldDocComment")
-	public var blendMode:BlendMode;
+	public var blendMode:BlendMode = NORMAL;
 
 	/**
 		The growth in pixels on the bottom side of the target object.
@@ -141,8 +141,6 @@ class ShaderFilter extends BitmapFilter
 		super();
 
 		this.shader = shader;
-
-		this.blendMode = NORMAL;
 
 		__numShaderPasses = 1;
 	}

--- a/src/openfl/filters/ShaderFilter.hx
+++ b/src/openfl/filters/ShaderFilter.hx
@@ -142,6 +142,8 @@ class ShaderFilter extends BitmapFilter
 
 		this.shader = shader;
 
+		this.blendMode = NORMAL;
+
 		__numShaderPasses = 1;
 	}
 
@@ -152,6 +154,7 @@ class ShaderFilter extends BitmapFilter
 		filter.leftExtension = leftExtension;
 		filter.rightExtension = rightExtension;
 		filter.topExtension = topExtension;
+		filter.blendMode = blendMode;
 		return filter;
 	}
 


### PR DESCRIPTION
Fix for hashlink, before hl automatically set blendMode to ADD and not NORMAL.

//tw: fnf
[before](https://user-images.githubusercontent.com/75984453/222259375-a6a970b5-83aa-4628-a11e-319dc8e98f6f.png)
[after](https://user-images.githubusercontent.com/75984453/222259158-e4b4760b-8075-4085-833d-aef7796687a4.png)

