### PR TITLE
Make `ByteArray` compatible with Haxe's `Bytes` class.

### DIFF
--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -1103,17 +1103,17 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 				set: ByteArrayData.prototype.set_endian
 			},
 			"length": {
-				get: ByteArrayData.prototype.get_length,
-				set: ByteArrayData.prototype.set_length
+				get: ByteArrayData.prototype.openfljs_get_length,
+				set: ByteArrayData.prototype.openfljs_set_length
 			}
 		});
 	}
-	private function get_length():Int
+	private function openfljs_get_length():Int
 	{
 		return __length;
 	}
 
-	private function set_length(value:Int):Int
+	private function openfljs_set_length(value:Int):Int
 	{
 		return (this : ByteArray).length = value;
 	}

--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -1007,8 +1007,10 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if display
 		return 0;
-		#else
+		#elseif openfljs
 		return this == null ? 0 : this.__length;
+		#else
+		return this == null ? 0 : this.length;
 		#end
 	}
 
@@ -1016,7 +1018,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if display
 		#elseif flash
-		this.__length = value;
+		this.length = value;
 		#else
 		if (value >= 0)
 		{
@@ -1024,7 +1026,11 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 			if (value < this.position) this.position = value;
 		}
 
+		#if openfljs
 		this.__length = value;
+		#else
+		this.length = value;
+		#end
 		#end
 
 		return value;

--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -1070,6 +1070,9 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	public var position:Int;
 
 	@:noCompletion private var __endian:Endian;
+	/**
+		The number of bytes allocated. May be ~50% larger than `length`.
+	**/
 	@:noCompletion private var __length:Int;
 
 	#if lime_bytes_length_getter

--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -1008,7 +1008,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		#if display
 		return 0;
 		#else
-		return this == null ? 0 : this.length;
+		return this == null ? 0 : this.__length;
 		#end
 	}
 
@@ -1016,7 +1016,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if display
 		#elseif flash
-		this.length = value;
+		this.__length = value;
 		#else
 		if (value >= 0)
 		{
@@ -1155,9 +1155,9 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if lime
 		#if js
-		if (__allocated > length)
+		if (__allocated > __length)
 		{
-			var cacheLength = length;
+			var cacheLength = __length;
 			__length = __allocated;
 			var data = Bytes.alloc(cacheLength);
 			data.blit(0, this, 0, cacheLength);
@@ -1180,7 +1180,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 			__setData(bytes);
 
 			__length = __allocated;
-			position = length;
+			position = __length;
 		}
 		#end
 	}
