### PR TITLE
Implement `stage.mouseLock` and `MouseEvent.movement` properties

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -946,8 +946,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	#end
 	#if desktop
 	@:noCompletion private var __mouseLock:Bool;
-	@:noCompletion private var movementMouseX:Float;
-	@:noCompletion private var movementMouseY:Float;
+	@:noCompletion private var __movementX:Float;
+	@:noCompletion private var __movementY:Float;
 	#end
 
 	#if openfljs
@@ -2073,8 +2073,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	{
 		if (this.window == null || this.window != window) return;
 		#if desktop
-		movementMouseX = x;
-		movementMouseY = y;
+		__movementX = x;
+		__movementY = y;
 		#end
 	}
 
@@ -2726,9 +2726,11 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 							event.stageY = 0;
 							event.localX = 0;
 							event.localY = 0;
-							event.movementX = movementMouseX;
-							event.movementY = movementMouseY;
-						} else {
+							event.movementX = __movementX;
+							event.movementY = __movementY;
+						}
+						else
+						{
 							event.stageX = __mouseX;
 							event.stageY = __mouseY;
 							event.localX = __mouseX;
@@ -2750,7 +2752,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						#if desktop
 						if (__mouseLock)
 						{
-							event = MouseEvent.__create(MouseEvent.RELEASE_OUTSIDE, 1, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, this);
+							event = MouseEvent.__create(MouseEvent.RELEASE_OUTSIDE, 1, 0, 0, 0, new Point(0, 0), __movementX, __movementY, this);
 						}
 						else
 						{
@@ -2807,8 +2809,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			event.stageY = 0;
 			event.localX = 0;
 			event.localY = 0;
-			event.movementX = movementMouseX;
-			event.movementY = movementMouseY;
+			event.movementX = __movementX;
+			event.movementY = __movementY;
 		}
 		else
 		{
@@ -2835,7 +2837,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		#if desktop
 		if (window.mouseLock)
 		{
-			event = MouseEvent.__create(type, button, clickCount, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
+			event = MouseEvent.__create(type, button, clickCount, 0, 0, new Point(0, 0), __movementX, __movementY, target);
 		}
 		else
 		{
@@ -2869,8 +2871,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				event.stageY = 0;
 				event.localX = 0;
 				event.localY = 0;
-				event.movementX = movementMouseX;
-				event.movementY = movementMouseY;
+				event.movementX = __movementX;
+				event.movementY = __movementY;
 			}
 			else
 			{
@@ -2897,7 +2899,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			#if desktop
 			if (window.mouseLock)
 			{
-				event = MouseEvent.__create(clickType, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
+				event = MouseEvent.__create(clickType, button, 0, 0, 0, new Point(0, 0), __movementX, __movementY, target);
 			}
 			else
 			{
@@ -2934,8 +2936,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						event.stageY = 0;
 						event.localX = 0;
 						event.localY = 0;
-						event.movementX = movementMouseX;
-						event.movementY = movementMouseY;
+						event.movementX = __movementX;
+						event.movementY = __movementY;
 					}
 					else
 					{
@@ -2962,7 +2964,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					#if desktop
 					if (window.mouseLock)
 					{
-						event = MouseEvent.__create(MouseEvent.DOUBLE_CLICK, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
+						event = MouseEvent.__create(MouseEvent.DOUBLE_CLICK, button, 0, 0, 0, new Point(0, 0), __movementX, __movementY, target);
 					}
 					else
 					{
@@ -3039,8 +3041,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					event.stageY = 0;
 					event.localX = 0;
 					event.localY = 0;
-					event.movementX = movementMouseX;
-					event.movementY = movementMouseY;
+					event.movementX = __movementX;
+					event.movementY = __movementY;
 				}
 				else
 				{
@@ -3067,7 +3069,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				#if desktop
 				if (window.mouseLock)
 				{
-					event = MouseEvent.__create(MouseEvent.MOUSE_OUT, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast __mouseOverTarget);
+					event = MouseEvent.__create(MouseEvent.MOUSE_OUT, button, 0, 0, 0, new Point(0, 0), __movementX, __movementY, cast __mouseOverTarget);
 				}
 				else
 				{
@@ -3109,8 +3111,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					event.stageY = 0;
 					event.localX = 0;
 					event.localY = 0;
-					event.movementX = movementMouseX;
-					event.movementY = movementMouseY;
+					event.movementX = __movementX;
+					event.movementY = __movementY;
 				}
 				else
 				{
@@ -3137,7 +3139,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				#if desktop
 				if (window.mouseLock)
 				{
-					event = MouseEvent.__create(MouseEvent.ROLL_OUT, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast item);
+					event = MouseEvent.__create(MouseEvent.ROLL_OUT, button, 0, 0, 0, new Point(0, 0), __movementX, __movementY, cast item);
 				}
 				else
 				{
@@ -3182,8 +3184,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						event.stageY = 0;
 						event.localX = 0;
 						event.localY = 0;
-						event.movementX = movementMouseX;
-						event.movementY = movementMouseY;
+						event.movementX = __movementX;
+						event.movementY = __movementY;
 					}
 					else
 					{
@@ -3211,7 +3213,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					#if desktop
 					if (window.mouseLock)
 					{
-						event = MouseEvent.__create(MouseEvent.ROLL_OVER, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast item);
+						event = MouseEvent.__create(MouseEvent.ROLL_OVER, button, 0, 0, 0, new Point(0, 0), __movementX, __movementY, cast item);
 					}
 					else
 					{
@@ -3256,8 +3258,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					event.stageY = 0;
 					event.localX = 0;
 					event.localY = 0;
-					event.movementX = movementMouseX;
-					event.movementY = movementMouseY;
+					event.movementX = __movementX;
+					event.movementY = __movementY;
 				}
 				else
 				{
@@ -3285,7 +3287,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				#if desktop
 				if (window.mouseLock)
 				{
-					event = MouseEvent.__create(MouseEvent.MOUSE_OVER, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY,  cast target);
+					event = MouseEvent.__create(MouseEvent.MOUSE_OVER, button, 0, 0, 0, new Point(0, 0), __movementX, __movementY,  cast target);
 				}
 				else
 				{

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1619,7 +1619,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					var clickEvent = MouseEvent.__pool.get();
 					clickEvent.type = MouseEvent.CLICK;
 					#if desktop
-					if (__mouseLock)
+					if (window.mouseLock)
 					{
 						clickEvent.stageX = 0;
 						clickEvent.stageY = 0;
@@ -1653,7 +1653,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					#else
 					var clickEvent:MouseEvent;
 					#if desktop
-					if (__mouseLock)
+					if (window.mouseLock)
 					{
 						clickEvent = MouseEvent.__create(MouseEvent.CLICK, 0, 0, 0, 0, new Point(0, 0), 0, 0, sprite);
 					}
@@ -2534,6 +2534,13 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 		__resize();
 
+		#if desktop
+		if (__mouseLock) // Was fullscreen before with mouse locking enabled.
+		{
+			window.mouseLock = true;
+		}
+		#end
+
 		if (!__wasFullscreen)
 		{
 			__wasFullscreen = true;
@@ -2741,7 +2748,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						event.clickCount = 0;
 						#else
 						#if desktop
-						if (mouseLock)
+						if (__mouseLock)
 						{
 							event = MouseEvent.__create(MouseEvent.RELEASE_OUTSIDE, 1, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, this);
 						}
@@ -2794,7 +2801,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		event = MouseEvent.__pool.get();
 		event.type = type;
 		#if desktop
-		if (__mouseLock)
+		if (window.mouseLock)
 		{
 			event.stageX = 0;
 			event.stageY = 0;
@@ -2826,7 +2833,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		event.clickCount = clickCount;
 		#else
 		#if desktop
-		if (__mouseLock)
+		if (window.mouseLock)
 		{
 			event = MouseEvent.__create(type, button, clickCount, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
 		}
@@ -2856,7 +2863,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			event = MouseEvent.__pool.get();
 			event.type = clickType;
 			#if desktop
-			if (__mouseLock)
+			if (window.mouseLock)
 			{
 				event.stageX = 0;
 				event.stageY = 0;
@@ -2888,7 +2895,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			event.clickCount = 0;
 			#else
 			#if desktop
-			if (__mouseLock)
+			if (window.mouseLock)
 			{
 				event = MouseEvent.__create(clickType, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
 			}
@@ -2921,7 +2928,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					event = MouseEvent.__pool.get();
 					event.type = MouseEvent.DOUBLE_CLICK;
 					#if desktop
-					if (__mouseLock)
+					if (window.mouseLock)
 					{
 						event.stageX = 0;
 						event.stageY = 0;
@@ -2953,7 +2960,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					event.clickCount = 0;
 					#else
 					#if desktop
-					if (__mouseLock)
+					if (window.mouseLock)
 					{
 						event = MouseEvent.__create(MouseEvent.DOUBLE_CLICK, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
 					}
@@ -3026,7 +3033,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				event = MouseEvent.__pool.get();
 				event.type = MouseEvent.MOUSE_OUT;
 				#if desktop
-				if (__mouseLock)
+				if (window.mouseLock)
 				{
 					event.stageX = 0;
 					event.stageY = 0;
@@ -3058,7 +3065,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				event.clickCount = 0;
 				#else
 				#if desktop
-				if (__mouseLock)
+				if (window.mouseLock)
 				{
 					event = MouseEvent.__create(MouseEvent.MOUSE_OUT, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast __mouseOverTarget);
 				}
@@ -3096,7 +3103,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				event = MouseEvent.__pool.get();
 				event.type = MouseEvent.ROLL_OUT;
 				#if desktop
-				if (__mouseLock)
+				if (window.mouseLock)
 				{
 					event.stageX = 0;
 					event.stageY = 0;
@@ -3128,7 +3135,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				event.clickCount = 0;
 				#else
 				#if desktop
-				if (__mouseLock)
+				if (window.mouseLock)
 				{
 					event = MouseEvent.__create(MouseEvent.ROLL_OUT, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast item);
 				}
@@ -3169,7 +3176,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					var mouseEvent = MouseEvent.__pool.get();
 					mouseEvent.type = MouseEvent.ROLL_OVER;
 					#if desktop
-					if (__mouseLock)
+					if (window.mouseLock)
 					{
 						event.stageX = 0;
 						event.stageY = 0;
@@ -3202,7 +3209,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					event.clickCount = 0;
 					#else
 					#if desktop
-					if (__mouseLock)
+					if (window.mouseLock)
 					{
 						event = MouseEvent.__create(MouseEvent.ROLL_OVER, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast item);
 					}
@@ -3243,7 +3250,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				var mouseEvent = MouseEvent.__pool.get();
 				mouseEvent.type = MouseEvent.MOUSE_OVER;
 				#if desktop
-				if (__mouseLock)
+				if (window.mouseLock)
 				{
 					event.stageX = 0;
 					event.stageY = 0;
@@ -3276,7 +3283,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				event.clickCount = 0;
 				#else
 				#if desktop
-				if (__mouseLock)
+				if (window.mouseLock)
 				{
 					event = MouseEvent.__create(MouseEvent.MOUSE_OVER, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY,  cast target);
 				}
@@ -3368,7 +3375,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 		var event:MouseEvent;
 		#if desktop
-		if (__mouseLock)
+		if (window.mouseLock)
 		{
 			event = MouseEvent.__create(MouseEvent.MOUSE_WHEEL, 0, 0, 0, 0, new Point(0, 0), 0, 0, target, delta);
 		}

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -4052,7 +4052,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	#if desktop
 	@:noCompletion private function get_mouseLock():Bool
 	{
-		return __mouseLock;
+		return window.mouseLock;
 	}
 
 	@:noCompletion private function set_mouseLock(value:Bool):Bool

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -946,6 +946,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	#end
 	#if desktop
 	@:noCompletion private var __mouseLock:Bool;
+	@:noCompletion private var movementMouseX:Float;
+	@:noCompletion private var movementMouseY:Float;
 	#end
 
 	#if openfljs
@@ -2069,7 +2071,11 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 	@:noCompletion private function __onLimeMouseMoveRelative(window:Window, x:Float, y:Float):Void
 	{
-		// if (this.window == null || this.window != window) return;
+		if (this.window == null || this.window != window) return;
+		#if desktop
+		movementMouseX = x;
+		movementMouseY = y;
+		#end
 	}
 
 	@:noCompletion private function __onLimeMouseUp(window:Window, x:Float, y:Float, button:Int):Void
@@ -2586,6 +2592,13 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		}, 500);
 		#end
 
+		#if desktop
+		if (__mouseLock && !window.fullscreen && window.mouseLock) // User just existed fullscreen
+		{
+			window.mouseLock = false; // The resize is expected to be temporary, don't set __mouseLock.
+		}
+		#end
+
 		if (__wasFullscreen && !window.fullscreen)
 		{
 			__wasFullscreen = false;
@@ -2615,10 +2628,6 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		targetPoint.setTo(x, y);
 		__displayMatrix.__transformInversePoint(targetPoint);
 
-		#if desktop
-		var movementMouseX = targetPoint.x - __mouseX;
-		var movementMouseY = targetPoint.y - __mouseY;
-		#end
 		__mouseX = targetPoint.x;
 		__mouseY = targetPoint.y;
 

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1616,14 +1616,52 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					#if openfl_pool_events
 					var clickEvent = MouseEvent.__pool.get();
 					clickEvent.type = MouseEvent.CLICK;
+					#if desktop
+					if (__mouseLock)
+					{
+						clickEvent.stageX = 0;
+						clickEvent.stageY = 0;
+						clickEvent.localX = 0;
+						clickEvent.localY = 0;
+						// Click is not initiated through the mouse, so attaching movement data
+						// Doesn't make sense
+						clickEvent.movementX = 0;
+						clickEvent.movementY = 0;
+					}
+					else
+					{
+						clickEvent.stageX = __mouseX;
+						clickEvent.stageY = __mouseY;
+						var local = sprite.__globalToLocal(targetPoint, localPoint);
+						clickEvent.localX = local.x;
+						clickEvent.localY = local.y;
+						clickEvent.movementX = 0;
+						clickEvent.movementY = 0;
+					}
+					#else
 					clickEvent.stageX = __mouseX;
 					clickEvent.stageY = __mouseY;
 					var local = sprite.__globalToLocal(targetPoint, localPoint);
 					clickEvent.localX = local.x;
 					clickEvent.localY = local.y;
+					clickEvent.movementX = 0;
+					clickEvent.movementY = 0;
+					#end
 					clickEvent.target = sprite;
 					#else
-					var clickEvent = MouseEvent.__create(MouseEvent.CLICK, 0, 0, __mouseX, __mouseY, sprite.__globalToLocal(targetPoint, localPoint), sprite);
+					var clickEvent:MouseEvent;
+					#if desktop
+					if (__mouseLock)
+					{
+						clickEvent = MouseEvent.__create(MouseEvent.CLICK, 0, 0, 0, 0, new Point(0, 0), 0, 0, sprite);
+					}
+					else
+					{
+						clickEvent = MouseEvent.__create(MouseEvent.CLICK, 0, 0, __mouseX, __mouseY, sprite.__globalToLocal(targetPoint, localPoint), 0, 0, sprite);
+					}
+					#else
+					clickEvent = MouseEvent.__create(MouseEvent.CLICK, 0, 0, __mouseX, __mouseY, sprite.__globalToLocal(targetPoint, localPoint), 0, 0, sprite);
+					#end
 					#end
 
 					__dispatchStack(clickEvent, stack);
@@ -2577,6 +2615,10 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		targetPoint.setTo(x, y);
 		__displayMatrix.__transformInversePoint(targetPoint);
 
+		#if desktop
+		var movementMouseX = targetPoint.x - __mouseX;
+		var movementMouseY = targetPoint.y - __mouseY;
+		#end
 		__mouseX = targetPoint.x;
 		__mouseY = targetPoint.y;
 
@@ -2661,14 +2703,46 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						#if openfl_pool_events
 						event = MouseEvent.__pool.get();
 						event.type = MouseEvent.RELEASE_OUTSIDE;
+						#if desktop
+						if (__mouseLock)
+						{
+							event.stageX = 0;
+							event.stageY = 0;
+							event.localX = 0;
+							event.localY = 0;
+							event.movementX = movementMouseX;
+							event.movementY = movementMouseY;
+						} else {
+							event.stageX = __mouseX;
+							event.stageY = __mouseY;
+							event.localX = __mouseX;
+							event.localY = __mouseY;
+							event.movementX = 0;
+							event.movementY = 0;
+						}
+						#else
 						event.stageX = __mouseX;
 						event.stageY = __mouseY;
 						event.localX = __mouseX;
 						event.localY = __mouseY;
+						event.movementX = 0;
+						event.movementY = 0;
+						#end
 						event.target = this;
 						event.clickCount = 0;
 						#else
-						event = MouseEvent.__create(MouseEvent.RELEASE_OUTSIDE, 1, 0, __mouseX, __mouseY, new Point(__mouseX, __mouseY), this);
+						#if desktop
+						if (mouseLock)
+						{
+							event = MouseEvent.__create(MouseEvent.RELEASE_OUTSIDE, 1, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, this);
+						}
+						else
+						{
+							event = MouseEvent.__create(MouseEvent.RELEASE_OUTSIDE, 1, 0, __mouseX, __mouseY, new Point(__mouseX, __mouseY), 0, 0, this);
+						}
+						#else
+						event = MouseEvent.__create(MouseEvent.RELEASE_OUTSIDE, 1, 0, __mouseX, __mouseY, new Point(__mouseX, __mouseY), 0, 0, this);
+						#end
 						#end
 
 						__mouseDownLeft.dispatchEvent(event);
@@ -2710,15 +2784,50 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		#if openfl_pool_events
 		event = MouseEvent.__pool.get();
 		event.type = type;
+		#if desktop
+		if (__mouseLock)
+		{
+			event.stageX = 0;
+			event.stageY = 0;
+			event.localX = 0;
+			event.localY = 0;
+			event.movementX = movementMouseX;
+			event.movementY = movementMouseY;
+		}
+		else
+		{
+			event.stageX = __mouseX;
+			event.stageY = __mouseY;
+			var local = target.__globalToLocal(targetPoint, localPoint);
+			event.localX = local.x;
+			event.localY = local.y;
+			event.movementX = 0;
+			event.movementY = 0;
+		}
+		#else
 		event.stageX = __mouseX;
 		event.stageY = __mouseY;
 		var local = target.__globalToLocal(targetPoint, localPoint);
 		event.localX = local.x;
 		event.localY = local.y;
+		event.movementX = 0;
+		event.movementY = 0;
+		#end
 		event.target = target;
 		event.clickCount = clickCount;
 		#else
-		event = MouseEvent.__create(type, button, clickCount, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), target);
+		#if desktop
+		if (__mouseLock)
+		{
+			event = MouseEvent.__create(type, button, clickCount, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
+		}
+		else
+		{
+			event = MouseEvent.__create(type, button, clickCount, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, target);
+		}
+		#else
+		event = MouseEvent.__create(type, button, clickCount, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, target);
+		#end
 		#end
 
 		__dispatchStack(event, stack);
@@ -2737,15 +2846,50 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			#if openfl_pool_events
 			event = MouseEvent.__pool.get();
 			event.type = clickType;
+			#if desktop
+			if (__mouseLock)
+			{
+				event.stageX = 0;
+				event.stageY = 0;
+				event.localX = 0;
+				event.localY = 0;
+				event.movementX = movementMouseX;
+				event.movementY = movementMouseY;
+			}
+			else
+			{
+				event.stageX = __mouseX;
+				event.stageY = __mouseY;
+				var local = target.__globalToLocal(targetPoint, localPoint);
+				event.localX = local.x;
+				event.localY = local.y;
+				event.movementX = 0;
+				event.movementY = 0;
+			}
+			#else
 			event.stageX = __mouseX;
 			event.stageY = __mouseY;
 			var local = target.__globalToLocal(targetPoint, localPoint);
 			event.localX = local.x;
 			event.localY = local.y;
+			event.movementX = 0;
+			event.movementY = 0;
+			#end
 			event.target = target;
 			event.clickCount = 0;
 			#else
-			event = MouseEvent.__create(clickType, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), target);
+			#if desktop
+			if (__mouseLock)
+			{
+				event = MouseEvent.__create(clickType, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
+			}
+			else
+			{
+				event = MouseEvent.__create(clickType, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, target);
+			}
+			#else
+			event = MouseEvent.__create(clickType, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, target);
+			#end
 			#end
 
 			__dispatchStack(event, stack);
@@ -2767,16 +2911,50 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					#if openfl_pool_events
 					event = MouseEvent.__pool.get();
 					event.type = MouseEvent.DOUBLE_CLICK;
+					#if desktop
+					if (__mouseLock)
+					{
+						event.stageX = 0;
+						event.stageY = 0;
+						event.localX = 0;
+						event.localY = 0;
+						event.movementX = movementMouseX;
+						event.movementY = movementMouseY;
+					}
+					else
+					{
+						event.stageX = __mouseX;
+						event.stageY = __mouseY;
+						var local = target.__globalToLocal(targetPoint, localPoint);
+						event.localX = local.x;
+						event.localY = local.y;
+						event.movementX = 0;
+						event.movementY = 0;
+					}
+					#else
 					event.stageX = __mouseX;
 					event.stageY = __mouseY;
 					var local = target.__globalToLocal(targetPoint, localPoint);
 					event.localX = local.x;
 					event.localY = local.y;
+					event.movementX = 0;
+					event.movementY = 0;
+					#end
 					event.target = target;
 					event.clickCount = 0;
 					#else
-					event = MouseEvent.__create(MouseEvent.DOUBLE_CLICK, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint),
-						target);
+					#if desktop
+					if (__mouseLock)
+					{
+						event = MouseEvent.__create(MouseEvent.DOUBLE_CLICK, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, target);
+					}
+					else
+					{
+						event = MouseEvent.__create(MouseEvent.DOUBLE_CLICK, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, target);
+					}
+					#else
+					event = MouseEvent.__create(MouseEvent.DOUBLE_CLICK, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, target);
+					#end
 					#end
 
 					__dispatchStack(event, stack);
@@ -2838,16 +3016,50 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				#if openfl_pool_events
 				event = MouseEvent.__pool.get();
 				event.type = MouseEvent.MOUSE_OUT;
+				#if desktop
+				if (__mouseLock)
+				{
+					event.stageX = 0;
+					event.stageY = 0;
+					event.localX = 0;
+					event.localY = 0;
+					event.movementX = movementMouseX;
+					event.movementY = movementMouseY;
+				}
+				else
+				{
+					event.stageX = __mouseX;
+					event.stageY = __mouseY;
+					var local = __mouseOverTarget.__globalToLocal(targetPoint, localPoint);
+					event.localX = local.x;
+					event.localY = local.y;
+					event.movementX = 0;
+					event.movementY = 0;
+				}
+				#else
 				event.stageX = __mouseX;
 				event.stageY = __mouseY;
 				var local = __mouseOverTarget.__globalToLocal(targetPoint, localPoint);
 				event.localX = local.x;
 				event.localY = local.y;
+				event.movementX = 0;
+				event.movementY = 0;
+				#end
 				event.target = __mouseOverTarget;
 				event.clickCount = 0;
 				#else
-				event = MouseEvent.__create(MouseEvent.MOUSE_OUT, button, 0, __mouseX, __mouseY, __mouseOverTarget.__globalToLocal(targetPoint, localPoint),
-					cast __mouseOverTarget);
+				#if desktop
+				if (__mouseLock)
+				{
+					event = MouseEvent.__create(MouseEvent.MOUSE_OUT, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast __mouseOverTarget);
+				}
+				else
+				{
+					event = MouseEvent.__create(MouseEvent.MOUSE_OUT, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, cast __mouseOverTarget);
+				}
+				#else
+				event = MouseEvent.__create(MouseEvent.MOUSE_OUT, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, cast __mouseOverTarget);
+				#end
 				#end
 
 				__dispatchStack(event, __mouseOutStack);
@@ -2874,16 +3086,50 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				#if openfl_pool_events
 				event = MouseEvent.__pool.get();
 				event.type = MouseEvent.ROLL_OUT;
+				#if desktop
+				if (__mouseLock)
+				{
+					event.stageX = 0;
+					event.stageY = 0;
+					event.localX = 0;
+					event.localY = 0;
+					event.movementX = movementMouseX;
+					event.movementY = movementMouseY;
+				}
+				else
+				{
+					event.stageX = __mouseX;
+					event.stageY = __mouseY;
+					var local = __mouseOverTarget.__globalToLocal(targetPoint, localPoint);
+					event.localX = local.x;
+					event.localY = local.y;
+					event.movementX = 0;
+					event.movementY = 0;
+				}
+				#else
 				event.stageX = __mouseX;
 				event.stageY = __mouseY;
 				var local = __mouseOverTarget.__globalToLocal(targetPoint, localPoint);
 				event.localX = local.x;
 				event.localY = local.y;
+				event.movementX = 0;
+				event.movementY = 0;
+				#end
 				event.target = item;
 				event.clickCount = 0;
 				#else
-				event = MouseEvent.__create(MouseEvent.ROLL_OUT, button, 0, __mouseX, __mouseY, __mouseOverTarget.__globalToLocal(targetPoint, localPoint),
-					cast item);
+				#if desktop
+				if (__mouseLock)
+				{
+					event = MouseEvent.__create(MouseEvent.ROLL_OUT, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast item);
+				}
+				else
+				{
+					event = MouseEvent.__create(MouseEvent.ROLL_OUT, button, 0, __mouseX, __mouseY, __mouseOverTarget.__globalToLocal(targetPoint, localPoint), 0, 0, cast item);
+				}
+				#else
+				event = MouseEvent.__create(MouseEvent.ROLL_OUT, button, 0, __mouseX, __mouseY, __mouseOverTarget.__globalToLocal(targetPoint, localPoint), 0, 0, cast item);
+				#end
 				#end
 				event.bubbles = false;
 
@@ -2913,17 +3159,51 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					#if openfl_pool_events
 					var mouseEvent = MouseEvent.__pool.get();
 					mouseEvent.type = MouseEvent.ROLL_OVER;
-					mouseEvent.stageX = __mouseX;
-					mouseEvent.stageY = __mouseY;
+					#if desktop
+					if (__mouseLock)
+					{
+						event.stageX = 0;
+						event.stageY = 0;
+						event.localX = 0;
+						event.localY = 0;
+						event.movementX = movementMouseX;
+						event.movementY = movementMouseY;
+					}
+					else
+					{
+						event.stageX = __mouseX;
+						event.stageY = __mouseY;
+						var local = __mouseOverTarget.__globalToLocal(targetPoint, localPoint);
+						event.localX = local.x;
+						event.localY = local.y;
+						event.movementX = 0;
+						event.movementY = 0;
+					}
+					#else
+					event.stageX = __mouseX;
+					event.stageY = __mouseY;
 					var local = __mouseOverTarget.__globalToLocal(targetPoint, localPoint);
-					mouseEvent.localX = local.x;
-					mouseEvent.localY = local.y;
+					event.localX = local.x;
+					event.localY = local.y;
+					event.movementX = 0;
+					event.movementY = 0;
+					#end
 					mouseEvent.target = item;
 					event = mouseEvent;
 					event.clickCount = 0;
 					#else
-					event = MouseEvent.__create(MouseEvent.ROLL_OVER, button, 0, __mouseX, __mouseY,
-						__mouseOverTarget.__globalToLocal(targetPoint, localPoint), cast item);
+					#if desktop
+					if (__mouseLock)
+					{
+						event = MouseEvent.__create(MouseEvent.ROLL_OVER, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY, cast item);
+					}
+					else
+					{
+						event = MouseEvent.__create(MouseEvent.ROLL_OVER, button, 0, __mouseX, __mouseY, __mouseOverTarget.__globalToLocal(targetPoint, localPoint), 0, 0, cast item);
+					}
+					#else
+					event = MouseEvent.__create(MouseEvent.ROLL_OVER, button, 0, __mouseX, __mouseY, __mouseOverTarget.__globalToLocal(targetPoint, localPoint), 0, 0, cast item);
+					#end
 					#end
 					event.bubbles = false;
 
@@ -2953,16 +3233,51 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				#if openfl_pool_events
 				var mouseEvent = MouseEvent.__pool.get();
 				mouseEvent.type = MouseEvent.MOUSE_OVER;
-				mouseEvent.stageX = __mouseX;
-				mouseEvent.stageY = __mouseY;
+				#if desktop
+				if (__mouseLock)
+				{
+					event.stageX = 0;
+					event.stageY = 0;
+					event.localX = 0;
+					event.localY = 0;
+					event.movementX = movementMouseX;
+					event.movementY = movementMouseY;
+				}
+				else
+				{
+					event.stageX = __mouseX;
+					event.stageY = __mouseY;
+					var local = target.__globalToLocal(targetPoint, localPoint);
+					event.localX = local.x;
+					event.localY = local.y;
+					event.movementX = 0;
+					event.movementY = 0;
+				}
+				#else
+				event.stageX = __mouseX;
+				event.stageY = __mouseY;
 				var local = target.__globalToLocal(targetPoint, localPoint);
-				mouseEvent.localX = local.x;
-				mouseEvent.localY = local.y;
+				event.localX = local.x;
+				event.localY = local.y;
+				event.movementX = 0;
+				event.movementY = 0;
+				#end
 				mouseEvent.target = target;
 				event = mouseEvent;
 				event.clickCount = 0;
 				#else
-				event = MouseEvent.__create(MouseEvent.MOUSE_OVER, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), cast target);
+				#if desktop
+				if (__mouseLock)
+				{
+					event = MouseEvent.__create(MouseEvent.MOUSE_OVER, button, 0, 0, 0, new Point(0, 0), movementMouseX, movementMouseY,  cast target);
+				}
+				else
+				{
+					event = MouseEvent.__create(MouseEvent.MOUSE_OVER, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, cast target);
+				}
+				#else
+				event = MouseEvent.__create(MouseEvent.MOUSE_OVER, button, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, localPoint), 0, 0, cast target);
+				#end
 				#end
 
 				__dispatchStack(event, stack);
@@ -3042,7 +3357,19 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		__displayMatrix.__transformInversePoint(targetPoint);
 		var delta = Std.int(deltaY);
 
-		var event = MouseEvent.__create(MouseEvent.MOUSE_WHEEL, 0, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, targetPoint), target, delta);
+		var event:MouseEvent;
+		#if desktop
+		if (__mouseLock)
+		{
+			event = MouseEvent.__create(MouseEvent.MOUSE_WHEEL, 0, 0, 0, 0, new Point(0, 0), 0, 0, target, delta);
+		}
+		else
+		{
+			event = MouseEvent.__create(MouseEvent.MOUSE_WHEEL, 0, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, targetPoint), 0, 0, target, delta);
+		}
+		#else
+		event = MouseEvent.__create(MouseEvent.MOUSE_WHEEL, 0, 0, __mouseX, __mouseY, target.__globalToLocal(targetPoint, targetPoint), 0, 0, target, delta);
+		#end
 		event.cancelable = true;
 		__dispatchStack(event, stack);
 		if (event.isDefaultPrevented()) window.onMouseWheel.cancel();

--- a/src/openfl/events/MouseEvent.hx
+++ b/src/openfl/events/MouseEvent.hx
@@ -39,11 +39,13 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var CLICK:EventType<MouseEvent> = "click";
@@ -64,12 +66,14 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
 		| `clickCount` | Count of the number of mouse clicks to indicate whether the event is part of a multi-click sequence. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	// @:noCompletion @:dox(hide) @:require(flash11_2) public static var CONTEXT_MENU:String;
@@ -91,11 +95,13 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var DOUBLE_CLICK:EventType<MouseEvent> = "doubleClick";
@@ -115,11 +121,13 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MIDDLE_CLICK:EventType<MouseEvent> = "middleClick";
@@ -139,12 +147,14 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
 		| `clickCount` | Count of the number of mouse clicks to indicate whether the event is part of a multi-click sequence. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MIDDLE_MOUSE_DOWN:EventType<MouseEvent> = "middleMouseDown";
@@ -164,12 +174,14 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
 		| `clickCount` | Count of the number of mouse clicks to indicate whether the event is part of a multi-click sequence. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MIDDLE_MOUSE_UP:EventType<MouseEvent> = "middleMouseUp";
@@ -189,12 +201,14 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows and Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
 		| `clickCount` | Count of the number of mouse clicks to indicate whether the event is part of a multi-click sequence. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MOUSE_DOWN:EventType<MouseEvent> = "mouseDown";
@@ -214,11 +228,13 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MOUSE_MOVE:EventType<MouseEvent> = "mouseMove";
@@ -239,11 +255,13 @@ class MouseEvent extends Event
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
 		| `relatedObject` | The display list object to which the pointing device now points. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MOUSE_OUT:EventType<MouseEvent> = "mouseOut";
@@ -264,11 +282,13 @@ class MouseEvent extends Event
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
 		| `relatedObject` | The display list object to which the pointing device was pointing. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MOUSE_OVER:EventType<MouseEvent> = "mouseOver";
@@ -287,12 +307,14 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
 		| `clickCount` | Count of the number of mouse clicks to indicate whether the event is part of a multi-click sequence. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MOUSE_UP:EventType<MouseEvent> = "mouseUp";
@@ -313,11 +335,13 @@ class MouseEvent extends Event
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
 		| `delta` | The number of lines that that each notch on the mouse wheel represents. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var MOUSE_WHEEL:EventType<MouseEvent> = "mouseWheel";
@@ -345,11 +369,13 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var RIGHT_CLICK:EventType<MouseEvent> = "rightClick";
@@ -369,12 +395,14 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
 		| `clickCount` | Count of the number of mouse clicks to indicate whether the event is part of a multi-click sequence. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var RIGHT_MOUSE_DOWN:EventType<MouseEvent> = "rightMouseDown";
@@ -394,12 +422,14 @@ class MouseEvent extends Event
 		| `controlKey` | `true` if the Ctrl or Control key is active; `false` if it is inactive. |
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
 		| `clickCount` | Count of the number of mouse clicks to indicate whether the event is part of a multi-click sequence. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var RIGHT_MOUSE_UP:EventType<MouseEvent> = "rightMouseUp";
@@ -419,11 +449,13 @@ class MouseEvent extends Event
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
 		| `relatedObject` | The display list object to which the pointing device now points. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var ROLL_OUT:EventType<MouseEvent> = "rollOut";
@@ -444,11 +476,13 @@ class MouseEvent extends Event
 		| `ctrlKey` | `true` on Windows or Linux if the Ctrl key is active. `true` on Mac if either the Ctrl key or the Command key is active. Otherwise, `false`. |
 		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
 		| `relatedObject` | The display list object to which the pointing device was pointing. |
-		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. |
-		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. |
+		| `localX` | The horizontal coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `localY` | The vertical coordinate at which the event occurred relative to the containing sprite. When mouse locking is enabled, this is set to `0`. |
+		| `movementX` | When mouse locking is enabled, the change in mouse position in the horizontal coordinate since the last mouse event. |
+		| `movementY` | When mouse locking is enabled, the change in mouse position in the vertical coordinate since the last mouse event. |
 		| `shiftKey` | `true` if the Shift key is active; `false` if it is inactive. |
-		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. |
-		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. |
+		| `stageX` | The horizontal coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
+		| `stageY` | The vertical coordinate at which the event occurred in global stage coordinates. When mouse locking is enabled, this is set to `0`. |
 		| `target` | The InteractiveObject instance under the pointing device. The `target` is not always the object in the display list that registered the event listener. Use the `currentTarget` property to access the object in the display list that is currently processing the event. |
 	**/
 	public static inline var ROLL_OVER:EventType<MouseEvent> = "rollOver";

--- a/src/openfl/events/MouseEvent.hx
+++ b/src/openfl/events/MouseEvent.hx
@@ -525,19 +525,30 @@ class MouseEvent extends Event
 	public var isRelatedObjectInaccessible:Bool;
 
 	/**
-		The horizontal coordinate at which the event occurred relative to the
-		containing sprite.
+		The horizontal coordinate at which the event occurred
+		relative to the containing sprite. When mouse locking
+		is enabled, this is set to `0`.
 	**/
 	public var localX:Float;
 
 	/**
-		The vertical coordinate at which the event occurred relative to the
-		containing sprite.
+		The vertical coordinate at which the event occurred
+		relative to the containing sprite. When mouse locking
+		is enabled, this is set to `0`.
 	**/
 	public var localY:Float;
 
-	// @:noCompletion @:dox(hide) @:require(flash11_2) public var movementX:Float;
-	// @:noCompletion @:dox(hide) @:require(flash11_2) public var movementY:Float;
+	/**
+		When mouse locking is enabled, the change in mouse position in the
+		horizontal coordinate since the last mouse event.
+	**/
+	public var movementX:Float;
+
+	/**
+		When mouse locking is enabled, the change in mouse position in the
+		vertical coordinate since the last mouse event.
+	**/
+	public var movementY:Float;
 
 	/**
 		A reference to a display list object that is related to the event. For
@@ -564,14 +575,14 @@ class MouseEvent extends Event
 	/**
 		The horizontal coordinate at which the event occurred in global Stage
 		coordinates. This property is calculated when the `localX`
-		property is set.
+		property is set. When mouse locking is enabled, this is set to `0`.
 	**/
 	public var stageX:Float;
 
 	/**
 		The vertical coordinate at which the event occurred in global Stage
 		coordinates. This property is calculated when the `localY`
-		property is set.
+		property is set. When mouse locking is enabled, this is set to `0`.
 	**/
 	public var stageY:Float;
 
@@ -613,9 +624,17 @@ class MouseEvent extends Event
 							 the bubbling phase of the event flow.
 		@param cancelable    Determines whether the Event object can be canceled.
 		@param localX        The horizontal coordinate at which the event occurred
-							 relative to the containing sprite.
+							 relative to the containing sprite. When mouse locking is
+							 enabled, this is set to `0`.
 		@param localY        The vertical coordinate at which the event occurred
-							 relative to the containing sprite.
+							 relative to the containing sprite. When mouse locking is
+							 enabled, this is set to `0`.
+		@param movementX	 When mouse locking is enabled, The change in mouse position
+							 in the horizontal coordinate. When mouse locking is disabled,
+							 this is set to `0`.
+		@param movementY	 When mouse locking is enabled, The change in mouse position
+							 in the vertical coordinate. When mouse locking is disabled,
+							 this is set to `0`.
 		@param relatedObject The complementary InteractiveObject instance that is
 							 affected by the event. For example, when a
 							 `mouseOut` event occurs,
@@ -637,9 +656,9 @@ class MouseEvent extends Event
 							 values. This parameter is used only for the
 							 `MouseEvent.mouseWheel` event.
 	**/
-	public function new(type:String, bubbles:Bool = true, cancelable:Bool = false, localX:Float = 0, localY:Float = 0, relatedObject:InteractiveObject = null,
-			ctrlKey:Bool = false, altKey:Bool = false, shiftKey:Bool = false, buttonDown:Bool = false, delta:Int = 0, commandKey:Bool = false,
-			controlKey:Bool = false, clickCount:Int = 0)
+	public function new(type:String, bubbles:Bool = true, cancelable:Bool = false, localX:Float = 0, localY:Float = 0, movementX:Float = 0, movementY:Float = 0,
+						relatedObject:InteractiveObject = null, ctrlKey:Bool = false, altKey:Bool = false, shiftKey:Bool = false, buttonDown:Bool = false,
+						delta:Int = 0, commandKey:Bool = false, controlKey:Bool = false, clickCount:Int = 0)
 	{
 		super(type, bubbles, cancelable);
 
@@ -651,6 +670,8 @@ class MouseEvent extends Event
 		this.delta = delta;
 		this.localX = localX;
 		this.localY = localY;
+		this.movementX = movementX;
+		this.movementY = movementY;
 		this.buttonDown = buttonDown;
 		this.commandKey = commandKey;
 		this.controlKey = controlKey;
@@ -665,7 +686,7 @@ class MouseEvent extends Event
 
 	public override function clone():MouseEvent
 	{
-		var event = new MouseEvent(type, bubbles, cancelable, localX, localY, relatedObject, ctrlKey, altKey, shiftKey, buttonDown, delta, commandKey,
+		var event = new MouseEvent(type, bubbles, cancelable, localX, localY, movementX, movementY, relatedObject, ctrlKey, altKey, shiftKey, buttonDown, delta, commandKey,
 			controlKey, clickCount);
 		event.target = target;
 		event.currentTarget = currentTarget;
@@ -676,7 +697,7 @@ class MouseEvent extends Event
 	public override function toString():String
 	{
 		return __formatToString("MouseEvent", [
-			"type", "bubbles", "cancelable", "localX", "localY", "relatedObject", "ctrlKey", "altKey", "shiftKey", "buttonDown", "delta"
+			"type", "bubbles", "cancelable", "localX", "localY", "movementX", "movementY", "relatedObject", "ctrlKey", "altKey", "shiftKey", "buttonDown", "delta"
 		]);
 	}
 
@@ -693,10 +714,10 @@ class MouseEvent extends Event
 		__updateAfterEventFlag = true;
 	}
 
-	@:noCompletion private static function __create(type:String, button:Int, clickCount:Int, stageX:Float, stageY:Float, local:Point, target:InteractiveObject,
+	@:noCompletion private static function __create(type:String, button:Int, clickCount:Int, stageX:Float, stageY:Float, local:Point, movementX:Float, movementY:Float, target:InteractiveObject,
 			delta:Int = 0):MouseEvent
 	{
-		var event = new MouseEvent(type, true, false, local.x, local.y, null, __ctrlKey, __altKey, __shiftKey, __buttonDown, delta, __commandKey,
+		var event = new MouseEvent(type, true, false, local.x, local.y, movementX, movementY, null, __ctrlKey, __altKey, __shiftKey, __buttonDown, delta, __commandKey,
 			__controlKey, clickCount);
 		event.stageX = stageX;
 		event.stageY = stageY;
@@ -716,6 +737,8 @@ class MouseEvent extends Event
 		delta = 0;
 		localX = 0;
 		localY = 0;
+		movementX = 0;
+		movementY = 0;
 		buttonDown = false;
 		commandKey = false;
 		controlKey = false;

--- a/src/openfl/events/ScreenMouseEvent.hx
+++ b/src/openfl/events/ScreenMouseEvent.hx
@@ -155,7 +155,7 @@ class ScreenMouseEvent extends MouseEvent
 	public function new(type:String, bubbles:Bool = false, cancelable:Bool = false, screenX:Float = 0, screenY:Float = 0, ctrlKey:Bool = false,
 			altKey:Bool = false, shiftKey:Bool = false, buttonDown:Bool = false, commandKey:Bool = false, controlKey:Bool = false)
 	{
-		super(type, bubbles, cancelable, screenX, screenY, null, ctrlKey, altKey, shiftKey, buttonDown, 0, commandKey, controlKey, 0);
+		super(type, bubbles, cancelable, screenX, screenY, 0, 0, null, ctrlKey, altKey, shiftKey, buttonDown, 0, commandKey, controlKey, 0);
 		this.screenX = screenX;
 		this.screenY = screenY;
 	}


### PR DESCRIPTION
Mouse locking is already implemented in lime. This this pull requests implements mouse locking similarly to flash, as in:

 - Locking is only available in desktop targets and only when in full screen
   - On non-desktop targets, the `mouseLock` property is not available
   - When not in full-screen, setting `mouseLock` to `true` throws `IllegalOperationError("Property can not be set in non full screen mode.");`
 - When the mouse is locked `MouseEvent`'s `stageX/Y` and `localX/Y` are equal to 0, and `movementX/Y` reports differences between previous and current mouse position.
 - Locking is temporarily disabled when the window loses focus, or exits fullscreen
   - When re-entering both of the states above, mouse locking is re-enabled
 
### Implementation details:

under the hood, there's a less sensitive mouseLock property named `__mouseLock`. It is not changed when the user forces mouse unlocking, and is used for when the user temporarily disables mouse locking using one of the methods above. It is not used when retrieving `stage.mouseLock`, so it is possible that `stage.mouseLock` gets changed with user interaction, when the developer explicitly set it to `true`. The only property that the developer has full control of is `__mouseLock`, and it is the property deciding when to re-enable `window.mouseLock`.

Mouse events switch to reporting movement based coordinates only when the mouse is visually locked, so setting `stage.mouseLock` to `true` and receiving non-0 `stageX` property is possible, for example, but, this only happens when mouse locking is temporarily off. We know mouse locking is temporarily off when `__mouseLock && !window.mouseLock`

mouse movement details are retrieved from `__onLimeMouseMoveRelative` event listener