### PR TITLE
Add mipmapping support in the OpenGL rendering

### DIFF
--- a/src/openfl/display3D/textures/TextureBase.hx
+++ b/src/openfl/display3D/textures/TextureBase.hx
@@ -313,7 +313,14 @@ class TextureBase extends EventDispatcher
 
 			if (__textureTarget == __context.gl.TEXTURE_CUBE_MAP) __context.__bindGLTextureCubeMap(__textureID);
 			else
+			{
 				__context.__bindGLTexture2D(__textureID);
+				if (state.mipfilter != MIPNONE)
+				{
+					gl.generateMipmap(__textureTarget);
+					state.mipmapGenerated = true;
+				}
+			}
 
 			var wrapModeS = 0, wrapModeT = 0;
 
@@ -361,12 +368,8 @@ class TextureBase extends EventDispatcher
 			gl.texParameteri(__textureTarget, gl.TEXTURE_MAG_FILTER, magFilter);
 			gl.texParameteri(__textureTarget, gl.TEXTURE_WRAP_S, wrapModeS);
 			gl.texParameteri(__textureTarget, gl.TEXTURE_WRAP_T, wrapModeT);
+			gl.texParameterf(__textureTarget, 34049, state.lodBias); // GL_TEXTURE_LOD_BIAS
 
-			if (state.lodBias != 0.0)
-			{
-				// TODO
-				// throw new IllegalOperationError("Lod bias setting not supported yet");
-			}
 
 			if (__samplerState == null) __samplerState = state.clone();
 			__samplerState.copyFrom(state);


### PR DESCRIPTION
MIP maps (also known as mipmaps), are bitmaps grouped together and associated with a texture to increase runtime rendering quality and performance. Each bitmap image in the MIP map is a version of the main bitmap image, but at a reduced level of detail from the main image. (taken from the [Actionscript developer guide](https://help.adobe.com/en_US/as3/dev/WS5b3ccc516d4fbf351e63e3d118a9b90204-7d5b.html))

This PR generates Mipmaps from a texture, plus sets a specific lod bias specified in the `SamplerState`