### PR TITLE
Adding Sound will stop the SoundChannel through the buffer during the close method execution.

### DIFF
--- a/src/openfl/media/Sound.hx
+++ b/src/openfl/media/Sound.hx
@@ -338,6 +338,7 @@ class Sound extends EventDispatcher
 		#if lime
 		if (__buffer != null)
 		{
+			SoundMixer.__unregisterSoundChannelByBuffer(__buffer);
 			__buffer.dispose();
 			__buffer = null;
 		}

--- a/src/openfl/media/SoundMixer.hx
+++ b/src/openfl/media/SoundMixer.hx
@@ -170,9 +170,9 @@ package openfl.media;
 	**/
 	public static function stopAll():Void
 	{
-		for (channel in __soundChannels)
-		{
-			channel.stop();
+		var i = __soundChannels.length;
+		while (i-- > 0) {
+			__soundChannels[i].stop();
 		}
 	}
 
@@ -191,6 +191,21 @@ package openfl.media;
 	{
 		return __soundTransform;
 	}
+
+	#if lime
+	@:noCompletion private static function __unregisterSoundChannelByBuffer(buffer:lime.media.AudioBuffer):Void
+	{
+		var i = __soundChannels.length;
+		while (i-- > 0)
+		{
+			var channel = __soundChannels[i];
+			if (channel.__source.buffer == buffer)
+			{
+				channel.stop();
+			}
+		}
+	}
+	#end
 
 	@:noCompletion private static function set_soundTransform(value:SoundTransform):SoundTransform
 	{

--- a/src/openfl/media/SoundMixer.hx
+++ b/src/openfl/media/SoundMixer.hx
@@ -171,8 +171,10 @@ package openfl.media;
 	public static function stopAll():Void
 	{
 		var i = __soundChannels.length;
-		while (i-- > 0) {
+		while (i > 0)
+		{
 			__soundChannels[i].stop();
+			i--;
 		}
 	}
 
@@ -196,13 +198,14 @@ package openfl.media;
 	@:noCompletion private static function __unregisterSoundChannelByBuffer(buffer:lime.media.AudioBuffer):Void
 	{
 		var i = __soundChannels.length;
-		while (i-- > 0)
+		while (i > 0)
 		{
 			var channel = __soundChannels[i];
 			if (channel.__audioSource.buffer == buffer)
 			{
 				channel.stop();
 			}
+			i--;
 		}
 	}
 	#end

--- a/src/openfl/media/SoundMixer.hx
+++ b/src/openfl/media/SoundMixer.hx
@@ -199,7 +199,7 @@ package openfl.media;
 		while (i-- > 0)
 		{
 			var channel = __soundChannels[i];
-			if (channel.__source.buffer == buffer)
+			if (channel.__audioSource.buffer == buffer)
 			{
 				channel.stop();
 			}


### PR DESCRIPTION
Fixed the issue where SoundChannel may cause SoundMixer to close during playback the __soundChannels array will not be removed, ultimately causing the audio to reach its maximum limit and unable to play the audio.

Like this:
```haxe
var sound:Sound = openfl.Assets.getSound("assets/sound.mp3");
sound.play();
sound.close();
// The audio length is 1, but the correct value should be 0. 
// After the audio is turned off, you will never receive an audio playback completion event.
trace(@privateAccess SoundMixer.__soundChannels.length);
```