### PR TITLE
Make `curveTo()` and `cubicCurveTo()` update drawing position.

### DIFF
--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -533,10 +533,16 @@ class CairoGraphics
 						c.anchorY
 						- offsetY);
 
+					positionX = c.anchorX;
+					positionY = c.anchorY;
+
 				case CURVE_TO:
 					var c = data.readCurveTo();
 					hasPath = true;
 					quadraticCurveTo(c.controlX - offsetX, c.controlY - offsetY, c.anchorX - offsetX, c.anchorY - offsetY);
+
+					positionX = c.anchorX;
+					positionY = c.anchorY;
 
 				case DRAW_CIRCLE:
 					var c = data.readDrawCircle();

--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -686,10 +686,16 @@ class CanvasGraphics
 						c.anchorY
 						- offsetY);
 
+					positionX = c.anchorX;
+					positionY = c.anchorY;
+
 				case CURVE_TO:
 					var c = data.readCurveTo();
 					hasPath = true;
 					context.quadraticCurveTo(c.controlX - offsetX, c.controlY - offsetY, c.anchorX - offsetX, c.anchorY - offsetY);
+
+					positionX = c.anchorX;
+					positionY = c.anchorY;
 
 				case DRAW_CIRCLE:
 					var c = data.readDrawCircle();


### PR DESCRIPTION
Fixes #2740.

```haxe
graphics.lineStyle(1, 0x000000);

graphics.curveTo(100, 0, 100, 100);
graphics.lineStyle(1, 0x000000);
graphics.lineTo(200, 100);

graphics.cubicCurveTo(250, 100, 300, 150, 300, 200);
graphics.lineStyle(1, 0x000000);
graphics.lineTo(400, 200);
```

This code is supposed to draw alternating curves and horizontal lines, like these:

![Expected](https://github.com/user-attachments/assets/f02c34c1-c779-4af7-9e2f-703811b4a04b)

But without this fix, `lineStyle()` reset the drawing position to where it was before the previous curve. This means the first `lineTo()` starts from (0, 0) and the second starts from the end of the first:

![Actual](https://github.com/user-attachments/assets/2b496abb-74aa-4694-80ec-3ecd23830839)