### PR TITLE
Fix the issue of array index errors

### DIFF
--- a/src/openfl/media/SoundMixer.hx
+++ b/src/openfl/media/SoundMixer.hx
@@ -173,8 +173,8 @@ package openfl.media;
 		var i = __soundChannels.length;
 		while (i > 0)
 		{
-			__soundChannels[i].stop();
 			i--;
+			__soundChannels[i].stop();
 		}
 	}
 
@@ -200,12 +200,12 @@ package openfl.media;
 		var i = __soundChannels.length;
 		while (i > 0)
 		{
+			i--;
 			var channel = __soundChannels[i];
 			if (channel.__audioSource.buffer == buffer)
 			{
 				channel.stop();
 			}
-			i--;
 		}
 	}
 	#end


### PR DESCRIPTION
The subscript should be decremented first, Otherwise, it will cause empty references.

```
Null Object Reference
Called from openfl.media.SoundMixer.__unregisterSoundChannelByBuffer (openfl/media/SoundMixer.hx line 204)
Called from openfl.media.Sound.close (openfl/media/Sound.hx line 341)
```