### PR TITLE
Update Code Editor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Code Editors
 Plugins have been written for many [code editors](http://haxe.org/documentation/introduction/editors-and-ides.html), but the most popular editors used for Haxe and OpenFL development are:
 
  * [Visual Studio Code](https://code.visualstudio.com/) (with [plugin](https://marketplace.visualstudio.com/items?itemName=openfl.lime-vscode-extension))
- * [HaxeDevelop](http://haxedevelop.org/)
- * [Sublime Text](http://www.sublimetext.com) (with [plugin](https://github.com/clemos/haxe-sublime-bundle))
- * [IntelliJ IDEA](http://www.jetbrains.com/idea/) (with [plugin](http://plugins.jetbrains.com/plugin/6873?pr=))
+ * [HaxeDevelop](https://github.com/HaxeFoundation/haxedevelop.org) ([development builds](https://flashdevelop.org/downloads/builds/))
+ * [Sublime Text](https://www.sublimetext.com) (with [plugin](https://github.com/clemos/haxe-sublime-bundle))
+ * [IntelliJ IDEA](https://www.jetbrains.com/idea/) (with [plugin](https://plugins.jetbrains.com/plugin/6873-haxe-toolkit-support))
 
 
 Easy Deployment


### PR DESCRIPTION
Updated links to https.
Updated URLs where they'd changed.
Replaced stale haxedevelop.org with GitHub link, and added development builds.