### PR TITLE
Remove textfield cache immediately.

### DIFF
--- a/src/openfl/display/_internal/CairoTextField.hx
+++ b/src/openfl/display/_internal/CairoTextField.hx
@@ -158,8 +158,8 @@ class CairoTextField
 			// Clear old cache immediately.
 			if(graphics.__bitmap != null)
 			{
-				if(graphics.__bitmap._texture != null)
-					graphics.__bitmap._texture.dispose();
+				if(graphics.__bitmap.__texture != null)
+					graphics.__bitmap.__texture.dispose();
 				
 				graphics.__bitmap.dispose();
 			}

--- a/src/openfl/display/_internal/CairoTextField.hx
+++ b/src/openfl/display/_internal/CairoTextField.hx
@@ -27,6 +27,7 @@ import lime.graphics.cairo.CairoHintStyle;
 @:access(openfl.display.Graphics)
 @:access(openfl.geom.Matrix)
 @:access(openfl.text.TextField)
+@:access(openfl.display.BitmapData)
 @SuppressWarnings("checkstyle:FieldDocComment")
 class CairoTextField
 {
@@ -153,6 +154,15 @@ class CairoTextField
 			graphics.__cairo = new Cairo(surface);
 			graphics.__visible = true;
 			graphics.__managed = true;
+			
+			// Clear old cache immediately.
+			if(graphics.__bitmap != null)
+			{
+				if(graphics.__bitmap._texture != null)
+					graphics.__bitmap._texture.dispose();
+				
+				graphics.__bitmap.dispose();
+			}
 
 			graphics.__bitmap = bitmap;
 			graphics.__bitmapScale = pixelRatio;

--- a/src/openfl/display/_internal/CanvasTextField.hx
+++ b/src/openfl/display/_internal/CanvasTextField.hx
@@ -20,6 +20,7 @@ import js.Browser;
 @:access(openfl.geom.Matrix)
 @:access(openfl.text.TextField)
 @:access(openfl.text.TextFormat)
+@:access(openfl.display.BitmapData)
 @SuppressWarnings("checkstyle:FieldDocComment")
 class CanvasTextField
 {
@@ -373,6 +374,15 @@ class CanvasTextField
 						context.stroke();
 						context.closePath();
 					}
+				}
+
+				// Clear old cache immediately.
+				if(graphics.__bitmap != null)
+				{
+					if(graphics.__bitmap._texture != null)
+						graphics.__bitmap._texture.dispose();
+					
+					graphics.__bitmap.dispose();
 				}
 
 				graphics.__bitmap = BitmapData.fromCanvas(textField.__graphics.__canvas);

--- a/src/openfl/display/_internal/CanvasTextField.hx
+++ b/src/openfl/display/_internal/CanvasTextField.hx
@@ -379,8 +379,8 @@ class CanvasTextField
 				// Clear old cache immediately.
 				if(graphics.__bitmap != null)
 				{
-					if(graphics.__bitmap._texture != null)
-						graphics.__bitmap._texture.dispose();
+					if(graphics.__bitmap.__texture != null)
+						graphics.__bitmap.__texture.dispose();
 					
 					graphics.__bitmap.dispose();
 				}


### PR DESCRIPTION
This pull request specifically affects the html5 target.

Since the html5 target is constantly creating textures, the memory starts to swell and forces the application to major gc.

Reproduce Steps
- Run Code Below
```haxe
var textField:TextField = new TextField();
addChild(textField);

openfl.Lib.setInterval(() -> {
	var str:String = "";
	for(i in 0...10000)
	{
		str += Std.random(9);

		if(i % 100 == 0)
		{
			str += "\n";
		}
	}
	textField.text = str;
	textField.width = textField.textWidth;
	textField.height = textField.textHeight;
}, 0);
```
- Open Task Manager in a Chromium-based browser (SHIFT + ESC)
- Observe the memory footprint used by the GPU Process.

![Animation](https://github.com/user-attachments/assets/7764e894-1578-4eb0-b71d-3b590074a70e)
