### PR TITLE
HTML5 beginGradientFill() -> Support for SpreadMethod.REPEAT & SpreadMethod.REFLECT

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -1451,6 +1451,16 @@ import js.html.CanvasRenderingContext2D;
 	public function lineStyle(thickness:Null<Float> = null, color:Int = 0, alpha:Float = 1, pixelHinting:Bool = false,
 			scaleMode:LineScaleMode = LineScaleMode.NORMAL, caps:CapsStyle = null, joints:JointStyle = null, miterLimit:Float = 3):Void
 	{
+		if (caps == null)
+		{
+			caps = CapsStyle.ROUND;
+		}
+
+		if (joints == null)
+		{
+			joints = JointStyle.ROUND;
+		}
+
 		if (thickness != null)
 		{
 			if (joints == JointStyle.MITER)

--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -224,7 +224,10 @@ class CanvasGraphics
 							}
 
 							pendingMatrix = new Matrix();
-							inversePendingMatrix = matrix.clone();
+							pendingMatrix.tx = matrix.tx - dimensions.width / 2;
+							pendingMatrix.ty = matrix.ty - dimensions.height / 2;
+
+							inversePendingMatrix = pendingMatrix.clone();
 							inversePendingMatrix.invert();
 
 							var path:Path2D = cast new Path2D();

--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -105,156 +105,165 @@ class CanvasGraphics
 
 	@SuppressWarnings("checkstyle:Dynamic")
 	private static function createGradientPattern(type:GradientType, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, matrix:Matrix,
-		spreadMethod:SpreadMethod, interpolationMethod:InterpolationMethod, focalPointRatio:Float):
-	#if (js && html5) CanvasPattern #else Void #end
+			spreadMethod:SpreadMethod, interpolationMethod:InterpolationMethod, focalPointRatio:Float):#if (js && html5) CanvasPattern #else Void #end
+	{
+		#if (js && html5)
+		var pattern:CanvasPattern = null,
+			point:Point = null,
+			point2:Point = null,
+			releaseMatrix = false;
+
+		if (matrix == null)
 		{
-			#if (js && html5)
-				var gradientFill:CanvasGradient = null,
-					point:Point = null,
-					point2:Point = null,
-					releaseMatrix = false,
-					ratio:Float = 0.0;
-
-				if (matrix == null)
-				{
-					matrix = Matrix.__pool.get();
-					matrix.identity();
-					releaseMatrix = true;
-				}
-
-				switch (type)
-				{
-					case RADIAL:
-						var radius = 819.2;
-						focalPointRatio = focalPointRatio>1.0 ? 1.0:focalPointRatio< - 1.0 ? -1.0:focalPointRatio;
-						gradientFill = context.createRadialGradient(radius * focalPointRatio, 0, 0, 0, 0, radius);
-
-						pendingMatrix = matrix.clone();
-						inversePendingMatrix = matrix.clone();
-						inversePendingMatrix.invert();
-
-						for (i in 0...colors.length)
-						{
-							ratio = ratios[i] / 0xFF;
-							if (ratio<0) ratio = 0;
-							if (ratio>1) ratio = 1;
-
-							gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
-						}
-
-						case LINEAR:
-							var gradientScale:Float = spreadMethod == PAD ? 1.0:25.0;
-							var dx = 0.5 * (gradientScale - 1.0) * 1638.4;
-							var canvas:CanvasElement = cast Browser.document.createElement("canvas");
-							var context2 = canvas.getContext("2d");
-
-							var dimensions:Dynamic = getDimensions(matrix);
-
-							canvas.width = context.canvas.width;
-							canvas.height = context.canvas.height;
-							gradientFill = context.createLinearGradient(-819.2 - dx, 0, 819.2 + dx, 0);
-							if (spreadMethod == PAD)
-							{
-								for (i in 0...colors.length)
-								{
-									ratio = ratios[i] / 0xFF;
-									if (ratio<0) ratio = 0;
-									if (ratio>1) ratio = 1;
-
-									gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
-								}
-							}
-							else
-							if (spreadMethod == REFLECT)
-							{
-								var t:Float = 0;
-								var step:Float = 1 / 25;
-								var a:Int;
-								while (t<1)
-								{
-									for (i in 0...colors.length)
-									{
-										ratio = ratios[i] / 0xFF;
-										ratio = t + ratio * step;
-										if (ratio<0) ratio = 0;
-										if (ratio>1) ratio = 1;
-
-										gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
-									}
-									t += step;
-									a = colors.length - 1;
-									while (a>=0)
-									{
-										ratio = ratios[a] / 0xFF;
-										ratio = t + (1.0 - ratio) * step;
-										if (ratio<0) ratio = 0;
-										if (ratio>1) ratio = 1;
-										gradientFill.addColorStop(ratio, getRGBA(colors[a], alphas[a]));
-										a--;
-									}
-									t += step;
-								}
-							}
-							else
-							if (spreadMethod == REPEAT)
-							{
-								var t:Float = 0;
-								var step:Float = 1 / 25;
-								var a:Int;
-								while (t<1)
-								{
-									for (i in 0...colors.length)
-									{
-										ratio = ratios[i] / 0xFF;
-										ratio = t + ratio * step;
-										if (ratio<0) ratio = 0;
-										if (ratio>1) ratio = 1 - 0.001;
-
-										gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
-									}
-
-									ratio = t + 0.001;
-									if (ratio<0) ratio = 0;
-									if (ratio>1) ratio = 1;
-									gradientFill.addColorStop(ratio - 0.001, getRGBA(colors[colors.length - 1], alphas[alphas.length - 1]));
-									gradientFill.addColorStop(ratio, getRGBA(colors[0], alphas[0]));
-
-									t += step;
-								}
-							}
-
-							pendingMatrix = new Matrix();
-							pendingMatrix.tx = matrix.tx - dimensions.width / 2;
-							pendingMatrix.ty = matrix.ty - dimensions.height / 2;
-
-							inversePendingMatrix = pendingMatrix.clone();
-							inversePendingMatrix.invert();
-
-							var path:Path2D = cast new Path2D();
-							path.rect(0, 0, canvas.width, canvas.height);
-							path.closePath();
-							var gradientMatrix:DOMMatrix = new DOMMatrix([matrix.a, matrix.b, matrix.c, matrix.d, matrix.tx, matrix.ty]);
-							var inverseMatrix = cast gradientMatrix.inverse();
-							var untransformedPath:Path2D = cast new Path2D();
-							untransformedPath.addPath(path, inverseMatrix);
-							context2.fillStyle = gradientFill;
-							context2.setTransform(gradientMatrix);
-							context2.fill(untransformedPath);
-							return cast context.createPattern(canvas, 'no-repeat');
-				}
-
-				if (point != null) Point.__pool.release(point);
-				if (point2 != null) Point.__pool.release(point2);
-				if (releaseMatrix) Matrix.__pool.release(matrix);
-
-				return cast(gradientFill);
-			#end
+			matrix = Matrix.__pool.get();
+			matrix.identity();
+			releaseMatrix = true;
 		}
+
+		switch (type)
+		{
+			case RADIAL:
+				var radius = 819.2;
+				focalPointRatio = focalPointRatio > 1.0 ? 1.0 : focalPointRatio < -1.0 ? -1.0 : focalPointRatio;
+				var gradientFill = context.createRadialGradient(radius * focalPointRatio, 0, 0, 0, 0, radius);
+				pattern = cast gradientFill;
+
+				pendingMatrix = matrix.clone();
+				inversePendingMatrix = matrix.clone();
+				inversePendingMatrix.invert();
+
+				for (i in 0...colors.length)
+				{
+					var ratio = ratios[i] / 0xFF;
+					if (ratio < 0) ratio = 0;
+					if (ratio > 1) ratio = 1;
+
+					gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
+				}
+
+			case LINEAR:
+				if (spreadMethod == PAD)
+				{
+					var gradientFill = context.createLinearGradient(-819.2, 0, 819.2, 0);
+					pattern = cast gradientFill;
+
+					pendingMatrix = matrix.clone();
+					inversePendingMatrix = matrix.clone();
+					inversePendingMatrix.invert();
+
+					for (i in 0...colors.length)
+					{
+						var ratio = ratios[i] / 0xFF;
+						if (ratio < 0) ratio = 0;
+						if (ratio > 1) ratio = 1;
+
+						gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
+					}
+				}
+				else
+				{
+					var gradientScale:Float = spreadMethod == PAD ? 1.0 : 25.0;
+					var dx = 0.5 * (gradientScale - 1.0) * 1638.4;
+					var gradientFill = context.createLinearGradient(-819.2 - dx, 0, 819.2 + dx, 0);
+					var canvas:CanvasElement = cast Browser.document.createElement("canvas");
+					var context2 = canvas.getContext("2d");
+
+					var dimensions:Dynamic = getDimensions(matrix);
+
+					canvas.width = context.canvas.width;
+					canvas.height = context.canvas.height;
+
+					if (spreadMethod == REFLECT)
+					{
+						var t:Float = 0;
+						var step:Float = 1 / 25;
+						var a:Int;
+						while (t < 1)
+						{
+							for (i in 0...colors.length)
+							{
+								var ratio = ratios[i] / 0xFF;
+								ratio = t + ratio * step;
+								if (ratio < 0) ratio = 0;
+								if (ratio > 1) ratio = 1;
+
+								gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
+							}
+							t += step;
+							a = colors.length - 1;
+							while (a >= 0)
+							{
+								var ratio = ratios[a] / 0xFF;
+								ratio = t + (1.0 - ratio) * step;
+								if (ratio < 0) ratio = 0;
+								if (ratio > 1) ratio = 1;
+								gradientFill.addColorStop(ratio, getRGBA(colors[a], alphas[a]));
+								a--;
+							}
+							t += step;
+						}
+					}
+					else if (spreadMethod == REPEAT)
+					{
+						var t:Float = 0;
+						var step:Float = 1 / 25;
+						var a:Int;
+						while (t < 1)
+						{
+							for (i in 0...colors.length)
+							{
+								var ratio = ratios[i] / 0xFF;
+								ratio = t + ratio * step;
+								if (ratio < 0) ratio = 0;
+								if (ratio > 1) ratio = 1 - 0.001;
+
+								gradientFill.addColorStop(ratio, getRGBA(colors[i], alphas[i]));
+							}
+
+							var ratio = t + 0.001;
+							if (ratio < 0) ratio = 0;
+							if (ratio > 1) ratio = 1;
+							gradientFill.addColorStop(ratio - 0.001, getRGBA(colors[colors.length - 1], alphas[alphas.length - 1]));
+							gradientFill.addColorStop(ratio, getRGBA(colors[0], alphas[0]));
+
+							t += step;
+						}
+					}
+
+					pendingMatrix = new Matrix();
+					pendingMatrix.tx = matrix.tx - dimensions.width / 2;
+					pendingMatrix.ty = matrix.ty - dimensions.height / 2;
+
+					inversePendingMatrix = pendingMatrix.clone();
+					inversePendingMatrix.invert();
+
+					var path:Path2D = cast new Path2D();
+					path.rect(0, 0, canvas.width, canvas.height);
+					path.closePath();
+					var gradientMatrix:DOMMatrix = new DOMMatrix([matrix.a, matrix.b, matrix.c, matrix.d, matrix.tx, matrix.ty]);
+					var inverseMatrix = cast gradientMatrix.inverse();
+					var untransformedPath:Path2D = cast new Path2D();
+					untransformedPath.addPath(path, inverseMatrix);
+					context2.fillStyle = gradientFill;
+					context2.setTransform(gradientMatrix);
+					context2.fill(untransformedPath);
+
+					pattern = cast context.createPattern(canvas, 'no-repeat');
+				}
+		}
+
+		if (point != null) Point.__pool.release(point);
+		if (point2 != null) Point.__pool.release(point2);
+		if (releaseMatrix) Matrix.__pool.release(matrix);
+
+		return pattern;
+		#end
+	}
 
 	private static function getRGBA(color:UInt, alpha:Float):String
 	{
-		var r:UInt = (color & 0xFF0000)>>>16;
-		var g:UInt = (color & 0x00FF00)>>>8;
+		var r:UInt = (color & 0xFF0000) >>> 16;
+		var g:UInt = (color & 0x00FF00) >>> 8;
 		var b:UInt = (color & 0x0000FF);
 
 		return "rgba(" + r + ", " + g + ", " + b + ", " + alpha + ")";
@@ -273,8 +282,8 @@ class CanvasGraphics
 			w = h = 819.2;
 		}
 		return {
-			width:w,
-			height:h
+			width: w,
+			height: h
 		};
 	}
 