@@ -1223,7 +1223,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readBoolean():Bool
 	{
-		if (position < length)
+		if (position < __length)
 		{
 			return (get(position++) != 0);
 		}
@@ -1250,14 +1250,14 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readBytes(bytes:ByteArray, offset:Int = 0, length:Int = 0):Void
 	{
-		if (length == 0) length = this.length - position;
+		if (length == 0) length = __length - position;
 
-		if (position + length > this.length)
+		if (position + length > __length)
 		{
 			throw new EOFError();
 		}
 
-		if ((bytes : ByteArrayData).length < offset + length)
+		if ((bytes : ByteArrayData).__length < offset + length)
 		{
 			(bytes : ByteArrayData).__resize(offset + length);
 		}
@@ -1270,7 +1270,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		if (endian == LITTLE_ENDIAN)
 		{
-			if (position + 8 > length)
+			if (position + 8 > __length)
 			{
 				throw new EOFError();
 				return 0;
@@ -1292,7 +1292,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		if (endian == LITTLE_ENDIAN)
 		{
-			if (position + 4 > length)
+			if (position + 4 > __length)
 			{
 				throw new EOFError();
 				return 0;
@@ -1472,7 +1472,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readUnsignedByte():Int
 	{
-		if (position < length)
+		if (position < __length)
 		{
 			return get(position++);
 		}
@@ -1523,7 +1523,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readUTFBytes(length:Int):String
 	{
-		if (position + length > this.length)
+		if (position + length > __length)
 		{
 			throw new EOFError();
 		}
@@ -1537,9 +1537,9 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if lime
 		#if js
-		if (__allocated > length)
+		if (__allocated > __length)
 		{
-			var cacheLength = length;
+			var cacheLength = __length;
 			__length = __allocated;
 			var data = Bytes.alloc(cacheLength);
 			data.blit(0, this, 0, cacheLength);
@@ -1731,7 +1731,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 			if (__allocated > 0)
 			{
-				var cacheLength = length;
+				var cacheLength = __length;
 				__length = __allocated;
 				bytes.blit(0, this, 0, __allocated);
 				__length = cacheLength;
@@ -1740,7 +1740,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 			__setData(bytes);
 		}
 
-		if (length < size)
+		if (__length < size)
 		{
 			__length = size;
 		}
@@ -1751,7 +1751,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		#if eval
 		// TODO: Not quite correct, but this will probably
 		// not be called while in a macro
-		var count = bytes.length < length ? bytes.length : length;
+		var count = bytes.length < __length ? bytes.length : __length;
 		for (i in 0...count)
 			set(i, bytes.get(i));
 		#else
@@ -1768,7 +1768,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	// Get & Set Methods
 	@:noCompletion private inline function get_bytesAvailable():Int
 	{
-		return length - position;
+		return __length - position;
 	}
 
 	@:noCompletion private inline static function get_defaultEndian():Endian

--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -1007,8 +1007,6 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if display
 		return 0;
-		#elseif lime_bytes_length_getter
-		return this == null ? 0 : this.l;
 		#else
 		return this == null ? 0 : this.length;
 		#end
@@ -1018,8 +1016,6 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if display
 		#elseif flash
-		this.length = value;
-		#elseif lime_bytes_length_getter
 		this.length = value;
 		#else
 		if (value >= 0)
@@ -1097,10 +1093,6 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_endian (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_endian (v); }")
 			},
-			"length": {
-				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_length (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_length (v); }")
-			},
 		});
 	}
 	#end
@@ -1141,22 +1133,14 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if lime
 		#if js
-		if (__length > #if lime_bytes_length_getter l #else length #end)
+		if (__length > length)
 		{
-			var cacheLength = #if lime_bytes_length_getter l #else length #end;
-			#if lime_bytes_length_getter
-			this.l = __length;
-			#else
-			this.length = __length;
-			#end
+			var cacheLength = length;
+			length = __length;
 			var data = Bytes.alloc(cacheLength);
 			data.blit(0, this, 0, cacheLength);
 			__setData(data);
-			#if lime_bytes_length_getter
-			this.l = cacheLength;
-			#else
-			this.length = cacheLength;
-			#end
+			length = cacheLength;
 		}
 		#end
 
@@ -1173,13 +1157,8 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		{
 			__setData(bytes);
 
-			#if lime_bytes_length_getter
-			l
-			#else
-			length
-			#end
-			= __length;
-			position = #if lime_bytes_length_getter l #else length #end;
+			length = __length;
+			position = length;
 		}
 		#end
 	}
@@ -1222,7 +1201,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readBoolean():Bool
 	{
-		if (position < #if lime_bytes_length_getter l #else length #end)
+		if (position < length)
 		{
 			return (get(position++) != 0);
 		}
@@ -1249,9 +1228,9 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readBytes(bytes:ByteArray, offset:Int = 0, length:Int = 0):Void
 	{
-		if (length == 0) length = #if lime_bytes_length_getter l #else this.length #end - position;
+		if (length == 0) length = this.length - position;
 
-		if (position + length > #if lime_bytes_length_getter l #else this.length #end)
+		if (position + length > this.length)
 		{
 			throw new EOFError();
 		}
@@ -1269,7 +1248,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		if (endian == LITTLE_ENDIAN)
 		{
-			if (position + 8 > #if lime_bytes_length_getter l #else length #end)
+			if (position + 8 > length)
 			{
 				throw new EOFError();
 				return 0;
@@ -1291,7 +1270,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		if (endian == LITTLE_ENDIAN)
 		{
-			if (position + 4 > #if lime_bytes_length_getter l #else length #end)
+			if (position + 4 > length)
 			{
 				throw new EOFError();
 				return 0;
@@ -1471,7 +1450,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readUnsignedByte():Int
 	{
-		if (position < #if lime_bytes_length_getter l #else length #end)
+		if (position < length)
 		{
 			return get(position++);
 		}
@@ -1522,7 +1501,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readUTFBytes(length:Int):String
 	{
-		if (position + length > #if lime_bytes_length_getter l #else this.length #end)
+		if (position + length > this.length)
 		{
 			throw new EOFError();
 		}
@@ -1536,22 +1515,14 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		#if lime
 		#if js
-		if (__length > #if lime_bytes_length_getter l #else length #end)
+		if (__length > length)
 		{
-			var cacheLength = #if lime_bytes_length_getter l #else length #end;
-			#if lime_bytes_length_getter
-			this.l = __length;
-			#else
-			this.length = __length;
-			#end
+			var cacheLength = length;
+			length = __length;
 			var data = Bytes.alloc(cacheLength);
 			data.blit(0, this, 0, cacheLength);
 			__setData(data);
-			#if lime_bytes_length_getter
-			this.l = cacheLength;
-			#else
-			this.length = cacheLength;
-			#end
+			length = cacheLength;
 		}
 		#end
 
@@ -1568,12 +1539,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		{
 			__setData(bytes);
 
-			#if lime_bytes_length_getter
-			l
-			#else
-			length
-			#end
-			= __length;
+			length = __length;
 		}
 		#end
 
@@ -1716,7 +1682,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		var bytes = Bytes.ofString(value);
 
-		writeShort(#if lime_bytes_length_getter bytes.l #else bytes.length #end);
+		writeShort(bytes.length);
 		writeBytes(bytes);
 	}
 
@@ -1729,11 +1695,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	@:noCompletion private function __fromBytes(bytes:Bytes):Void
 	{
 		__setData(bytes);
-		#if lime_bytes_length_getter
-		l = bytes.l;
-		#else
 		length = bytes.length;
-		#end
 	}
 
 	@:noCompletion private function __resize(size:Int):Void
@@ -1747,28 +1709,18 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 			if (__length > 0)
 			{
-				var cacheLength = #if lime_bytes_length_getter l #else length #end;
-				#if lime_bytes_length_getter
-				l
-				#else
-				length
-				#end
-				= __length;
+				var cacheLength = length;
+				length = __length;
 				bytes.blit(0, this, 0, __length);
-				#if lime_bytes_length_getter
-				l
-				#else
-				length
-				#end
-				= cacheLength;
+				length = cacheLength;
 			}
 
 			__setData(bytes);
 		}
 
-		if (#if lime_bytes_length_getter l #else length #end < size)
+		if (length < size)
 		{
-			#if lime_bytes_length_getter l #else length #end = size;
+			length = size;
 		}
 	}
 
@@ -1784,7 +1736,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		b = bytes.b;
 		#end
 
-		__length = #if lime_bytes_length_getter bytes.l #else bytes.length #end;
+		__length = bytes.length;
 
 		#if js
 		data = bytes.data;
@@ -1794,7 +1746,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	// Get & Set Methods
 	@:noCompletion private inline function get_bytesAvailable():Int
 	{
-		return #if lime_bytes_length_getter l #else length #end - position;
+		return length - position;
 	}
 
 	@:noCompletion private inline static function get_defaultEndian():Endian
@@ -1834,24 +1786,6 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 	{
 		return __endian = value;
 	}
-
-	#if lime_bytes_length_getter
-	@:noCompletion private override function set_length(value:Int):Int
-	{
-		#if display
-		#else
-		if (value >= 0)
-		{
-			this.__resize(value);
-			if (value < this.position) this.position = value;
-		}
-
-		this.l = value;
-		#end
-
-		return value;
-	}
-	#end
 }
 #else
 #if flash


### PR DESCRIPTION
Currently, Lime shadows `haxe.io.Bytes`, but we might not have to. I'm trying to rewrite any piece of code that references [the shadowed version of the class](https://github.com/openfl/lime/blob/2ccee960dc43cc338ad70425bae953ff30c779d9/src/haxe/io/Bytes.hx) to refer to the original version instead.

`ByteArrayData` is one such piece of code. It includes lots of references to the private variable [`l`](https://github.com/openfl/lime/blob/2ccee960dc43cc338ad70425bae953ff30c779d9/src/haxe/io/Bytes.hx#L671), which only exists in Lime's version of the class.

For whatever reason, [openfl-js](https://github.com/openfl/openfl-js) wants `length` to be a property with a getter and setter. But it also wants to be able to bypass those accessors. But it _also_ doesn't want to use Haxe's accessors that can be bypassed using `@:bypassAccessor`; it calls [`Object.defineProperties()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties) at runtime. So it stores the value in `l`, and uses `l` when it wants to bypass the accessors.

It all works, of course. But I can't seem to find any reason for any of it. `ByteArray` is the public API for all this, and it defines a perfectly functional getter and setter. There's no need for `ByteArrayData` to have its own setter on top of that. Is there? (I'll admit I've never actually used openfl-js, but I did make sure it still compiles after these changes.)