### PR TITLE
Add System.totalMemoryNumber

### DIFF
--- a/src/openfl/system/System.hx
+++ b/src/openfl/system/System.hx
@@ -80,7 +80,20 @@ import hl.Gc;
 	**/
 	public static var totalMemory(get, never):Int;
 
-	// @:noCompletion @:dox(hide) @:require(flash10_1) public static var totalMemoryNumber (default, null):Float;
+	/**
+		The amount of memory (in bytes) currently in use that has been directly
+		allocated by Flash Player or AIR.
+
+		This property is expressed as a Float, which allows higher values than the
+		`System.totalMemory` property, which is of type Int.
+
+		This property does not return _all_ memory used by an OpenFL
+		application or by the application (such as a browser) containing Flash
+		Player content. The browser or operating system may consume other memory.
+		The `System.privateMemory` property reflects _all_ memory
+		used by an application.
+	**/
+	public static var totalMemoryNumber(get, never):Float;
 
 	/**
 		A Boolean value that determines which code page to use to interpret
@@ -274,6 +287,17 @@ import hl.Gc;
 		return Std.int(Gc.stats().currentMemory);
 		#else
 		return 0;
+		#end
+	}
+
+	@:noCompletion private static function get_totalMemoryNumber():Float
+	{
+		#if cpp
+		return Gc.memInfo64(cpp.vm.Gc.MEM_INFO_USAGE);
+		#elseif hl
+		return Gc.stats().currentMemory;
+		#else
+		return System.totalMemory;
 		#end
 	}
 


### PR DESCRIPTION
This PR adds the `openfl.system.System.totalMemoryNumber` field to allow getting a 64bit memory usage value. If the target does not support getting a higher precision memory usage value, it will simply return `totalMemory`