### PR TITLE
Work around "instance constructor not found" error.

### DIFF
--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -1904,6 +1904,8 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	@:noCompletion @:dox(hide) @:require(flash11_4) public function atomicCompareAndSwapLength(expectedLength:Int, newLength:Int):Int;
 	#end
 
+	public function new(length:Int = 0);
+
 	/**
 		Clears the contents of the byte array and resets the `length`
 		and `position` properties to 0. Calling this method explicitly


### PR DESCRIPTION
Occasionally, the Haxe compiler gets confused and crashes because `ByteArrayData` doesn't have a constructor. Specifically, it prints "Instance constructor not found: openfl.utils.ByteArrayData."

I think this is usually caused by some other compile error, but the compiler won't tell you about that error until you declare a constructor. Then once you fix the other error(s) you can safely delete the constructor again.

I don't know how to reproduce the error reliably. It just happens once every couple months. But this change will permanently fix it and shouldn't have any side effects.