### PR TITLE
Delete Math.ceil and Math.floor for __ scissorRect.

### DIFF
--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -977,17 +977,18 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	{
 		if (clipRect != null)
 		{
-			var x = clipRect.x;
-			var y = clipRect.y;
-			var width = (clipRect.width > 0 ? clipRect.right - x : 0);
-			var height = (clipRect.height > 0 ? clipRect.bottom - y : 0);
+			var x:Float = Math.floor(clipRect.x);
+			var y:Float = Math.floor(clipRect.y);
+			var width:Float = (clipRect.width > 0 ? Math.ceil(clipRect.right) - x : 0);
+			var height:Float = (clipRect.height > 0 ? Math.ceil(clipRect.bottom) - y : 0);
 			#if !openfl_dpi_aware
 			if (__context3D.__backBufferWantsBestResolution)
 			{
+				var uv = 1.5 / __pixelRatio;
 				x = clipRect.x / __pixelRatio;
 				y = clipRect.y / __pixelRatio;
-				width = (clipRect.width > 0 ? clipRect.right / __pixelRatio - x : 0);
-				height = (clipRect.height > 0 ? clipRect.bottom / __pixelRatio - y : 0);
+				width = (clipRect.width > 0 ? (clipRect.right / __pixelRatio) - x + uv : 0);
+				height = (clipRect.height > 0 ? (clipRect.bottom / __pixelRatio) - y + uv : 0);
 			}
 			#end
 

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -977,17 +977,17 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	{
 		if (clipRect != null)
 		{
-			var x = Math.floor(clipRect.x);
-			var y = Math.floor(clipRect.y);
-			var width = (clipRect.width > 0 ? Math.ceil(clipRect.right) - x : 0);
-			var height = (clipRect.height > 0 ? Math.ceil(clipRect.bottom) - y : 0);
+			var x = clipRect.x;
+			var y = clipRect.y;
+			var width = (clipRect.width > 0 ? clipRect.right - x : 0);
+			var height = (clipRect.height > 0 ? clipRect.bottom - y : 0);
 			#if !openfl_dpi_aware
 			if (__context3D.__backBufferWantsBestResolution)
 			{
-				x = Math.floor(clipRect.x / __pixelRatio);
-				y = Math.floor(clipRect.y / __pixelRatio);
-				width = (clipRect.width > 0 ? Math.ceil(clipRect.right / __pixelRatio) - x : 0);
-				height = (clipRect.height > 0 ? Math.ceil(clipRect.bottom / __pixelRatio) - y : 0);
+				x = clipRect.x / __pixelRatio;
+				y = clipRect.y / __pixelRatio;
+				width = (clipRect.width > 0 ? clipRect.right / __pixelRatio - x : 0);
+				height = (clipRect.height > 0 ? clipRect.bottom / __pixelRatio - y : 0);
 			}
 			#end
 

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -977,10 +977,10 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	{
 		if (clipRect != null)
 		{
-			var x:Float = Math.floor(clipRect.x);
-			var y:Float = Math.floor(clipRect.y);
-			var width:Float = (clipRect.width > 0 ? Math.ceil(clipRect.right) - x : 0);
-			var height:Float = (clipRect.height > 0 ? Math.ceil(clipRect.bottom) - y : 0);
+			var x = Math.ffloor(clipRect.x);
+			var y = Math.ffloor(clipRect.y);
+			var width = (clipRect.width > 0 ? Math.fceil(clipRect.right) - x : 0);
+			var height = (clipRect.height > 0 ? Math.fceil(clipRect.bottom) - y : 0);
 			#if !openfl_dpi_aware
 			if (__context3D.__backBufferWantsBestResolution)
 			{


### PR DESCRIPTION
In cases where the browser scaling ratio is very large, using Math.floor or Math.ceil will result in significant pixel errors, so it needs to be removed.