### PR TITLE
Fix. Allow resizing of the Video object via the width and height props

### DIFF
--- a/src/openfl/media/Video.hx
+++ b/src/openfl/media/Video.hx
@@ -165,6 +165,8 @@ class Video extends DisplayObject
 	@:noCompletion private var __bufferColorTransform:ColorTransform;
 	@:noCompletion private var __bufferContext:#if lime RenderContext #else Dynamic #end;
 	@:noCompletion private var __bufferData:Float32Array;
+	@:noCompletion private var __currentWidth:Float;
+	@:noCompletion private var __currentHeight:Float;
 	@:noCompletion private var __dirty:Bool;
 	@:noCompletion private var __height:Float;
 	@:noCompletion private var __indexBuffer:IndexBuffer3D;
@@ -352,8 +354,13 @@ class Video extends DisplayObject
 		#if (lime || js)
 		var gl = context.gl;
 
-		if (__vertexBuffer == null || __vertexBufferContext != context.__context)
+		if (__vertexBuffer == null
+			|| __vertexBufferContext != context.__context
+			|| __currentWidth != width
+			|| __currentHeight != height)
 		{
+			__currentWidth = width;
+			__currentHeight = height;
 			#if openfl_power_of_two
 			var newWidth = 1;
 			var newHeight = 1;


### PR DESCRIPTION
Changing the width and height of the Video object does nothing when rendering in OpenGL. This change fixes that.