### PR TITLE
fix offset math in ColorTransform.concat

### DIFF
--- a/src/openfl/geom/ColorTransform.hx
+++ b/src/openfl/geom/ColorTransform.hx
@@ -185,10 +185,10 @@ class ColorTransform
 	**/
 	public function concat(second:ColorTransform):Void
 	{
-		redOffset = redOffset * redMultiplier + second.redOffset;
-		greenOffset = greenOffset * greenMultiplier + second.greenOffset;
-		blueOffset = blueOffset * blueMultiplier + second.blueOffset;
-		alphaOffset = alphaOffset * alphaMultiplier + second.alphaOffset;
+		redOffset = redOffset * second.redMultiplier + second.redOffset;
+		greenOffset = greenOffset * second.greenMultiplier + second.greenOffset;
+		blueOffset = blueOffset * second.blueMultiplier + second.blueOffset;
+		alphaOffset = alphaOffset * second.alphaMultiplier + second.alphaOffset;
 
 		redMultiplier *= second.redMultiplier;
 		greenMultiplier *= second.greenMultiplier;

--- a/src/openfl/geom/ColorTransform.hx
+++ b/src/openfl/geom/ColorTransform.hx
@@ -185,10 +185,10 @@ class ColorTransform
 	**/
 	public function concat(second:ColorTransform):Void
 	{
-		redOffset = second.redOffset * redMultiplier + redOffset;
-		greenOffset = second.greenOffset * greenMultiplier + greenOffset;
-		blueOffset = second.blueOffset * blueMultiplier + blueOffset;
-		alphaOffset = second.alphaOffset * alphaMultiplier + alphaOffset;
+		redOffset = redOffset * redMultiplier + second.redOffset;
+		greenOffset = greenOffset * greenMultiplier + second.greenOffset;
+		blueOffset = blueOffset * blueMultiplier + second.blueOffset;
+		alphaOffset = alphaOffset * alphaMultiplier + second.alphaOffset;
 
 		redMultiplier *= second.redMultiplier;
 		greenMultiplier *= second.greenMultiplier;

--- a/tests/geom/src/ColorTransformTest.hx
+++ b/tests/geom/src/ColorTransformTest.hx
@@ -142,7 +142,7 @@ class ColorTransformTest extends Test
 		Assert.equals(118.145, base.redOffset);
 		Assert.equals(-8.35, base.greenOffset);
 		Assert.equals(-74.5, base.blueOffset);
-		Assert.equals(18.1441, base.alphaOffset);
+		Assert.equals(18.144129, base.alphaOffset);
 
 		Assert.equals(0.1 * 0.321, base.redMultiplier);
 		Assert.equals(0.55 * 0.33, base.greenMultiplier);

--- a/tests/geom/src/ColorTransformTest.hx
+++ b/tests/geom/src/ColorTransformTest.hx
@@ -139,10 +139,11 @@ class ColorTransformTest extends Test
 
 		base.concat(second);
 
-		Assert.equals(-235, base.redOffset);
-		Assert.equals(-0.5, base.greenOffset);
-		Assert.equals(215, base.blueOffset);
-		Assert.equals(125.67369, base.alphaOffset);
+
+		Assert.equals(174.5, base.redOffset);
+		Assert.equals(-7.25, base.greenOffset);
+		Assert.equals(2, base.blueOffset);
+		Assert.equals(112.6213, base.alphaOffset);
 
 		Assert.equals(0.1 * 0.321, base.redMultiplier);
 		Assert.equals(0.55 * 0.33, base.greenMultiplier);

--- a/tests/geom/src/ColorTransformTest.hx
+++ b/tests/geom/src/ColorTransformTest.hx
@@ -139,10 +139,10 @@ class ColorTransformTest extends Test
 
 		base.concat(second);
 
-		Assert.equals(118.145 , base.redOffset);
-		Assert.equals( -8.35  , base.greenOffset);
-		Assert.equals(-74.5   , base.blueOffset);
-		Assert.equals( 18.1441, base.alphaOffset);
+		Assert.equals(118.145, base.redOffset);
+		Assert.equals(-8.35, base.greenOffset);
+		Assert.equals(-74.5, base.blueOffset);
+		Assert.equals(18.1441, base.alphaOffset);
 
 		Assert.equals(0.1 * 0.321, base.redMultiplier);
 		Assert.equals(0.55 * 0.33, base.greenMultiplier);

--- a/tests/geom/src/ColorTransformTest.hx
+++ b/tests/geom/src/ColorTransformTest.hx
@@ -139,11 +139,10 @@ class ColorTransformTest extends Test
 
 		base.concat(second);
 
-
-		Assert.equals(174.5, base.redOffset);
-		Assert.equals(-7.25, base.greenOffset);
-		Assert.equals(2, base.blueOffset);
-		Assert.equals(112.6213, base.alphaOffset);
+		Assert.equals(118.145 , base.redOffset);
+		Assert.equals( -8.35  , base.greenOffset);
+		Assert.equals(-74.5   , base.blueOffset);
+		Assert.equals( 18.1441, base.alphaOffset);
 
 		Assert.equals(0.1 * 0.321, base.redMultiplier);
 		Assert.equals(0.55 * 0.33, base.greenMultiplier);

--- a/tests/geom/src/ColorTransformTest.hx
+++ b/tests/geom/src/ColorTransformTest.hx
@@ -132,7 +132,7 @@ class ColorTransformTest extends Test
 		Assert.equals(1.0, base.alphaMultiplier);
 	}
 
-	public function test_concat()
+	public function test_concat1()
 	{
 		var base = new ColorTransform(0.1, 0.55, 0.4, 0.89123, -255, 5, 255, 123);
 		var second = new ColorTransform(0.321, 0.33, 0.1, 0.123123, 200, -10, -100, 3);
@@ -149,5 +149,25 @@ class ColorTransformTest extends Test
 		Assert.equals(0.55 * 0.33, base.greenMultiplier);
 		Assert.equals(0.4 * 0.1, base.blueMultiplier);
 		Assert.equals(0.89123 * 0.123123, base.alphaMultiplier);
+	}
+
+	public function test_concat2()
+	{
+		// second should completely override base
+		var base = new ColorTransform(0.5, 0.5, 0.5, 1, 0x80, 0, 0x80, 0);
+		var second = new ColorTransform(0, 0, 0, 1, 0x62, 0x7D, 0xB0, 0);
+
+		base.concat(second);
+
+
+		Assert.equals(second.redOffset, base.redOffset);
+		Assert.equals(second.greenOffset, base.greenOffset);
+		Assert.equals(second.blueOffset, base.blueOffset);
+		Assert.equals(second.alphaOffset, base.alphaOffset);
+
+		Assert.equals(second.redMultiplier, base.redMultiplier);
+		Assert.equals(second.greenMultiplier, base.greenMultiplier);
+		Assert.equals(second.blueMultiplier, base.blueMultiplier);
+		Assert.equals(second.alphaMultiplier, base.alphaMultiplier);
 	}
 }


### PR DESCRIPTION
in [this thread](https://community.openfl.org/t/openfl-geom-colortransform-concat/6647/2?u=geokureli) Thomas outlined the expected offset formula:
```hx
concat_offset = multiplier2*offset1 + offset2;
```
Joshua replied that it was implemented, however the formula used was:
```hx
concat_offset = multiplier1*offset2 + offset1;
```

the doc states
> the effect is the same as applying the `second` color transformation after the _original_ color transformation.

but the previous code has this backwards

Came across this when I was implementing flixel tools for adobe animate's tint and brightness color transforms, I noticed that concatenating a full brightness or full tint on top of another transform did not completely override the initial transforms values.