### PR TITLE
Fix set_text and set_htmlText behavior that is different with Flash.

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2710,6 +2710,11 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function set_htmlText(value:String):String
 	{
+		if(value == null)
+		{
+			throw new TypeError("Error #2007: Parameter text must be non-null.");
+		}
+		
 		if (!__isHTML || __text != value)
 		{
 			__dirty = true;
@@ -2985,6 +2990,11 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function set_text(value:String):String
 	{
+		if(value == null)
+		{
+			throw new TypeError("Error #2007: Parameter text must be non-null.");
+		}
+		
 		if (__styleSheet != null)
 		{
 			return set_htmlText(value);

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -118,6 +118,7 @@ import js.html.DivElement;
 @:noDebug
 #end
 @:access(openfl.display.Graphics)
+@:access(openfl.errors.Error)
 @:access(openfl.geom.ColorTransform)
 @:access(openfl.geom.Matrix)
 @:access(openfl.geom.Rectangle)
@@ -2713,7 +2714,9 @@ class TextField extends InteractiveObject
 	{
 		if(value == null)
 		{
-			throw new TypeError("Error #2007: Parameter text must be non-null.", 2007);
+			var error = new TypeError("Error #2007: Parameter text must be non-null.");
+			error.errorID = 2007;
+			throw error;
 		}
 		
 		if (!__isHTML || __text != value)
@@ -2993,7 +2996,9 @@ class TextField extends InteractiveObject
 	{
 		if(value == null)
 		{
-			throw new TypeError("Error #2007: Parameter text must be non-null.", 2007);
+			var error = new TypeError("Error #2007: Parameter text must be non-null.");
+			error.errorID = 2007;
+			throw error;
 		}
 		
 		if (__styleSheet != null)

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2713,9 +2713,7 @@ class TextField extends InteractiveObject
 	{
 		if(value == null)
 		{
-			var error = new TypeError("Error #2007: Parameter text must be non-null.");
-			error.errorID = 2007;
-			throw error;
+			throw new TypeError("Error #2007: Parameter text must be non-null.", 2007);
 		}
 		
 		if (!__isHTML || __text != value)
@@ -2995,9 +2993,7 @@ class TextField extends InteractiveObject
 	{
 		if(value == null)
 		{
-			var error = new TypeError("Error #2007: Parameter text must be non-null.");
-			error.errorID = 2007;
-			throw error;
+			throw new TypeError("Error #2007: Parameter text must be non-null.", 2007);
 		}
 		
 		if (__styleSheet != null)

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -13,6 +13,7 @@ import openfl.display.Graphics;
 import openfl.display.InteractiveObject;
 import openfl.display.Stage;
 import openfl.errors.RangeError;
+import openfl.errors.TypeError;
 import openfl.events.Event;
 import openfl.events.FocusEvent;
 import openfl.events.KeyboardEvent;

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2713,7 +2713,9 @@ class TextField extends InteractiveObject
 	{
 		if(value == null)
 		{
-			throw new TypeError("Error #2007: Parameter text must be non-null.");
+			var error = new TypeError("Error #2007: Parameter text must be non-null.");
+			error.errorID = 2007;
+			throw error;
 		}
 		
 		if (!__isHTML || __text != value)
@@ -2993,7 +2995,9 @@ class TextField extends InteractiveObject
 	{
 		if(value == null)
 		{
-			throw new TypeError("Error #2007: Parameter text must be non-null.");
+			var error = new TypeError("Error #2007: Parameter text must be non-null.");
+			error.errorID = 2007;
+			throw error;
 		}
 		
 		if (__styleSheet != null)


### PR DESCRIPTION
Fix set_text and set_htmlText behavior that is different with Flash.

### Problem:

If the value is set to null, the error "TypeError: this.text.indexOf is not a function" occurs in the getLayoutGroups function.
Without null checking in the set_text and set_htmlText functions, it's almost impossible to find out which textField is set to null!


Flash Behavior:
```ex
TypeError: Error #2007: Parameter text must be non-null.
    at flash.text::TextField/set text()
    at Untitled_1_fla::MainTimeline/frame1()
```

OpenFL Behavior:
```haxe
TypeError: this.text.indexOf is not a function
  at getLayoutGroups
  at update
  at __updateLayout
  at __getBounds
  at __getBounds
  at __getLocalBounds
  at get_width
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __enterFrame
  at __onLimeRender
  at dispatch
  at handleApplicationEvent
```