### PR TITLE
Fix BitmapData.draw readable=false render error.

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -919,6 +919,7 @@ class BitmapData implements IBitmapDrawable
 			}
 
 			var renderer = new OpenGLRenderer(Lib.current.stage.context3D, this);
+			renderer.__stage = Lib.current.stage;
 			renderer.__allowSmoothing = smoothing;
 			renderer.__overrideBlendMode = blendMode;
 
@@ -940,6 +941,7 @@ class BitmapData implements IBitmapDrawable
 				renderer.__popMaskRect();
 				Matrix.__pool.release(clipMatrix);
 			}
+			renderer.__stage = null;
 		}
 		else
 		{


### PR DESCRIPTION
```shell
Uncaught TypeError TypeError: Cannot read properties of null (reading 'window')
    at __scissorRect (/Users/rainy/Documents/haxelib-self/openfl/src/openfl/display/ShaderInput.hx:178:29)
    at __pushMaskRect (/Users/rainy/Documents/haxelib-self/openfl/src/openfl/display/Preloader.hx:20:62)
    at openfl_display__$internal_Context3DTilemap.render (/Users/rainy/Documents/haxelib-self/openfl/src/openfl/display/_internal/Context3DVideo.hx:74:5)
    at openfl_display__$internal_Context3DTilemap.renderDrawable (/Users/rainy/Documents/haxelib-self/openfl/src/openfl/display/_internal/Context3DVideo.hx:119:46)
```
Code:
```haxe
var bitmapData:BitmapData = new BitmapData(Std.int(Start.current.getStageWidth()), Std.int(Start.current.getStageHeight()));
@:privateAccess bitmapData.readable = false;
bitmapData.draw(this.stage);
var bitmap = new Bitmap(bitmapData);
Start.current.getTopView().addChild(bitmap);
```