### PR TITLE
Avoid integer overflow when calculating sound length.

### DIFF
--- a/src/openfl/media/Sound.hx
+++ b/src/openfl/media/Sound.hx
@@ -867,7 +867,7 @@ class Sound extends EventDispatcher
 			#else
 			if (__buffer.data != null)
 			{
-				var samples = (__buffer.data.length * 8) / (__buffer.channels * __buffer.bitsPerSample);
+				var samples = (__buffer.data.length * 8.0) / (__buffer.channels * __buffer.bitsPerSample);
 				return Std.int(samples / __buffer.sampleRate * 1000);
 			}
 			else if (__buffer.__srcVorbisFile != null)


### PR DESCRIPTION
Attempting to address the same issue as in #2667, without changing as much.

Multiplying `data.length * 8` produces a high number, which in the case of very long audio files can exceed the integer limit. Multiplying by 8.0 coerces to float, allowing much higher values.

To see the overflow in action, see [this demo](https://try.haxe.org/#a51950E8).