### PR TITLE
CanvasTilemap compressed texture crash fixed

### DIFF
--- a/src/openfl/display/_internal/CanvasTilemap.hx
+++ b/src/openfl/display/_internal/CanvasTilemap.hx
@@ -138,7 +138,7 @@ class CanvasTilemap
 				}
 
 				bitmapData = tileset.__bitmapData;
-				if (bitmapData == null) continue;
+				if (bitmapData == null || bitmapData.image == null) continue;
 
 				if (bitmapData != cacheBitmapData)
 				{


### PR DESCRIPTION
When I create a tilemap with a compressed texture to draw using bitmapData, the application crashes.
The main source of the problem is that textures do not have the image variable.
As it should, it will skip textures and only draw what can be drawn.

This commit will solve the problem.