### PR TITLE
Make lime.ui.Gamepad accessible from a GameInputDevice

### DIFF
--- a/src/openfl/ui/GameInput.hx
+++ b/src/openfl/ui/GameInput.hx
@@ -135,7 +135,7 @@ import lime.ui.GamepadButton;
 
 		if (!__devices.exists(gamepad))
 		{
-			var device = new GameInputDevice(gamepad.guid, gamepad.name);
+			var device = new GameInputDevice(gamepad);
 			__deviceList.push(device);
 			__devices.set(gamepad, device);
 			numDevices = __deviceList.length;

--- a/src/openfl/ui/GameInputDevice.hx
+++ b/src/openfl/ui/GameInputDevice.hx
@@ -61,10 +61,11 @@ import lime.ui.Gamepad;
 	}
 	#end
 
-	@:noCompletion private function new(id:String, name:String)
+	@:noCompletion private function new(gamepad:Gamepad)
 	{
-		this.id = id;
-		this.name = name;
+		this.__gamepad = gamepad;
+		this.id = gamepad.guid;
+		this.name = gamepad.name;
 
 		var control;
 
@@ -92,6 +93,11 @@ import lime.ui.Gamepad;
 	public function getCachedSamples(data:ByteArray, append:Bool = false):Int
 	{
 		return 0;
+	}
+
+	public function getLimeGamepad():Gamepad
+	{
+		return __gamepad;
 	}
 
 	/**


### PR DESCRIPTION
A GameInputDevice now receives a reference to the Gamepad rather than its properties. It then holds onto it so it can be accessed via a function.

I haven't seen any major issues with this from having it on Funkin's fork of OpenFL.