### PR TITLE
Improving BitmapData.draw performance (in dispose Image mode)

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -222,6 +222,7 @@ class BitmapData implements IBitmapDrawable
 	@:noCompletion private var __worldAlpha:Float;
 	@:noCompletion private var __worldColorTransform:ColorTransform;
 	@:noCompletion private var __worldTransform:Matrix;
+	@:noCompletion private var __renderer:OpenGLRenderer;
 
 	/**
 		Creates a BitmapData object with a specified width and height. If you specify a value for
@@ -918,27 +919,35 @@ class BitmapData implements IBitmapDrawable
 				_colorTransform.__combine(colorTransform);
 			}
 
-			var renderer = new OpenGLRenderer(Lib.current.stage.context3D, this);
-			renderer.__allowSmoothing = smoothing;
-			renderer.__pixelRatio = #if openfl_disable_hdpi 1 #else Lib.current.stage.window.scale #end;
-			renderer.__overrideBlendMode = blendMode;
+			if (__renderer == null)
+			{
+				__renderer = new OpenGLRenderer(Lib.current.stage.context3D, this);
+			}
+			else
+			{
+				@:privateAccess __renderer.__cleanup();
+				__renderer.setShader(@:privateAccess __renderer.__defaultShader);
+			}
+			__renderer.__allowSmoothing = smoothing;
+			__renderer.__pixelRatio = #if openfl_disable_hdpi 1 #else Lib.current.stage.window.scale #end;
+			__renderer.__overrideBlendMode = blendMode;
 
-			renderer.__worldTransform = transform;
-			renderer.__worldAlpha = 1 / source.__worldAlpha;
-			renderer.__worldColorTransform = _colorTransform;
+			__renderer.__worldTransform = transform;
+			__renderer.__worldAlpha = 1 / source.__worldAlpha;
+			__renderer.__worldColorTransform = _colorTransform;
 
-			renderer.__resize(width, height);
+			__renderer.__resize(width, height);
 
 			if (clipRect != null)
 			{
-				renderer.__pushMaskRect(clipRect, clipMatrix);
+				__renderer.__pushMaskRect(clipRect, clipMatrix);
 			}
 
-			__drawGL(source, renderer);
+			__drawGL(source, __renderer);
 
 			if (clipRect != null)
 			{
-				renderer.__popMaskRect();
+				__renderer.__popMaskRect();
 				Matrix.__pool.release(clipMatrix);
 			}
 		}


### PR DESCRIPTION
1. Referencing the OpenGLRenderer renderer eliminates the need for reconstruction and reduces the cost of initializing the Shader.

2. Set default shaders for existing OpenGLRenderer renderers.

It is very effective in the following code:
```haxe
package;

import openfl.geom.Matrix;
import openfl.display.FPS;
import openfl.events.Event;
import openfl.display.BitmapData;
import openfl.display.Bitmap;
import openfl.display.Sprite;

class Main extends Sprite {
	public function new() {
		super();

		var spr = new Sprite();
		spr.graphics.beginFill(0xff0000);
		spr.graphics.drawCircle(0, 0, 10);
		spr.graphics.endFill();

		var drawBitmapData = new BitmapData(500, 500, false, 0);
		drawBitmapData.disposeImage();

		var drawBitmap = new Bitmap(drawBitmapData);
		this.addChild(drawBitmap);

		this.addEventListener(Event.ENTER_FRAME, (e) -> {
			var m = new Matrix();
			m.translate(Math.random() * 500, Math.random() * 500);
			for (i in 0...100) {
				drawBitmapData.draw(spr, m);
			}
		});

		var fps = new FPS();
		this.addChild(fps);
	}
}
```