@@ -1180,8 +1189,7 @@ class CanvasGraphics
 						if (canOptimizeMatrix && st >= 0 && sl >= 0 && sr <= bitmapFill.width && sb <= bitmapFill.height)
 						{
 							optimizationUsed = true;
-							if (!hitTesting) context.drawImage(bitmapFill.image.src, sl, st, sr - sl, sb - st, c.x - offsetX, c.y - offsetY, c.width,
-								c.height);
+							if (!hitTesting) context.drawImage(bitmapFill.image.src, sl, st, sr - sl, sb - st, c.x - offsetX, c.y - offsetY, c.width, c.height);
 						}
 					}
 

--- a/src/openfl/text/_internal/TextEngine.hx
+++ b/src/openfl/text/_internal/TextEngine.hx
@@ -867,8 +867,13 @@ class TextEngine
 			{
 				return html5Positions();
 			}
-
+			
+			#if skip_measurement_cache
+			return return html5Positions();
+			#else
 			return __shapeCache.cache(formatRange, html5Positions, text.substring(startIndex, endIndex));
+			#end
+				
 			#else
 			if (__textLayout == null)
 			{
@@ -898,8 +903,13 @@ class TextEngine
 			{
 				return __textLayout.positions;
 			}
-
+			
+			#if skip_measurement_cache
+			return __textLayout.positions;
+			#else
 			return __shapeCache.cache(formatRange, __textLayout);
+			#end
+				
 			#end
 		} #if !js inline #end function getPositionsWidth(positions:#if (js && html5) Array<Float> #else Array<GlyphPosition> #end):Float
 

