### PR TITLE
CI: Add jobs for latest haxe version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,42 +78,6 @@ jobs:
         run: |
           haxelib run hxp test -Dtarget=neko -Duse-lime-tools --install-hxp-alias
 
-  unit-test-neko-latest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - uses: krdlab/setup-haxe@v1
-        with:
-          haxe-version: latest
-
-      - name: Set HAXEPATH
-        run: |
-          echo "HAXEPATH=$HAXE_STD_PATH/.." >> $GITHUB_ENV
-
-      - name: Install Haxe dependencies
-        run: |
-          haxelib install hxcpp --quiet
-          haxelib install format --quiet
-          haxelib install hxp --quiet
-          haxelib install lime --quiet
-          haxelib install utest --quiet
-
-      - name: Setup environment
-        run: |
-          haxelib dev openfl ${{ github.workspace }}
-
-      - name: Install command aliases
-        run: |
-          haxelib run lime setup -alias -y
-          haxelib run openfl setup -alias -y
-
-      - name: Run tests on Neko
-        run: |
-          haxelib run hxp test -Dtarget=neko -Duse-lime-tools --install-hxp-alias
-
   unit-test-hashlink:
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
   unit-test-hashlink:
     strategy:
       matrix:
-        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, 4.3.5]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1]
     # AL init fails on both windows and ubuntu
     # macos-14 is arm64, which setup-haxe doesn't support yet
     runs-on: macos-13
@@ -155,7 +155,7 @@ jobs:
         run: |
           haxelib run hxp test -Dtarget=hl -Duse-lime-tools --install-hxp-alias
 
-  unit-test-hashlink-latest:
+  unit-test-hashlink-4_3_5:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
   unit-test-hashlink:
     strategy:
       matrix:
-        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, latest]
     # AL init fails on both windows and ubuntu
     # macos-14 is arm64, which setup-haxe doesn't support yet
     runs-on: macos-13

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: krdlab/setup-haxe@v1
+      - uses: krdlab/setup-haxe@master
         with:
           haxe-version: latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,8 +189,8 @@ jobs:
           haxelib git lime https://github.com/openfl/lime
           haxelib install format
           haxelib install hxp
-          haxelib rebuild tools
-          haxelib rebuild hl
+          haxelib run lime rebuild tools
+          haxelib run lime rebuild hl
 
       - name: Install command aliases
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,12 +175,19 @@ jobs:
           haxelib install hxcpp --quiet
           haxelib install format --quiet
           haxelib install hxp --quiet
-          haxelib install lime --quiet
           haxelib install utest --quiet
 
+      - name: Print Haxe Version
+        run: haxe -version
+  
       - name: Setup environment
         run: |
           haxelib dev openfl ${{ github.workspace }}
+
+      - name: Setup Lime dev
+        run: |
+          git clone https://github.com/openfl/lime.git
+          haxelib dev lime lime
 
       - name: Install command aliases
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
           haxelib run hxp test -Dtarget=hl -Duse-lime-tools --install-hxp-alias
 
   unit-test-hashlink-latest:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
           haxelib run hxp test -Dtarget=hl -Duse-lime-tools --install-hxp-alias
 
   unit-test-hashlink-4_3_5:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
   unit-test-hashlink:
     strategy:
       matrix:
-        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, latest]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, 4.3.4]
     # AL init fails on both windows and ubuntu
     # macos-14 is arm64, which setup-haxe doesn't support yet
     runs-on: macos-13

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
 
       - uses: krdlab/setup-haxe@master
         with:
-          haxe-version: latest
+          haxe-version: 4.3.5
 
       - name: Set HAXEPATH
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,42 @@ jobs:
         run: |
           haxelib run hxp test -Dtarget=neko -Duse-lime-tools --install-hxp-alias
 
