### PR TITLE
Fix: Track blendMode changes at the Context3D level instead of OpenGLRenderer level.

### DIFF
--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -753,6 +753,9 @@ class OpenGLRenderer extends DisplayObjectRenderer
 		__context3D.setScissorRectangle(null);
 
 		__blendMode = null;
+		if (__defaultRenderTarget == null) {
+			OpenGLRenderer.__currentBlendMode.remove(__context3D);
+		}
 		__setBlendMode(NORMAL);
 
 		if (__defaultRenderTarget == null)

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -753,7 +753,8 @@ class OpenGLRenderer extends DisplayObjectRenderer
 		__context3D.setScissorRectangle(null);
 
 		__blendMode = null;
-		if (__defaultRenderTarget == null) {
+		if (__defaultRenderTarget == null)
+		{
 			OpenGLRenderer.__currentBlendMode.remove(__context3D);
 		}
 		__setBlendMode(NORMAL);
@@ -1011,7 +1012,8 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private override function __setBlendMode(value:BlendMode):Void
 	{
 		if (__overrideBlendMode != null) value = __overrideBlendMode;
-		if (OpenGLRenderer.__currentBlendMode.get(__context3D) == value) {
+		if (OpenGLRenderer.__currentBlendMode.get(__context3D) == value)
+		{
 			__blendMode = value;
 			return;
 		}

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -63,6 +63,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private static var __hasColorTransformValue:Array<Bool> = [false];
 	@:noCompletion private static var __scissorRectangle:Rectangle = new Rectangle();
 	@:noCompletion private static var __textureSizeValue:Array<Float> = [0, 0];
+	@:noCompletion private static var __currentBlendMode:Map<Context3D, BlendMode> = new Map<Context3D, BlendMode>();
 
 	/**
 		The current OpenGL render context
@@ -1007,7 +1008,11 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private override function __setBlendMode(value:BlendMode):Void
 	{
 		if (__overrideBlendMode != null) value = __overrideBlendMode;
-		if (__blendMode == value) return;
+		if (OpenGLRenderer.__currentBlendMode.get(__context3D) == value) {
+			__blendMode = value;
+			return;
+		}
+		OpenGLRenderer.__currentBlendMode.set(__context3D, value);
 
 		__blendMode = value;
 


### PR DESCRIPTION
Fixes behavior when a blendMode is assigned to a child at the top of the layer stack in a container and the container's cacheAsBitmap is set to true. The child OpenGLRenderer will change the Context3D blend settings and so the parent renderer needs to be able to update the blend settings if the supplied blendMode differs from the one last used in the child renderer.