--- a/src/openfl/text/_internal/TextEngine.hx
+++ b/src/openfl/text/_internal/TextEngine.hx
@@ -869,7 +869,7 @@ class TextEngine
 			}
 			
 			#if skip_measurement_cache
-			return return html5Positions();
+			return html5Positions();
 			#else
 			return __shapeCache.cache(formatRange, html5Positions, text.substring(startIndex, endIndex));
 			#end


### PR DESCRIPTION
In it's current state, OpenFL ignores the `spreadMethod` parameter passed to the `beginGradientFill()` method when
targeting HTML5. This parameter controls the look of gradients.
Hence the following sample snippet:
```
package;

import openfl.display.Sprite;
import openfl.display.Shape;
import openfl.display.Sprite;
import openfl.display.GradientType;
import openfl.display.SpreadMethod;
import openfl.geom.Matrix;

class Main extends Sprite
{

	public function new()
	{
		super();
		var gradient:Shape;
		var fillType:String = GradientType.LINEAR;
		var colors:Array<UInt> = [0x2f252c, 0xd3ccb2, 0x6e6751];
		var alphas:Array<Float> = [1, 1, 1];
		var ratios:Array<Int> = [80, 150, 255];
		var mat:Matrix = new Matrix();
		var spreadMethod:String = "";
		mat.createGradientBox(150, 100, Math.PI / 4, 0, 0);
		for (a in 0...3)
		{
			switch (a)
			{
				case 0:
					spreadMethod = SpreadMethod.PAD;
				case 1:
					spreadMethod = SpreadMethod.REPEAT;
				case 2:
					spreadMethod = SpreadMethod.REFLECT;
			}
			gradient = new Shape();
			gradient.graphics.beginGradientFill(fillType, colors, alphas, ratios, mat, spreadMethod);
			gradient.graphics.drawRect(0, 0, 250, 250);
			gradient.graphics.endFill();
			gradient.x = a * 260;
			addChild(gradient);
		}
	}

}
```
which the Flashplayer displays like this:
![flashGradient](https://github.com/openfl/openfl/assets/22029272/bba8c196-946f-4bc0-9021-de0fe6ec3a1c)

looks like this when viewed inside the browser:
![openflGradient](https://github.com/openfl/openfl/assets/22029272/a4819b6b-1aca-4d98-befb-b210f74916dd)

With this pull request, things will look way closer to the original:
![fixedGradient](https://github.com/openfl/openfl/assets/22029272/c1c90123-f38e-4cfd-9290-ef042d734185)

Please note though that this just fixes **linear** gradients - I did not put my hands on radial gradients yet.