### PR TITLE
Update Bitmap.hx to support ScrollRect size.

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -132,7 +132,10 @@ class Bitmap extends DisplayObject
 	@:noCompletion private override function __getBounds(rect:Rectangle, matrix:Matrix):Void
 	{
 		var bounds = Rectangle.__pool.get();
-		if (__bitmapData != null)
+		if (scrollRect != null){
+			bounds.setTo(0, 0, scrollRect.width, scrollRect.height);
+		}
+		else if (__bitmapData != null)
 		{
 			bounds.setTo(0, 0, __bitmapData.width, __bitmapData.height);
 		}

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -222,7 +222,11 @@ class Bitmap extends DisplayObject
 	{
 		if (__bitmapData != null)
 		{
-			scaleY = value / __bitmapData.height; // get_height();
+			if (scrollRect != null) {
+				scaleY = value / scrollRect.height;
+			} else {
+				scaleY = value / __bitmapData.height; // get_height();
+			}
 		}
 		else
 		{
@@ -235,7 +239,11 @@ class Bitmap extends DisplayObject
 	{
 		if (__bitmapData != null)
 		{
-			scaleX = value / __bitmapData.width; // get_width();
+			if (scrollRect != null) {
+				scaleX = value / scrollRect.width;
+			} else {
+				scaleX = value / __bitmapData.width; // get_width();
+			}
 		}
 		else
 		{


### PR DESCRIPTION
When using ScrollRect, it will result in the width and height still being the original size, making it very difficult to calculate the actual proportion and size when using it.

Fix:
```haxe
var bitmap = new Bitmap();
bitmap.bitmapData = bitmapData; // size: 256x256
bitmap.scrollRect = new Rectangle(0,0,100,100);
trace(bitmap.width,bitmap.height); // right: 100, error: 256
```