### PR TITLE
Fixed opaqueBackground and BitmapData texture fillRect

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -3160,9 +3160,9 @@ class BitmapData implements IBitmapDrawable
 					y = Math.floor(rect.y / context.__stage.window.scale);
 					width = (rect.width > 0 ? Math.ceil(rect.right / context.__stage.window.scale) - x : 0);
 					height = (rect.height > 0 ? Math.ceil(rect.bottom / context.__stage.window.scale) - y : 0);
-					__fillRectRectangle.setTo(x, y, width, height);
 				}
 				#end
+				__fillRectRectangle.setTo(x, y, width, height);
 				context.setScissorRectangle(__fillRectRectangle);
 			}
 

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -129,6 +129,7 @@ class BitmapData implements IBitmapDrawable
 	@:noCompletion private static var __textureInternalFormat:Int;
 	#if lime
 	@:noCompletion private static var __tempVector:Vector2 = new Vector2();
+	@:noCompletion private static var __fillRectRectangle:Rectangle = new Rectangle();
 	#end
 
 	/**
@@ -3148,10 +3149,24 @@ class BitmapData implements IBitmapDrawable
 
 			if (useScissor)
 			{
-				context.setScissorRectangle(rect);
+				var x = Math.floor(rect.x);
+				var y = Math.floor(rect.y);
+				var width = (rect.width > 0 ? Math.ceil(rect.right) - x : 0);
+				var height = (rect.height > 0 ? Math.ceil(rect.bottom) - y : 0);
+				#if !openfl_dpi_aware
+				if (context.__backBufferWantsBestResolution)
+				{
+					x = Math.floor(rect.x / context.__stage.window.scale);
+					y = Math.floor(rect.y / context.__stage.window.scale);
+					width = (rect.width > 0 ? Math.ceil(rect.right / context.__stage.window.scale) - x : 0);
+					height = (rect.height > 0 ? Math.ceil(rect.bottom / context.__stage.window.scale) - y : 0);
+					__fillRectRectangle.setTo(x, y, width, height);
+				}
+				#end
+				context.setScissorRectangle(__fillRectRectangle);
 			}
 
-			context.clear(color.r / 0xFF, color.g / 0xFF, color.b / 0xFF, transparent ? color.a / 0xFF : 1, 0, 0, Context3DClearMask.COLOR);
+			context.__clear(useScissor, color.r / 0xFF, color.g / 0xFF, color.b / 0xFF, transparent ? color.a / 0xFF : 1, 0, 0, Context3DClearMask.COLOR);
 
 			if (useScissor)
 			{

--- a/src/openfl/display/_internal/Context3DDisplayObject.hx
+++ b/src/openfl/display/_internal/Context3DDisplayObject.hx
@@ -40,7 +40,7 @@ class Context3DDisplayObject
 
 			#if lime
 			var color:ARGB = (displayObject.opaqueBackground : ARGB);
-			context.clear(color.r / 0xFF, color.g / 0xFF, color.b / 0xFF, 1, 0, 0, Context3DClearMask.COLOR);
+			context.__clear(true, color.r / 0xFF, color.g / 0xFF, color.b / 0xFF, 1, 0, 0, Context3DClearMask.COLOR);
 			#end
 
 			renderer.__popMaskRect();

--- a/src/openfl/display3D/Context3D.hx
+++ b/src/openfl/display3D/Context3D.hx
@@ -460,6 +460,12 @@ import lime.math.Vector2;
 	public function clear(red:Float = 0, green:Float = 0, blue:Float = 0, alpha:Float = 1, depth:Float = 1, stencil:UInt = 0,
 			mask:UInt = Context3DClearMask.ALL):Void
 	{
+		__clear(false, red, green, blue, alpha, depth, stencil, mask);
+	}
+
+	@:noCompletion private function __clear(useScissor:Bool, red:Float = 0, green:Float = 0, blue:Float = 0, alpha:Float = 1, depth:Float = 1,
+			stencil:UInt = 0, mask:UInt = Context3DClearMask.ALL)
+	{
 		__flushGLFramebuffer();
 		__flushGLViewport();
 
@@ -519,7 +525,15 @@ import lime.math.Vector2;
 
 		if (clearMask == 0) return;
 
-		__setGLScissorTest(false);
+		if (useScissor)
+		{
+			__flushGLScissor();
+		}
+		else
+		{
+			__setGLScissorTest(false);
+		}
+
 		gl.clear(clearMask);
 	}
 


### PR DESCRIPTION
Fixed opaqueBackground. Also fixed BitmapData's fillRect when backed by a Texture. In both cases, the Context3D clear() clears the entire framebuffer and ignores any scissor setting. We need a new __clear() method that takes into account the supplied scissor rectangle.

Here's an example that shows both glitches.

```
package;

import openfl.display.Bitmap;
import openfl.geom.Rectangle;
import openfl.display3D.Context3DTextureFormat;
import openfl.display.BitmapData;
import openfl.display.Shape;
import openfl.display.Sprite;

class Main extends Sprite
{
	public function new ()
	{
		super ();

		stage.color = 0;

		test_opaqueBackground();

		#if !flash
		test_texture_fillRect();
		#end
	}

	// Should render a red circle with a green opaque background
	function test_opaqueBackground()
	{
		var shape = new Shape();
		shape.opaqueBackground = 0x00FF00;
		shape.graphics.beginFill(0xFF0000);
		shape.graphics.drawCircle(100, 100, 100);
		shape.graphics.endFill();
		shape.x = 100;
		shape.y = 100;
		addChild(shape);
	}

	// It should render a blue square with a red square in the center
	function test_texture_fillRect()
	{
		var texture = stage.context3D.createRectangleTexture(200, 200, Context3DTextureFormat.BGRA, true);
		var bitmapData = BitmapData.fromTexture(texture);
		bitmapData.fillRect(bitmapData.rect, 0xFF0000FF);
		bitmapData.fillRect(new Rectangle(50, 50, 100, 100), 0xFFFF0000);

		var bitmap = new Bitmap(bitmapData);
		bitmap.x = 400;
		bitmap.y = 100;
		addChild(bitmap);
	}
}
```