### PR TITLE
fix error handling based on flash behavior

### DIFF
--- a/src/openfl/Lib.hx
+++ b/src/openfl/Lib.hx
@@ -526,7 +526,18 @@ import js.Browser;
 		__timers[id] = timer;
 		timer.run = function()
 		{
+			#if flash
 			Reflect.callMethod(closure, closure, args == null ? [] : args);
+			#else
+			try
+			{
+				Reflect.callMethod(closure, closure, args == null ? [] : args);
+			}
+			catch (e:Dynamic)
+			{
+				@:privateAccess Lib.current.stage.__handleError(e);
+			}
+			#end
 		};
 		return id;
 	}
@@ -559,7 +570,18 @@ import js.Browser;
 		__timers[id] = Timer.delay(function()
 		{
 			__timers.remove(id);
+			#if flash
 			Reflect.callMethod(closure, closure, args == null ? [] : args);
+			#else
+			try
+			{
+				Reflect.callMethod(closure, closure, args == null ? [] : args);
+			}
+			catch (e)
+			{
+				@:privateAccess Lib.current.stage.__handleError(e);
+			}
+			#end
 		}, delay);
 		return id;
 	}

--- a/src/openfl/Lib.hx
+++ b/src/openfl/Lib.hx
@@ -577,7 +577,7 @@ import js.Browser;
 			{
 				Reflect.callMethod(closure, closure, args == null ? [] : args);
 			}
-			catch (e)
+			catch (e:Dynamic)
 			{
 				@:privateAccess Lib.current.stage.__handleError(e);
 			}

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1480,11 +1480,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	{
 		var event = new UncaughtErrorEvent(UncaughtErrorEvent.UNCAUGHT_ERROR, true, true, e);
 
-		try
-		{
-			Lib.current.__loaderInfo.uncaughtErrorEvents.dispatchEvent(event);
-		}
-		catch (e:Dynamic) {}
+		Lib.current.__loaderInfo.uncaughtErrorEvents.dispatchEvent(event);
 
 		if (!event.__preventDefault)
 		{

--- a/src/openfl/events/EventDispatcher.hx
+++ b/src/openfl/events/EventDispatcher.hx
@@ -419,7 +419,7 @@ class EventDispatcher implements IEventDispatcher
                         {
 							weakCallback(event);
 						}
-						catch (e)
+						catch (e:Dynamic)
 						{
 							if(!(event is UncaughtErrorEvent))
 								@:privateAccess Lib.current.stage.__handleError(e);
@@ -432,7 +432,7 @@ class EventDispatcher implements IEventDispatcher
                     {
 						listener.callback(event);
 					}
-					catch (e)
+					catch (e:Dynamic)
 					{
 						if(!(event is UncaughtErrorEvent))
 							@:privateAccess Lib.current.stage.__handleError(e);
@@ -443,7 +443,7 @@ class EventDispatcher implements IEventDispatcher
 				{
 					listener.callback(event);
 				}
-				catch (e)
+				catch (e:Dynamic)
 				{
 					if(!(event is UncaughtErrorEvent))
 						@:privateAccess Lib.current.stage.__handleError(e);

--- a/src/openfl/events/EventDispatcher.hx
+++ b/src/openfl/events/EventDispatcher.hx
@@ -415,15 +415,39 @@ class EventDispatcher implements IEventDispatcher
 					}
 					else
 					{
-						weakCallback(event);
+						try
+                        {
+							weakCallback(event);
+						}
+						catch (e)
+						{
+							if(!(event is UncaughtErrorEvent))
+								@:privateAccess Lib.current.stage.__handleError(e);
+						}
 					}
 				}
 				else
 				{
-					listener.callback(event);
+					try
+                    {
+						listener.callback(event);
+					}
+					catch (e)
+					{
+						if(!(event is UncaughtErrorEvent))
+							@:privateAccess Lib.current.stage.__handleError(e);
+					}
 				}
 				#else
-				listener.callback(event);
+				try
+				{
+					listener.callback(event);
+				}
+				catch (e)
+				{
+					if(!(event is UncaughtErrorEvent))
+						@:privateAccess Lib.current.stage.__handleError(e);
+				}
 				#end
 
 				if (event.__isCanceledNow)


### PR DESCRIPTION
This commit, makes error handling similar to flash.

Test Code:
```haxe
package;

import flash.display.Sprite;
import flash.errors.Error;
import flash.events.Event;
import flash.events.UncaughtErrorEvent;
class Main extends Sprite
{
    public function new()
    {
        super();
		
		this.loaderInfo.uncaughtErrorEvents.addEventListener(UncaughtErrorEvent.UNCAUGHT_ERROR, onUncaughtError);

        openfl.Lib.setTimeout(function()
        {
            throw new Error("Interval Fail!");
        }, 500);
		
		addEventListener(CustomEvent.GOT_RESULT, onGotResult);
		addEventListener(CustomEvent.GOT_RESULT, onGotResult2);
		dispatchEvent(new CustomEvent(CustomEvent.GOT_RESULT, {}));
				
		var event = new UncaughtErrorEvent(UncaughtErrorEvent.UNCAUGHT_ERROR, true, true, new Error("test"));
		this.loaderInfo.uncaughtErrorEvents.dispatchEvent(event);
		trace("Execution finished!");
    }
	
	private function onGotResult(e:CustomEvent):Void
	{
		throw new Error("onGotResult Fail!");
	}
	
	private function onGotResult2(e:CustomEvent):Void
	{
		throw new Error("onGotResult2 Running!");
	}
	
	private function onUncaughtError(e:UncaughtErrorEvent):Void
	{
		e.preventDefault();
		trace(e.error);
		
		// The only difference in behavior is that in flash if you throw an error in onUncaughtError, the UncaughtErrorEvent.UNCAUGHT_ERROR event will run again for one time, but in OpenFL the event will not run again.
		//throw new Error("onUncaughtError fail!");
	}
}

class CustomEvent extends Event
{
    public static var GOT_RESULT:String = "gotResult";

    public var result:Dynamic;

    public function new(type:String, result:Dynamic, bubbles:Bool=false, cancelable:Bool=false)
    {
        super(type, bubbles, cancelable);
        this.result = result;
    }

    public override function clone():Event
    {
        return new CustomEvent(type, result, bubbles, cancelable);
    }
}
```

Flash Output:
```
src/Main.hx:42: Error: onGotResult Fail!
src/Main.hx:42: Error: onGotResult2 Running!
src/Main.hx:42: Error: test
src/Main.hx:26: Execution finished!
src/Main.hx:42: Error: Interval Fail!
```

OpenFL (HTML5 Target) Output:
```
src/Main.hx:42: onGotResult Fail!
src/Main.hx:42: onGotResult2 Running!
src/Main.hx:42: test
src/Main.hx:26: Execution finished!
src/Main.hx:42: Interval Fail!
```