### PR TITLE
Work around text highlighting crash.

### DIFF
--- a/src/openfl/display/_internal/CairoTextField.hx
+++ b/src/openfl/display/_internal/CairoTextField.hx
@@ -355,13 +355,6 @@ class CairoTextField
 								selectionEnd = group.endIndex;
 							}
 
-							// this isn't supposed to happen, but better to
-							// avoid a crash if there's a bug somewhere
-							if (glyphs.length < selectionEnd - selectionStart)
-							{
-								selectionEnd = selectionStart + glyphs.length;
-							}
-
 							var start, end;
 
 							start = textField.getCharBoundaries(selectionStart);
@@ -393,6 +386,11 @@ class CairoTextField
 
 								selectionStart -= group.startIndex;
 								selectionEnd -= group.startIndex;
+								if (selectionEnd > glyphs.length)
+								{
+									selectionEnd = glyphs.length;
+								}
+
 								for (i in selectionStart...selectionEnd)
 									selectedGylphs.push(glyphs[i]);
 								cairo.showGlyphs(selectedGylphs);


### PR DESCRIPTION
The wrong characters are still highlighted, but it no longer crashes, which is more important for now.