### PR TITLE
Adjust rendered DisplayObjects' dimensions with filters

### DIFF
--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -370,8 +370,8 @@ class DisplayObjectRenderer extends EventDispatcher
 
 				displayObject.__getFilterBounds(rect, displayObject.__cacheBitmapMatrix);
 
-				filterWidth = rect.width > 0 ? Math.ceil(rect.width * pixelRatio) : 0;
-				filterHeight = rect.height > 0 ? Math.ceil(rect.height * pixelRatio) : 0;
+				filterWidth = rect.width > 0 ? Math.floor(rect.width * pixelRatio) : 0;
+				filterHeight = rect.height > 0 ? Math.floor(rect.height * pixelRatio) : 0;
 
 				offsetX = rect.x > 0 ? Math.ceil(rect.x) : Math.floor(rect.x);
 				offsetY = rect.y > 0 ? Math.ceil(rect.y) : Math.floor(rect.y);

--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -370,8 +370,8 @@ class DisplayObjectRenderer extends EventDispatcher
 
 				displayObject.__getFilterBounds(rect, displayObject.__cacheBitmapMatrix);
 
-				filterWidth = rect.width > 0 ? Math.ceil((rect.width + 1) * pixelRatio) : 0;
-				filterHeight = rect.height > 0 ? Math.ceil((rect.height + 1) * pixelRatio) : 0;
+				filterWidth = rect.width > 0 ? Math.ceil(rect.width * pixelRatio) : 0;
+				filterHeight = rect.height > 0 ? Math.ceil(rect.height * pixelRatio) : 0;
 
 				offsetX = rect.x > 0 ? Math.ceil(rect.x) : Math.floor(rect.x);
 				offsetY = rect.y > 0 ? Math.ceil(rect.y) : Math.floor(rect.y);


### PR DESCRIPTION
This is has been an old bug;
For example if you put one or more filters on a Flixel's FlxCamera (that for rendering Shaders, and so Filters, uses an OpenFL's Sprite) on certain screens you can easily notice that the camera gains +1 pixel on the right and bottom side (and so it's oblivious that this doesn't happen on FlxCameras only but on every OpenFL's Rendered DisplayObjects).
Me and @NeeEoo found an easy way to fix this on certain resolutions which comprehends a lot of screen sizes actually (still testing on FlxCameras), but we feel like there could be a more dynamic fix so this is going to stay a draft until we find out a better fix.
Here's an example of two overlapped cameras with the bottom one using filters (filters on that camera'a OpenFL Sprite) and the top one not using them but having a black sprite that uses the camera's dimensions (better visible on larger screens or zooming): 
![Screenshot_20240319-135118_Gallery](https://github.com/openfl/openfl/assets/87421482/59633870-6bbf-4555-9548-6113e1763232)
As you can see the bottom camera with filters has one more pixel on bottom and right side than the one without filters.
This disappears with this Pull Request's fix.


