### PR TITLE
Refer to OpenAL constants instead of instance variables.

### DIFF
--- a/src/openfl/media/SoundChannel.hx
+++ b/src/openfl/media/SoundChannel.hx
@@ -14,6 +14,7 @@ import js.html.audio.ScriptProcessorNode;
 #if lime_openal
 import openfl.events.SampleDataEvent;
 import openfl.utils.ByteArray;
+import lime.media.openal.AL;
 import lime.media.openal.ALBuffer;
 import lime.media.openal.ALSource;
 import lime.utils.ArrayBufferView;
@@ -237,9 +238,9 @@ import lime.utils.Int16Array;
 			{
 				bufferSize = 0;
 				__alSource = alAudioContext.createSource();
-				alAudioContext.sourcef(__alSource, alAudioContext.GAIN, 1);
-				alAudioContext.source3f(__alSource, alAudioContext.POSITION, 0, 0, 0);
-				alAudioContext.sourcef(__alSource, alAudioContext.PITCH, 1.0);
+				alAudioContext.sourcef(__alSource, AL.GAIN, 1);
+				alAudioContext.source3f(__alSource, AL.POSITION, 0, 0, 0);
+				alAudioContext.sourcef(__alSource, AL.PITCH, 1.0);
 
 				__alBuffers = alAudioContext.genBuffers(__numberOfBuffers);
 				__outputBuffer = new ByteArray();
@@ -251,13 +252,13 @@ import lime.utils.Int16Array;
 					{
 						bufferSize = __sampleDataEvent.getBufferSize();
 						__sampleDataEvent.getSamples(__outputBuffer);
-						alAudioContext.bufferData(__alBuffers[a], alAudioContext.FORMAT_STEREO16, __bufferView, bufferSize * 4, 44100);
+						alAudioContext.bufferData(__alBuffers[a], AL.FORMAT_STEREO16, __bufferView, bufferSize * 4, 44100);
 					}
 					else
 					{
 						__sound.dispatchEvent(__sampleDataEvent);
 						__sampleDataEvent.getSamples(__outputBuffer);
-						alAudioContext.bufferData(__alBuffers[a], alAudioContext.FORMAT_STEREO16, __bufferView, bufferSize * 4, 44100);
+						alAudioContext.bufferData(__alBuffers[a], AL.FORMAT_STEREO16, __bufferView, bufferSize * 4, 44100);
 					}
 				}
 
@@ -394,7 +395,7 @@ import lime.utils.Int16Array;
 
 		if (alAudioContext != null)
 		{
-			var bufferState = alAudioContext.getSourcei(__alSource, alAudioContext.BUFFERS_PROCESSED);
+			var bufferState = alAudioContext.getSourcei(__alSource, AL.BUFFERS_PROCESSED);
 			if (bufferState > 0)
 			{
 				__emptyBuffers = alAudioContext.sourceUnqueueBuffers(__alSource, bufferState);
@@ -409,13 +410,13 @@ import lime.utils.Int16Array;
 					else
 					{
 						__sampleDataEvent.getSamples(__outputBuffer);
-						alAudioContext.bufferData(__emptyBuffers[a], alAudioContext.FORMAT_STEREO16, __bufferView, __sampleDataEvent.getBufferSize() * 4,
+						alAudioContext.bufferData(__emptyBuffers[a], AL.FORMAT_STEREO16, __bufferView, __sampleDataEvent.getBufferSize() * 4,
 							44100);
 						alAudioContext.sourceQueueBuffer(__alSource, __emptyBuffers[a]);
 					}
 				}
 
-				if (hasSampleData && alAudioContext.getSourcei(__alSource, alAudioContext.SOURCE_STATE) != alAudioContext.PLAYING)
+				if (hasSampleData && alAudioContext.getSourcei(__alSource, AL.SOURCE_STATE) != AL.PLAYING)
 				{
 					alAudioContext.sourcePlay(__alSource);
 				}


### PR DESCRIPTION
Most likely, the intent was to allow users to override these values, but there isn't a clear use case for doing so. Audio libraries besides OpenAL might use other constants, but in that case `#if lime_openal` would fail and this code wouldn't even run.

If this is merged, we could then clean up the 74 variables from [`OpenALAudioContext`](https://github.com/openfl/lime/blob/develop/src/lime/media/OpenALAudioContext.hx). (This is only a fraction of the constants listed in `AL`, and I'm not sure why those 74 were picked. They aren't even all used.)

Speaking of, I also don't think `**OpenAL**AudioContext` would function correctly if the backend library isn't OpenAL. I guess we could rename it to just `AudioContext` and then add some backend-switching code... Oh wait, [we already have `lime.media.AudioContext`](https://github.com/openfl/lime/blob/develop/src/lime/media/AudioContext.hx).

Is there a use case I'm missing here? It just seems pointlessly risky to be using variables.