+  unit-test-neko-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: krdlab/setup-haxe@v1
+        with:
+          haxe-version: latest
+
+      - name: Set HAXEPATH
+        run: |
+          echo "HAXEPATH=$HAXE_STD_PATH/.." >> $GITHUB_ENV
+
+      - name: Install Haxe dependencies
+        run: |
+          haxelib install hxcpp --quiet
+          haxelib install format --quiet
+          haxelib install hxp --quiet
+          haxelib install lime --quiet
+          haxelib install utest --quiet
+
+      - name: Setup environment
+        run: |
+          haxelib dev openfl ${{ github.workspace }}
+
+      - name: Install command aliases
+        run: |
+          haxelib run lime setup -alias -y
+          haxelib run openfl setup -alias -y
+
+      - name: Run tests on Neko
+        run: |
+          haxelib run hxp test -Dtarget=neko -Duse-lime-tools --install-hxp-alias
+
   unit-test-hashlink:
     strategy:
       matrix:
@@ -116,6 +152,42 @@ jobs:
           haxelib run openfl setup -alias -y
 
       - name: Run tests on HashLink
+        run: |
+          haxelib run hxp test -Dtarget=hl -Duse-lime-tools --install-hxp-alias
+
+  unit-test-hashlink-latest:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: krdlab/setup-haxe@v1
+        with:
+          haxe-version: latest
+
+      - name: Set HAXEPATH
+        run: |
+          echo "HAXEPATH=$HAXE_STD_PATH/.." >> $GITHUB_ENV
+
+      - name: Install Haxe dependencies
+        run: |
+          haxelib install hxcpp --quiet
+          haxelib install format --quiet
+          haxelib install hxp --quiet
+          haxelib install lime --quiet
+          haxelib install utest --quiet
+
+      - name: Setup environment
+        run: |
+          haxelib dev openfl ${{ github.workspace }}
+
+      - name: Install command aliases
+        run: |
+          haxelib run lime setup -alias -y
+          haxelib run openfl setup -alias -y
+
+      - name: Run tests on Hashlink
         run: |
           haxelib run hxp test -Dtarget=hl -Duse-lime-tools --install-hxp-alias
 
@@ -241,7 +313,7 @@ jobs:
     needs: package-haxelib
     strategy:
       matrix:
-        haxe-version: [3.4.7, 4.0.5, 4.1.5, 4.2.5, 4.3.1]
+        haxe-version: [3.4.7, 4.0.5, 4.1.5, 4.2.5, 4.3.1, latest]
     runs-on: ubuntu-20.04
     steps:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,8 +186,11 @@ jobs:
 
       - name: Setup Lime dev
         run: |
-          git clone https://github.com/openfl/lime.git
-          haxelib dev lime lime
+          haxelib git lime https://github.com/openfl/lime
+          haxelib install format
+          haxelib install hxp
+          haxelib rebuild tools
+          haxelib rebuild hl
 
       - name: Install command aliases
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,12 @@ jobs:
 
       - name: Print Haxe Version
         run: haxe -version
-  
+
+      - name: Install dependencies with Homebrew
+        run: |
+          brew update
+          brew install mbedtls
+        
       - name: Setup environment
         run: |
           haxelib dev openfl ${{ github.workspace }}
@@ -187,8 +192,6 @@ jobs:
       - name: Setup Lime dev
         run: |
           haxelib git lime https://github.com/openfl/lime
-          haxelib install format
-          haxelib install hxp
           haxelib run lime rebuild tools
           haxelib run lime rebuild hl
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
   unit-test-neko:
     strategy:
       matrix:
-        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, 4.3.5]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
   unit-test-hashlink:
     strategy:
       matrix:
-        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, 4.3.4]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, 4.3.5]
     # AL init fails on both windows and ubuntu
     # macos-14 is arm64, which setup-haxe doesn't support yet
     runs-on: macos-13
@@ -195,7 +195,7 @@ jobs:
     strategy:
       matrix:
         # until Lime 8.0.3 is release, we can't test Haxe 3.4.7 with AIR
-        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1]
+        haxe-version: [4.0.5, 4.1.5, 4.2.5, 4.3.1, 4.3.5]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Changes CI to account for the latest haxe version for now, as we prepare to get 9.4 released. Also preludes a forthcoming special branch with workflow changes to test for haxe nightlies so we can start preparing for haxe 5.