### PR TITLE
Shader system improvements (redo)

### DIFF
--- a/src/openfl/display/GraphicsShader.hx
+++ b/src/openfl/display/GraphicsShader.hx
@@ -8,7 +8,6 @@ import openfl.utils.ByteArray;
 #end
 class GraphicsShader extends Shader
 {
-	@:glVersion("120")
 	@:glVertexHeader("attribute float openfl_Alpha;
 		attribute vec4 openfl_ColorMultiplier;
 		attribute vec4 openfl_ColorOffset;

--- a/src/openfl/display/GraphicsShader.hx
+++ b/src/openfl/display/GraphicsShader.hx
@@ -8,6 +8,7 @@ import openfl.utils.ByteArray;
 #end
 class GraphicsShader extends Shader
 {
+	@:glVersion("120")
 	@:glVertexHeader("attribute float openfl_Alpha;
 		attribute vec4 openfl_ColorMultiplier;
 		attribute vec4 openfl_ColorOffset;

--- a/src/openfl/display/GraphicsShader.hx
+++ b/src/openfl/display/GraphicsShader.hx
@@ -8,7 +8,6 @@ import openfl.utils.ByteArray;
 #end
 class GraphicsShader extends Shader
 {
-	@:glVersion(120)
 	@:glVertexHeader("attribute float openfl_Alpha;
 		attribute vec4 openfl_ColorMultiplier;
 		attribute vec4 openfl_ColorOffset;
@@ -22,7 +21,7 @@ class GraphicsShader extends Shader
 
 		uniform mat4 openfl_Matrix;
 		uniform bool openfl_HasColorTransform;
-		uniform vec2 openfl_TextureSize;")
+		uniform vec2 openfl_TextureSize;", true)
 	@:glVertexBody("openfl_Alphav = openfl_Alpha;
 		openfl_TextureCoordv = openfl_TextureCoord;
 
@@ -48,7 +47,7 @@ class GraphicsShader extends Shader
 
 		uniform bool openfl_HasColorTransform;
 		uniform vec2 openfl_TextureSize;
-		uniform sampler2D bitmap;")
+		uniform sampler2D bitmap;", true)
 	@:glFragmentBody("vec4 color = texture2D (bitmap, openfl_TextureCoordv);
 
 		if (color.a == 0.0) {
@@ -81,7 +80,7 @@ class GraphicsShader extends Shader
 
 			gl_FragColor = color * openfl_Alphav;
 
-		}")
+		}", true)
 	#if emscripten
 	@:glFragmentSource("#pragma header
 

--- a/src/openfl/display/GraphicsShader.hx
+++ b/src/openfl/display/GraphicsShader.hx
@@ -8,6 +8,7 @@ import openfl.utils.ByteArray;
 #end
 class GraphicsShader extends Shader
 {
+	@:glVersion(120)
 	@:glVertexHeader("attribute float openfl_Alpha;
 		attribute vec4 openfl_ColorMultiplier;
 		attribute vec4 openfl_ColorOffset;

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -154,9 +154,13 @@ class Shader
 		Example:
 		```
 		@:glExtensions([{name: "OES_standard_derivatives", behavior: "require"}])
+		@:glVertexExtensions([{name: "OES_standard_derivatives", behavior: "require"}])
+		@:glFragmentExtensions([{name: "OES_standard_derivatives", behavior: "require"}])
 		```
 	**/
-	public var glExtensions(get, set):Array<{name:String, behavior:String}>;
+	public var glVertexExtensions(get, set):Array<{name:String, behavior:String}>;
+
+	public var glFragmentExtensions(get, set):Array<{name:String, behavior:String}>;
 
 	/**
 		The default GLSL vertex header, before being applied to the vertex source.
@@ -263,7 +267,8 @@ class Shader
 	@:noCompletion private var __colorOffset:ShaderParameter<Float>;
 	@:noCompletion private var __context:Context3D;
 	@:noCompletion private var __data:ShaderData;
-	@:noCompletion private var __glExtensions:Array<{name:String, behavior:String}>;
+	@:noCompletion private var __glVertexExtensions:Array<{name:String, behavior:String}>;
+	@:noCompletion private var __glFragmentExtensions:Array<{name:String, behavior:String}>;
 	@:noCompletion private var __glVersion:String;
 	@:noCompletion private var __glFragmentHeaderRaw:String;
 	@:noCompletion private var __glFragmentBodyRaw:String;
@@ -295,9 +300,13 @@ class Shader
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_data (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_data (v); }")
 			},
-			"glExtensions": {
-				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glExtensions (); }"),
-				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_glExtensions (v); }")
+			"glVertexExtensions": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glVertexExtensions (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_glVertexExtensions (v); }")
+			},
+			"glFragmentExtensions": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glFragmentExtensions (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_glFragmentExtensions (v); }")
 			},
 			"glVersion": {
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glVersion (); }"),
@@ -542,11 +551,12 @@ class Shader
 		}
 	}
 
-	@:noCompletion private function __buildSourcePrefix():String
+	@:noCompletion private function __buildSourcePrefix(isFragment:Bool):String
 	{
 		var extensions = "";
 
-		for (ext in __glExtensions)
+		var extList = (isFragment ? __glFragmentExtensions : __glVertexExtensions);
+		for (ext in extList)
 		{
 			extensions += "#extension " + ext.name + " : " + ext.behavior + "\n";
 		}
@@ -594,8 +604,8 @@ class Shader
 		{
 			var gl = __context.gl;
 
-			var vertex = __buildSourcePrefix() + glVertexSource;
-			var fragment = __buildSourcePrefix() + glFragmentSource;
+			var vertex = __buildSourcePrefix(false) + glVertexSource;
+			var fragment = __buildSourcePrefix(true) + glFragmentSource;
 
 			var id = vertex + fragment;
 
@@ -1054,9 +1064,14 @@ class Shader
 		return __glVersion;
 	}
 
-	@:noCompletion private function get_glExtensions():Array<{name:String, behavior:String}>
+	@:noCompletion private function get_glVertexExtensions():Array<{name:String, behavior:String}>
 	{
-		return __glExtensions;
+		return __glVertexExtensions;
+	}
+
+	@:noCompletion private function get_glFragmentExtensions():Array<{name:String, behavior:String}>
+	{
+		return __glFragmentExtensions;
 	}
 
 	@:noCompletion private function set_glFragmentSource(value:String):String
@@ -1079,14 +1094,24 @@ class Shader
 		return __glVersion = value;
 	}
 
-	@:noCompletion private function set_glExtensions(value:Array<{name:String, behavior:String}>):Array<{name:String, behavior:String}>
+	@:noCompletion private function set_glVertexExtensions(value:Array<{name:String, behavior:String}>):Array<{name:String, behavior:String}>
 	{
-		if (value != __glExtensions)
+		if (value != __glVertexExtensions)
 		{
 			__glSourceDirty = true;
 		}
 
-		return __glExtensions = value;
+		return __glVertexExtensions = value;
+	}
+
+	@:noCompletion private function set_glFragmentExtensions(value:Array<{name:String, behavior:String}>):Array<{name:String, behavior:String}>
+	{
+		if (value != __glFragmentExtensions)
+		{
+			__glSourceDirty = true;
+		}
+
+		return __glFragmentExtensions = value;
 	}
 
 	@:noCompletion private function get_glVertexHeaderRaw():String

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -1,14 +1,14 @@
 package openfl.display;
 
 #if !flash
-import openfl.display3D._internal.GLProgram;
-import openfl.display3D._internal.GLShader;
 import openfl.display._internal.ShaderBuffer;
-import openfl.utils._internal.Float32Array;
-import openfl.utils._internal.Log;
 import openfl.display3D.Context3D;
 import openfl.display3D.Program3D;
+import openfl.display3D._internal.GLProgram;
+import openfl.display3D._internal.GLShader;
 import openfl.utils.ByteArray;
+import openfl.utils._internal.Float32Array;
+import openfl.utils._internal.Log;
 
 /**
 	// TODO: Document GLSL Shaders
@@ -141,6 +141,28 @@ class Shader
 	public var data(get, set):ShaderData;
 
 	/**
+		Get or set the GLSL version used in the header when compiling with GLSL.
+
+		Defaults to `120`
+	**/
+	public var glVersion(get, set):Int;
+
+	/**
+		The default GLSL vertex header, before being applied to the vertex source.
+	**/
+	public var glFragmentHeaderRaw(get, null):String;
+
+	/**
+		The default GLSL vertex body, before being applied to the vertex source.
+	**/
+	public var glFragmentBodyRaw(get, null):String;
+
+	/**
+		The default GLSL fragment source, before `#pragma` values are replaced.
+	**/
+	public var glFragmentSourceRaw(get, null):String;
+
+	/**
 		Get or set the fragment source used when compiling with GLSL.
 
 		This property is not available on the Flash target.
@@ -153,6 +175,21 @@ class Shader
 		This property is not available on the Flash target.
 	**/
 	@SuppressWarnings("checkstyle:Dynamic") public var glProgram(default, null):GLProgram;
+
+	/**
+		The default GLSL vertex header, before being applied to the vertex source.
+	**/
+	public var glVertexHeaderRaw(get, null):String;
+
+	/**
+		The default GLSL vertex body, before being applied to the vertex source.
+	**/
+	public var glVertexBodyRaw(get, null):String;
+
+	/**
+		The default GLSL vertex source, before `#pragma` values are replaced.
+	**/
+	public var glVertexSourceRaw(get, null):String;
 
 	/**
 		Get or set the vertex source used when compiling with GLSL.
@@ -215,8 +252,15 @@ class Shader
 	@:noCompletion private var __colorOffset:ShaderParameter<Float>;
 	@:noCompletion private var __context:Context3D;
 	@:noCompletion private var __data:ShaderData;
+	@:noCompletion private var __glVersion:Int;
+	@:noCompletion private var __glFragmentHeaderRaw:String;
+	@:noCompletion private var __glFragmentBodyRaw:String;
+	@:noCompletion private var __glFragmentSourceRaw:String;
 	@:noCompletion private var __glFragmentSource:String;
 	@:noCompletion private var __glSourceDirty:Bool;
+	@:noCompletion private var __glVertexHeaderRaw:String;
+	@:noCompletion private var __glVertexBodyRaw:String;
+	@:noCompletion private var __glVertexSourceRaw:String;
 	@:noCompletion private var __glVertexSource:String;
 	@:noCompletion private var __hasColorTransform:ShaderParameter<Bool>;
 	@:noCompletion private var __inputBitmapData:Array<ShaderInput<BitmapData>>;
@@ -239,9 +283,31 @@ class Shader
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_data (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_data (v); }")
 			},
+			"glVersion": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glVersion (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_glVersion (v); }")
+			},
+			"glFragmentHeaderRaw": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glFragmentHeaderRaw (); }"),
+			},
+			"glFragmentBodyRaw": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glFragmentBodyRaw (); }"),
+			},
+			"glFragmentSourceRaw": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glFragmentSourceRaw (); }"),
+			},
 			"glFragmentSource": {
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glFragmentSource (); }"),
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_glFragmentSource (v); }")
+			},
+			"glVertexHeaderRaw": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glVertexHeaderRaw (); }"),
+			},
+			"glVertexBodyRaw": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glVertexBodyRaw (); }"),
+			},
+			"glVertexSourceRaw": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glVertexSourceRaw (); }"),
 			},
 			"glVertexSource": {
 				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_glVertexSource (); }"),
@@ -460,6 +526,23 @@ class Shader
 		}
 	}
 
+	@:noCompletion private function __buildSourcePrefix():String
+	{
+		return "#version "
+			+ __glVersion
+			+ "
+				#ifdef GL_ES
+				"
+			+ (precisionHint == FULL ? "#ifdef GL_FRAGMENT_PRECISION_HIGH
+					precision highp float;
+				#else
+					precision mediump float;
+				#endif" : "precision lowp float;")
+			+ "
+				#endif
+				";
+	}
+
 	@:noCompletion private function __initGL():Void
 	{
 		if (__glSourceDirty || __paramBool == null)
@@ -493,8 +576,8 @@ class Shader
 				+ "#endif\n\n";
 			#end
 
-			var vertex = prefix + glVertexSource;
-			var fragment = prefix + glFragmentSource;
+			var vertex = __buildSourcePrefix() + glVertexSource;
+			var fragment = __buildSourcePrefix() + glFragmentSource;
 
 			var id = vertex + fragment;
 
@@ -570,16 +653,11 @@ class Shader
 
 	@:noCompletion private function __processGLData(source:String, storageType:String):Void
 	{
-		var lastMatch = 0, position, regex, name, type;
+		var position, name, type;
 
-		if (storageType == "uniform")
-		{
-			regex = ~/uniform ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
-		}
-		else
-		{
-			regex = ~/attribute ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
-		}
+		var regex = (storageType == "uniform") ? ~/uniform ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/ : ~/attribute ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
+
+		var lastMatch = 0;
 
 		while (regex.matchSub(source, lastMatch))
 		{
@@ -610,7 +688,7 @@ class Shader
 				}
 
 				Reflect.setField(__data, name, input);
-				if (__isGenerated) Reflect.setField(this, name, input);
+				if (__isGenerated && thisHasField(name)) Reflect.setProperty(this, name, input);
 			}
 			else if (!Reflect.hasField(__data, name) || Reflect.field(__data, name) == null)
 			{
@@ -676,7 +754,7 @@ class Shader
 						}
 
 						Reflect.setField(__data, name, parameter);
-						if (__isGenerated) Reflect.setField(this, name, parameter);
+						if (__isGenerated && thisHasField(name)) Reflect.setProperty(this, name, parameter);
 
 					case INT, INT2, INT3, INT4:
 						var parameter = new ShaderParameter<Int>();
@@ -688,7 +766,7 @@ class Shader
 						parameter.__length = length;
 						__paramInt.push(parameter);
 						Reflect.setField(__data, name, parameter);
-						if (__isGenerated) Reflect.setField(this, name, parameter);
+						if (__isGenerated && thisHasField(name)) Reflect.setProperty(this, name, parameter);
 
 					default:
 						var parameter = new ShaderParameter<Float>();
@@ -719,7 +797,7 @@ class Shader
 						}
 
 						Reflect.setField(__data, name, parameter);
-						if (__isGenerated) Reflect.setField(this, name, parameter);
+						if (__isGenerated && thisHasField(name)) Reflect.setProperty(this, name, parameter);
 				}
 			}
 
@@ -922,9 +1000,29 @@ class Shader
 		return __data = cast value;
 	}
 
+	@:noCompletion private function get_glFragmentHeaderRaw():String
+	{
+		return __glFragmentHeaderRaw;
+	}
+
+	@:noCompletion private function get_glFragmentBodyRaw():String
+	{
+		return __glFragmentBodyRaw;
+	}
+
+	@:noCompletion private function get_glFragmentSourceRaw():String
+	{
+		return __glFragmentSourceRaw;
+	}
+
 	@:noCompletion private function get_glFragmentSource():String
 	{
 		return __glFragmentSource;
+	}
+
+	@:noCompletion private function get_glVersion():Int
+	{
+		return __glVersion;
 	}
 
 	@:noCompletion private function set_glFragmentSource(value:String):String
@@ -935,6 +1033,31 @@ class Shader
 		}
 
 		return __glFragmentSource = value;
+	}
+
+	@:noCompletion private function set_glVersion(value:Int):Int
+	{
+		if (value != __glVersion)
+		{
+			__glSourceDirty = true;
+		}
+
+		return __glVersion = value;
+	}
+
+	@:noCompletion private function get_glVertexHeaderRaw():String
+	{
+		return __glVertexHeaderRaw;
+	}
+
+	@:noCompletion private function get_glVertexBodyRaw():String
+	{
+		return __glVertexBodyRaw;
+	}
+
+	@:noCompletion private function get_glVertexSourceRaw():String
+	{
+		return __glVertexSourceRaw;
 	}
 
 	@:noCompletion private function get_glVertexSource():String
@@ -950,6 +1073,18 @@ class Shader
 		}
 
 		return __glVertexSource = value;
+	}
+
+	private var __fieldList:Array<String> = null;
+
+	private function thisHasField(name:String)
+	{
+		// Reflect.hasField(this, name) is REALLY expensive so we cache the result.
+		if (__fieldList == null)
+		{
+			__fieldList = Reflect.fields(this).concat(Type.getInstanceFields(Type.getClass(this)));
+		}
+		return __fieldList.indexOf(name) != -1;
 	}
 }
 #else

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -145,7 +145,7 @@ class Shader
 
 		Defaults to `120`
 	**/
-	public var glVersion(get, set):Int;
+	public var glVersion(get, set):String;
 
 	/**
 		The default GLSL vertex header, before being applied to the vertex source.
@@ -252,7 +252,7 @@ class Shader
 	@:noCompletion private var __colorOffset:ShaderParameter<Float>;
 	@:noCompletion private var __context:Context3D;
 	@:noCompletion private var __data:ShaderData;
-	@:noCompletion private var __glVersion:Int;
+	@:noCompletion private var __glVersion:String;
 	@:noCompletion private var __glFragmentHeaderRaw:String;
 	@:noCompletion private var __glFragmentBodyRaw:String;
 	@:noCompletion private var __glFragmentSourceRaw:String;
@@ -1020,7 +1020,7 @@ class Shader
 		return __glFragmentSource;
 	}
 
-	@:noCompletion private function get_glVersion():Int
+	@:noCompletion private function get_glVersion():String
 	{
 		return __glVersion;
 	}
@@ -1035,7 +1035,7 @@ class Shader
 		return __glFragmentSource = value;
 	}
 
-	@:noCompletion private function set_glVersion(value:Int):Int
+	@:noCompletion private function set_glVersion(value:String):String
 	{
 		if (value != __glVersion)
 		{

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -469,20 +469,10 @@ class ShaderMacro
 		switch (glVersion)
 		{
 			default:
-				// We don't know this GLSL version, so don't do anything.
+				// Don't make any changes to undefined versions.
 				return source;
 
-			case "100":
-				return source;
-			case "110":
-				return source;
-			case "120":
-				return source;
-			case "130":
-				return source;
-			case "140":
-				return source;
-			case "150":
+			case "100", "110", "120", "130", "140", "150":
 				return source;
 
 			case "300 es":
@@ -501,41 +491,20 @@ class ShaderMacro
 				result = glFragColorKeyword.replace(result, "fragColor");
 				return result;
 
-			case "310 es":
+			case "310 es", "320 es":
 				var result = processGLSLText(source, "300 es", isFragment);
-				return result;
-
-			case "320 es":
-				var result = processGLSLText(source, "310 es", isFragment);
 				return result;
 
 			case "330":
 				#if desktop
-				var result = processGLSLText(source, "320 es", isFragment);
+				var result = processGLSLText(source, "300 es", isFragment);
 				#else
 				var result = source;
 				#end
 				return result;
-			case "400":
+
+			case "400", "410", "420", "430", "440", "450", "460":
 				var result = processGLSLText(source, "330", isFragment);
-				return result;
-			case "410":
-				var result = processGLSLText(source, "400", isFragment);
-				return result;
-			case "420":
-				var result = processGLSLText(source, "410", isFragment);
-				return result;
-			case "430":
-				var result = processGLSLText(source, "420", isFragment);
-				return result;
-			case "440":
-				var result = processGLSLText(source, "430", isFragment);
-				return result;
-			case "450":
-				var result = processGLSLText(source, "440", isFragment);
-				return result;
-			case "460":
-				var result = processGLSLText(source, "450", isFragment);
 				return result;
 		}
 	}
@@ -553,17 +522,10 @@ class ShaderMacro
 			case "300 es": "out vec4 fragColor;\n";
 			#end
 
-			case "310 es": buildGLSLHeaders("300 es");
-			case "320 es": buildGLSLHeaders("310 es");
-			case "330": buildGLSLHeaders("320 es");
-			case "400": buildGLSLHeaders("330");
-			case "410": buildGLSLHeaders("400");
-			case "420": buildGLSLHeaders("410");
-			case "430": buildGLSLHeaders("420");
-			case "440": buildGLSLHeaders("430");
-			case "450": buildGLSLHeaders("440");
-			case "460": buildGLSLHeaders("450");
+			case "310 es", "320 es", "330", "400", "410", "420", "430", "440", "450", "460":
+				buildGLSLHeaders("300 es");
 
+			// Don't add any default headers to undefined versions
 			default: "";
 		};
 	}
@@ -576,23 +538,12 @@ class ShaderMacro
 
 		switch (glVersion)
 		{
+			// Don't add any extensions to undefined versions
 			default:
 				return glExtensions;
 
-			case "100":
-				return glExtensions;
-			case "110":
-				return glExtensions;
-			case "120":
-				return glExtensions;
-			case "130":
-				return glExtensions;
-			case "140":
-				return glExtensions;
-			case "150":
-				return glExtensions;
-
-			case "300 es":
+			#if desktop
+			case "300 es", "310 es", "320 es", "330":
 				var hasSeparateShaderObjects = false;
 				for (extension in glExtensions)
 				{
@@ -600,7 +551,6 @@ class ShaderMacro
 					if (extension.name == "GL_EXT_separate_shader_objects") hasSeparateShaderObjects = true;
 				}
 
-				#if desktop
 				if (!hasSeparateShaderObjects)
 				{
 					#if linux
@@ -609,35 +559,8 @@ class ShaderMacro
 					return glExtensions.concat([{name: "GL_ARB_separate_shader_objects", behavior: "require"}]);
 					#end
 				}
-				#end
 				return glExtensions;
-
-			case "310 es":
-				var result = buildGLSLExtensions(glExtensions, "300 es", isFragment);
-				return result;
-
-			case "320 es":
-				var result = buildGLSLExtensions(glExtensions, "310 es", isFragment);
-				return result;
-
-			case "330":
-				var result = buildGLSLExtensions(glExtensions, "320 es", isFragment);
-				return result;
-
-			case "400":
-				return glExtensions;
-			case "410":
-				return glExtensions;
-			case "420":
-				return glExtensions;
-			case "430":
-				return glExtensions;
-			case "440":
-				return glExtensions;
-			case "450":
-				return glExtensions;
-			case "460":
-				return glExtensions;
+			#end
 		}
 	}
 

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -24,7 +24,10 @@ class ShaderMacro
 		var glVertexHeader = "";
 		var glVertexBody = "";
 
-		var glVersion = 120;
+		// Specify the default glVersion.
+		// We can use compile defines to guess the correct value.
+		var glVersion = #if android "300 es" #else "120" #end;
+
 		var glFragmentSource = null;
 		var glFragmentSourceRaw = "";
 		var glVertexSource = null;

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -24,9 +24,9 @@ class ShaderMacro
 		var glVertexHeader = "";
 		var glVertexBody = "";
 
-		// Specify the default glVersion.
-		// We can use compile defines to guess the correct value.
-		var glVersion = #if android "300 es" #else "120" #end;
+		var glVersion:String = null;
+
+		var glExtensions = [];
 
 		var glFragmentSource = null;
 		var glFragmentSourceRaw = "";
@@ -39,26 +39,86 @@ class ShaderMacro
 			{
 				switch (meta.name)
 				{
-					case "glFragmentSource", ":glFragmentSource":
-						glFragmentSource = meta.params[0].getValue();
-
-					case "glVertexSource", ":glVertexSource":
-						glVertexSource = meta.params[0].getValue();
-
-					case "glFragmentHeader", ":glFragmentHeader":
-						glFragmentHeader = meta.params[0].getValue();
-
-					case "glFragmentBody", ":glFragmentBody":
-						glFragmentBody = meta.params[0].getValue();
-
-					case "glVertexHeader", ":glVertexHeader":
-						glVertexHeader = meta.params[0].getValue();
-
-					case "glVertexBody", ":glVertexBody":
-						glVertexBody = meta.params[0].getValue();
-
 					case "glVersion", ":glVersion":
 						glVersion = meta.params[0].getValue();
+
+					case "glExtensions", ":glExtensions":
+						glExtensions = meta.params[0].getValue();
+
+					default:
+				}
+			}
+
+			for (meta in field.meta)
+			{
+				/**
+					`@:glFragmentSource`, `@:glVertexSource`, `@:glFragmentHeader`, `@:glFragmentBody`, `@:glVertexHeader`, `@:glVertexBody`
+					all have a second argument which, if true, will use `processGLSLText` to convert the text to be compatible with the current GLSL version.
+					Defaults to false to prevent converting user-defined GLSL.
+				**/
+				var shouldProcess = meta.params.length > 1 && cast(meta.params[1].getValue(), Bool);
+
+				switch (meta.name)
+				{
+					case "glFragmentSource", ":glFragmentSource":
+						if (shouldProcess)
+						{
+							glFragmentSource = processGLSLText(meta.params[0].getValue(), glVersion, true);
+						}
+						else
+						{
+							glFragmentSource = meta.params[0].getValue();
+						}
+
+					case "glVertexSource", ":glVertexSource":
+						if (shouldProcess)
+						{
+							glVertexSource = processGLSLText(meta.params[0].getValue(), glVersion, false);
+						}
+						else
+						{
+							glVertexSource = meta.params[0].getValue();
+						}
+
+					case "glFragmentHeader", ":glFragmentHeader":
+						if (shouldProcess)
+						{
+							glFragmentHeader += processGLSLText(meta.params[0].getValue(), glVersion, true);
+						}
+						else
+						{
+							glFragmentHeader += meta.params[0].getValue();
+						}
+
+					case "glFragmentBody", ":glFragmentBody":
+						if (shouldProcess)
+						{
+							glFragmentBody += processGLSLText(meta.params[0].getValue(), glVersion, true);
+						}
+						else
+						{
+							glFragmentBody += meta.params[0].getValue();
+						}
+
+					case "glVertexHeader", ":glVertexHeader":
+						if (shouldProcess)
+						{
+							glVertexHeader += processGLSLText(meta.params[0].getValue(), glVersion, false);
+						}
+						else
+						{
+							glVertexHeader += meta.params[0].getValue();
+						}
+
+					case "glVertexBody", ":glVertexBody":
+						if (shouldProcess)
+						{
+							glVertexBody += processGLSLText(meta.params[0].getValue(), glVersion, false);
+						}
+						else
+						{
+							glVertexBody += meta.params[0].getValue();
+						}
 
 					default:
 				}
@@ -81,26 +141,92 @@ class ShaderMacro
 				{
 					switch (meta.name)
 					{
-						case "glFragmentSource", ":glFragmentSource":
-							if (glFragmentSource == null) glFragmentSource = meta.params[0].getValue();
-
-						case "glVertexSource", ":glVertexSource":
-							if (glVertexSource == null) glVertexSource = meta.params[0].getValue();
-
 						case "glVersion", ":glVersion":
 							if (glVersion == null) glVersion = meta.params[0].getValue();
 
+						case "glExtensions", ":glExtensions":
+							if (glExtensions == null) glExtensions = meta.params[0].getValue();
+
+						default:
+					}
+				}
+
+				for (meta in field.meta.get())
+				{
+					/**
+						`@:glFragmentSource`, `@:glVertexSource`, `@:glFragmentHeader`, `@:glFragmentBody`, `@:glVertexHeader`, `@:glVertexBody`
+						all have a second argument which, if true, will use `processGLSLText` to convert the text to be compatible with the current GLSL version.
+						Defaults to false to prevent converting user-defined GLSL.
+					**/
+					var shouldProcess = meta.params.length > 1 && cast(meta.params[1].getValue(), Bool);
+
+					switch (meta.name)
+					{
+						case "glFragmentSource", ":glFragmentSource":
+							if (glFragmentSource == null)
+							{
+								if (shouldProcess)
+								{
+									glFragmentSource = processGLSLText(meta.params[0].getValue(), glVersion, true);
+								}
+								else
+								{
+									glFragmentSource = meta.params[0].getValue();
+								}
+							}
+
+						case "glVertexSource", ":glVertexSource":
+							if (glVertexSource == null)
+							{
+								if (shouldProcess)
+								{
+									glVertexSource = processGLSLText(meta.params[0].getValue(), glVersion, false);
+								}
+								else
+								{
+									glVertexSource = meta.params[0].getValue();
+								}
+							}
+
 						case "glFragmentHeader", ":glFragmentHeader":
-							glFragmentHeader = meta.params[0].getValue() + "\n" + glFragmentHeader;
+							if (shouldProcess)
+							{
+								glFragmentHeader = processGLSLText(meta.params[0].getValue(), glVersion, true) + "\n" + glFragmentHeader;
+							}
+							else
+							{
+								glFragmentHeader = meta.params[0].getValue() + "\n" + glFragmentHeader;
+							}
 
 						case "glFragmentBody", ":glFragmentBody":
-							glFragmentBody = meta.params[0].getValue() + "\n" + glFragmentBody;
+							if (shouldProcess)
+							{
+								glFragmentBody = processGLSLText(meta.params[0].getValue(), glVersion, true) + "\n" + glFragmentBody;
+							}
+							else
+							{
+								glFragmentBody = meta.params[0].getValue() + "\n" + glFragmentBody;
+							}
 
 						case "glVertexHeader", ":glVertexHeader":
-							glVertexHeader = meta.params[0].getValue() + "\n" + glVertexHeader;
+							if (shouldProcess)
+							{
+								glVertexHeader = processGLSLText(meta.params[0].getValue(), glVersion, false) + "\n" + glVertexHeader;
+							}
+							else
+							{
+								glVertexHeader = meta.params[0].getValue() + "\n" + glVertexHeader;
+							}
 
 						case "glVertexBody", ":glVertexBody":
-							glVertexBody = meta.params[0].getValue() + "\n" + glVertexBody;
+							if (shouldProcess)
+							{
+								glVertexBody = processGLSLText(meta.params[0].getValue(), glVersion, false) + "\n" + glVertexBody;
+							}
+							else
+							{
+								glVertexBody = meta.params[0].getValue() + "\n" + glVertexBody;
+							}
 
 						default:
 					}
@@ -110,19 +236,25 @@ class ShaderMacro
 			parent = parent.superClass != null ? parent.superClass.t.get() : null;
 		}
 
+		if (glVersion == null)
+		{
+			glVersion = getDefaultGLVersion();
+		}
+		glExtensions = buildGLSLExtensions(glExtensions, glVersion);
+
 		if (glVertexSource != null || glFragmentSource != null)
 		{
 			if (glFragmentSource != null && glFragmentHeader != null && glFragmentBody != null)
 			{
 				glFragmentSourceRaw = glFragmentSource;
-				glFragmentSource = StringTools.replace(glFragmentSource, "#pragma header", glFragmentHeader);
+				glFragmentSource = StringTools.replace(glFragmentSource, "#pragma header", buildGLSLHeaders(glVersion) + glFragmentHeader);
 				glFragmentSource = StringTools.replace(glFragmentSource, "#pragma body", glFragmentBody);
 			}
 
 			if (glVertexSource != null && glVertexHeader != null && glVertexBody != null)
 			{
 				glVertexSourceRaw = glVertexSource;
-				glVertexSource = StringTools.replace(glVertexSource, "#pragma header", glVertexHeader);
+				glVertexSource = StringTools.replace(glVertexSource, "#pragma header", buildGLSLHeaders(glVersion) + glVertexHeader);
 				glVertexSource = StringTools.replace(glVertexSource, "#pragma body", glVertexBody);
 			}
 
@@ -130,6 +262,7 @@ class ShaderMacro
 			var uniqueFields = [];
 
 			processFields(glVertexSource, "attribute", shaderDataFields, pos);
+			processFields(glVertexSource, "in", shaderDataFields, pos); // For higher GLSL versions
 			processFields(glVertexSource, "uniform", shaderDataFields, pos);
 			processFields(glFragmentSource, "uniform", shaderDataFields, pos);
 
@@ -249,9 +382,17 @@ class ShaderMacro
 							});
 						}
 
+						if (glExtensions != null)
+						{
+							block.unshift(macro if (__glExtensions == null)
+							{
+								__glExtensions = $v{glExtensions};
+							});
+						}
+
 						if (glVersion != null)
 						{
-							block.unshift(macro if (__glVersion == 0)
+							block.unshift(macro if (__glVersion == null)
 							{
 								__glVersion = $v{glVersion};
 							});
@@ -270,6 +411,245 @@ class ShaderMacro
 		return fields;
 	}
 
+	private static inline function getDefaultGLVersion():String
+	{
+		// Specify the default glVersion.
+		// We can use compile defines to guess the value that prevents crashes in the majority of cases.
+		return #if (android) "100" #elseif (web) "100" #else "100" #end;
+	}
+
+	/**
+	 * Attempt to migrate GLSL code from the current (old) GLSL shader format to the specified (newer) one.
+	 * @param source The source to convert.
+	 * @param version The version to convert to.
+	 * @param isFragment Whether the source is a fragment shader. False if it is a vertex shader.
+	 * @return The converted source.
+	 */
+	private static function processGLSLText(source:String, glVersion:String, isFragment:Bool)
+	{
+		if (glVersion == "" || glVersion == null) return processGLSLText(source, getDefaultGLVersion(), isFragment);
+
+		// No processing needed on "compatibility" profile
+		if (StringTools.endsWith(glVersion, " compatibility")) return source;
+		if (StringTools.endsWith(glVersion, " core")) return processGLSLText(source, StringTools.replace(glVersion, " core", ""), isFragment);
+
+		// Recall: Attribute values are per-vertex, varying values are per-fragment
+		// Thus, an `out` value in the vertex shader is an `in` value in the fragment shader
+		var attributeKeyword:EReg = ~/attribute ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/g; // g to match all
+		var varyingKeyword:EReg = ~/varying ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/g; // g to match all
+
+		var texture2DKeyword:EReg = ~/texture2D/g;
+		var glFragColorKeyword:EReg = ~/gl_FragColor/g;
+
+		switch (glVersion)
+		{
+			default:
+				// We don't know this GLSL version, so don't do anything.
+				return source;
+
+			case "100":
+				return source;
+			case "110":
+				return source;
+			case "120":
+				return source;
+			case "130":
+				return source;
+			case "140":
+				return source;
+			case "150":
+				return source;
+
+			case "300 es":
+				var result = source;
+				// Migrate, replacing "attribute" with "in" and "varying" with "out".
+				if (isFragment)
+				{
+					result = varyingKeyword.replace(result, "in $1 $2");
+				}
+				else
+				{
+					result = attributeKeyword.replace(result, "in $1 $2");
+					result = varyingKeyword.replace(result, "out $1 $2");
+				}
+				result = texture2DKeyword.replace(result, "texture");
+				result = glFragColorKeyword.replace(result, "fragColor");
+				return result;
+
+			case "310 es":
+				var result = processGLSLText(source, "300 es", isFragment);
+				return result;
+
+			case "320 es":
+				var result = processGLSLText(source, "310 es", isFragment);
+				return result;
+
+			case "330":
+				#if desktop
+				var result = processGLSLText(source, "320 es", isFragment);
+				#else
+				var result = source;
+				#end
+				return result;
+			case "400":
+				var result = processGLSLText(source, "330", isFragment);
+				return result;
+			case "410":
+				var result = processGLSLText(source, "400", isFragment);
+				return result;
+			case "420":
+				var result = processGLSLText(source, "410", isFragment);
+				return result;
+			case "430":
+				var result = processGLSLText(source, "420", isFragment);
+				return result;
+			case "440":
+				var result = processGLSLText(source, "430", isFragment);
+				return result;
+			case "450":
+				var result = processGLSLText(source, "440", isFragment);
+				return result;
+			case "460":
+				var result = processGLSLText(source, "450", isFragment);
+				return result;
+		}
+	}
+
+	private static function buildGLSLHeaders(glVersion:String):String
+	{
+		if (StringTools.endsWith(glVersion, " compatibility")) return "";
+		if (StringTools.endsWith(glVersion, " core")) return buildGLSLHeaders(StringTools.replace(glVersion, " core", ""));
+
+		switch (glVersion)
+		{
+			default:
+				return "";
+
+			case "100":
+				return "";
+			case "110":
+				return "";
+			case "120":
+				return "";
+			case "130":
+				return "";
+			case "140":
+				return "";
+			case "150":
+				return "";
+
+			case "300 es":
+				#if desktop
+				var result = "layout (location = 0) out vec4 fragColor;\n";
+				#else
+				var result = "out vec4 fragColor;\n";
+				// var result = "";
+				#end
+				return result;
+			case "310 es":
+				var result = buildGLSLHeaders("300 es");
+				return result;
+			case "320 es":
+				var result = buildGLSLHeaders("310 es");
+				return result;
+
+			case "330":
+				var result = buildGLSLHeaders("320 es");
+				return result;
+
+			case "400":
+				var result = buildGLSLHeaders("330");
+				return result;
+			case "410":
+				var result = buildGLSLHeaders("400");
+				return result;
+			case "420":
+				var result = buildGLSLHeaders("410");
+				return result;
+			case "430":
+				var result = buildGLSLHeaders("420");
+				return result;
+			case "440":
+				var result = buildGLSLHeaders("430");
+				return result;
+			case "450":
+				var result = buildGLSLHeaders("440");
+				return result;
+			case "460":
+				var result = buildGLSLHeaders("450");
+				return result;
+		}
+	}
+
+	private static function buildGLSLExtensions(glExtensions:Array<{name:String, behavior:String}>, glVersion:String):Array<{name:String, behavior:String}>
+	{
+		if (StringTools.endsWith(glVersion, " compatibility")) return glExtensions;
+		if (StringTools.endsWith(glVersion, " core")) return buildGLSLExtensions(glExtensions, StringTools.replace(glVersion, " core", ""));
+
+		switch (glVersion)
+		{
+			default:
+				return glExtensions;
+
+			case "100":
+				return glExtensions;
+			case "110":
+				return glExtensions;
+			case "120":
+				return glExtensions;
+			case "130":
+				return glExtensions;
+			case "140":
+				return glExtensions;
+			case "150":
+				return glExtensions;
+
+			case "300 es":
+				return glExtensions;
+			case "310 es":
+				return glExtensions;
+			case "320 es":
+				return glExtensions;
+
+			case "330":
+				var hasSeparateShaderObjects = false;
+				for (extension in glExtensions)
+				{
+					if (extension.name == "GL_ARB_separate_shader_objects") hasSeparateShaderObjects = true;
+				}
+
+				#if desktop
+				if (!hasSeparateShaderObjects)
+				{
+					return glExtensions.concat([{name: "GL_ARB_separate_shader_objects", behavior: "require"}]);
+				}
+				#end
+				return glExtensions;
+
+			case "400":
+				var result = buildGLSLExtensions(glExtensions, "330");
+				return result;
+			case "410":
+				var result = buildGLSLExtensions(glExtensions, "400");
+				return result;
+			case "420":
+				var result = buildGLSLExtensions(glExtensions, "410");
+				return result;
+			case "430":
+				var result = buildGLSLExtensions(glExtensions, "420");
+				return result;
+			case "440":
+				var result = buildGLSLExtensions(glExtensions, "430");
+				return result;
+			case "450":
+				var result = buildGLSLExtensions(glExtensions, "440");
+				return result;
+			case "460":
+				var result = buildGLSLExtensions(glExtensions, "450");
+				return result;
+		}
+	}
+
 	private static function processFields(source:String, storageType:String, fields:Array<Field>, pos:Position):Void
 	{
 		if (source == null) return;
@@ -279,6 +659,10 @@ class ShaderMacro
 		if (storageType == "uniform")
 		{
 			regex = ~/uniform ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
+		}
+		else if (storageType == "in")
+		{
+			regex = ~/in ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
 		}
 		else
 		{

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -545,65 +545,27 @@ class ShaderMacro
 		if (StringTools.endsWith(glVersion, " compatibility")) return "";
 		if (StringTools.endsWith(glVersion, " core")) return buildGLSLHeaders(StringTools.replace(glVersion, " core", ""));
 
-		switch (glVersion)
+		return switch (glVersion)
 		{
-			default:
-				return "";
+			#if desktop
+			case "300 es": "layout (location = 0) out vec4 fragColor;\n";
+			#else
+			case "300 es": "out vec4 fragColor;\n";
+			#end
 
-			case "100":
-				return "";
-			case "110":
-				return "";
-			case "120":
-				return "";
-			case "130":
-				return "";
-			case "140":
-				return "";
-			case "150":
-				return "";
+			case "310 es": buildGLSLHeaders("300 es");
+			case "320 es": buildGLSLHeaders("310 es");
+			case "330": buildGLSLHeaders("320 es");
+			case "400": buildGLSLHeaders("330");
+			case "410": buildGLSLHeaders("400");
+			case "420": buildGLSLHeaders("410");
+			case "430": buildGLSLHeaders("420");
+			case "440": buildGLSLHeaders("430");
+			case "450": buildGLSLHeaders("440");
+			case "460": buildGLSLHeaders("450");
 
-			case "300 es":
-				#if desktop
-				var result = "layout (location = 0) out vec4 fragColor;\n";
-				#else
-				var result = "out vec4 fragColor;\n";
-				// var result = "";
-				#end
-				return result;
-			case "310 es":
-				var result = buildGLSLHeaders("300 es");
-				return result;
-			case "320 es":
-				var result = buildGLSLHeaders("310 es");
-				return result;
-
-			case "330":
-				var result = buildGLSLHeaders("320 es");
-				return result;
-
-			case "400":
-				var result = buildGLSLHeaders("330");
-				return result;
-			case "410":
-				var result = buildGLSLHeaders("400");
-				return result;
-			case "420":
-				var result = buildGLSLHeaders("410");
-				return result;
-			case "430":
-				var result = buildGLSLHeaders("420");
-				return result;
-			case "440":
-				var result = buildGLSLHeaders("430");
-				return result;
-			case "450":
-				var result = buildGLSLHeaders("440");
-				return result;
-			case "460":
-				var result = buildGLSLHeaders("450");
-				return result;
-		}
+			default: "";
+		};
 	}
 
 	private static function buildGLSLExtensions(glExtensions:Array<{name:String, behavior:String}>, glVersion:String,

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -24,8 +24,11 @@ class ShaderMacro
 		var glVertexHeader = "";
 		var glVertexBody = "";
 
+		var glVersion = 120;
 		var glFragmentSource = null;
+		var glFragmentSourceRaw = "";
 		var glVertexSource = null;
+		var glVertexSourceRaw = "";
 
 		for (field in fields)
 		{
@@ -50,6 +53,9 @@ class ShaderMacro
 
 					case "glVertexBody", ":glVertexBody":
 						glVertexBody = meta.params[0].getValue();
+
+					case "glVersion", ":glVersion":
+						glVersion = meta.params[0].getValue();
 
 					default:
 				}
@@ -78,6 +84,9 @@ class ShaderMacro
 						case "glVertexSource", ":glVertexSource":
 							if (glVertexSource == null) glVertexSource = meta.params[0].getValue();
 
+						case "glVersion", ":glVersion":
+							if (glVersion == null) glVersion = meta.params[0].getValue();
+
 						case "glFragmentHeader", ":glFragmentHeader":
 							glFragmentHeader = meta.params[0].getValue() + "\n" + glFragmentHeader;
 
@@ -102,12 +111,14 @@ class ShaderMacro
 		{
 			if (glFragmentSource != null && glFragmentHeader != null && glFragmentBody != null)
 			{
+				glFragmentSourceRaw = glFragmentSource;
 				glFragmentSource = StringTools.replace(glFragmentSource, "#pragma header", glFragmentHeader);
 				glFragmentSource = StringTools.replace(glFragmentSource, "#pragma body", glFragmentBody);
 			}
 
 			if (glVertexSource != null && glVertexHeader != null && glVertexBody != null)
 			{
+				glVertexSourceRaw = glVertexSource;
 				glVertexSource = StringTools.replace(glVertexSource, "#pragma header", glVertexHeader);
 				glVertexSource = StringTools.replace(glVertexSource, "#pragma body", glVertexBody);
 			}
@@ -169,6 +180,8 @@ class ShaderMacro
 							default: null;
 						}
 
+						block.unshift(Context.parse("__isGenerated = true", pos));
+
 						if (glVertexSource != null)
 						{
 							block.unshift(macro if (__glVertexSource == null)
@@ -185,7 +198,62 @@ class ShaderMacro
 							});
 						}
 
-						block.push(Context.parse("__isGenerated = true", pos));
+						if (glVertexSourceRaw != null)
+						{
+							block.unshift(macro if (__glVertexSourceRaw == null)
+							{
+								__glVertexSourceRaw = $v{glVertexSourceRaw};
+							});
+						}
+
+						if (glFragmentSourceRaw != null)
+						{
+							block.unshift(macro if (__glFragmentSourceRaw == null)
+							{
+								__glFragmentSourceRaw = $v{glFragmentSourceRaw};
+							});
+						}
+
+						if (glVertexBody != null)
+						{
+							block.unshift(macro if (__glVertexBodyRaw == null)
+							{
+								__glVertexBodyRaw = $v{glVertexBody};
+							});
+						}
+
+						if (glFragmentBody != null)
+						{
+							block.unshift(macro if (__glFragmentBodyRaw == null)
+							{
+								__glFragmentBodyRaw = $v{glFragmentBody};
+							});
+						}
+
+						if (glVertexHeader != null)
+						{
+							block.unshift(macro if (__glVertexHeaderRaw == null)
+							{
+								__glVertexHeaderRaw = $v{glVertexHeader};
+							});
+						}
+
+						if (glFragmentHeader != null)
+						{
+							block.unshift(macro if (__glFragmentHeaderRaw == null)
+							{
+								__glFragmentHeaderRaw = $v{glFragmentHeader};
+							});
+						}
+
+						if (glVersion != null)
+						{
+							block.unshift(macro if (__glVersion == 0)
+							{
+								__glVersion = $v{glVersion};
+							});
+						}
+
 						block.push(Context.parse("__initGL ()", pos));
 
 					default:

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -440,7 +440,7 @@ class ShaderMacro
 	{
 		// Specify the default glVersion.
 		// We can use compile defines to guess the value that prevents crashes in the majority of cases.
-		return #if (android) "100" #elseif (web) "100" #else "100" #end;
+		return #if (android) "100" #elseif (web) "100" #elseif (mac) "120" #else "100" #end;
 	}
 
 	/**
@@ -659,7 +659,8 @@ class ShaderMacro
 				return result;
 
 			case "330":
-				return glExtensions;
+				var result = buildGLSLExtensions(glExtensions, "320 es", isFragment);
+				return result;
 
 			case "400":
 				return glExtensions;

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -659,30 +659,22 @@ class ShaderMacro
 				return result;
 
 			case "330":
-				var result = buildGLSLExtensions(glExtensions, "320 es", isFragment);
-				return result;
+				return glExtensions;
 
 			case "400":
-				var result = buildGLSLExtensions(glExtensions, "330", isFragment);
-				return result;
+				return glExtensions;
 			case "410":
-				var result = buildGLSLExtensions(glExtensions, "400", isFragment);
-				return result;
+				return glExtensions;
 			case "420":
-				var result = buildGLSLExtensions(glExtensions, "410", isFragment);
-				return result;
+				return glExtensions;
 			case "430":
-				var result = buildGLSLExtensions(glExtensions, "420", isFragment);
-				return result;
+				return glExtensions;
 			case "440":
-				var result = buildGLSLExtensions(glExtensions, "430", isFragment);
-				return result;
+				return glExtensions;
 			case "450":
-				var result = buildGLSLExtensions(glExtensions, "440", isFragment);
-				return result;
+				return glExtensions;
 			case "460":
-				var result = buildGLSLExtensions(glExtensions, "450", isFragment);
-				return result;
+				return glExtensions;
 		}
 	}
 


### PR DESCRIPTION
An update of #2577 which removes extraneous changes and updates the target branch to `9.4.0-Dev`.

Provides the following changes:

- Store the original values for the fragment/vertex header such that they can be accessed by child classes.
- Store the original values for the fragment/vertex body such that they can be accessed by child classes.
- Store the original values for the fragment/vertex source such that they can be accessed by child classes.
- Added a configurable `glVersion` annotation (and corresponding variables) which can be used to modify the [GLSL version directive](https://en.wikipedia.org/wiki/OpenGL_Shading_Language#Versions). The default value has been set to `120`, which should resolve an issue on some platforms where the `uniform` type is unavailable.
- Added checks to `__processGLData` to ensure a variable exists before it is assigned via Reflection.
  - This resolves an issue caused by custom implementation of variables in child classes.
  - Added caching to the field check to reduce calls to `Reflect.fields`, improving performance.

These changes were performed to support fixes for FlxRuntimeShader, as part of pull requests HaxeFlixel/flixel-addons#368 and HaxeFlixel/flixel-addons#399. Making changes here prevents code duplication in FlxRuntimeShader, improving maintainability.

These changes have been tested with Friday Night Funkin', where it is used on Windows, MacOS, Linux, and HTML5 platforms.