### PR TITLE
Fix access violation on HL when using hardware only bitmaps and shader fills

### DIFF
--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -781,10 +781,21 @@ class CairoGraphics
 
 					if (shaderBuffer.inputCount > 0)
 					{
-						fillPattern = createImagePattern(shaderBuffer.inputs[0], null, shaderBuffer.inputWrap[0] != CLAMP,
-							shaderBuffer.inputFilter[0] != NEAREST);
+						var bitmap = shaderBuffer.inputs[0];
+						if (bitmap.readable)
+						{
+							fillPattern = createImagePattern(bitmap, null, shaderBuffer.inputWrap[0] != CLAMP,
+								shaderBuffer.inputFilter[0] != NEAREST);
+						}
+						else
+						{
+							// if it's hardware-only BitmapData, fall back to
+							// drawing solid black because we have no software
+							// pixels to work with
+							fillPattern = CairoPattern.createRGB(0, 0, 0);
+						}
 
-						bitmapFill = shaderBuffer.inputs[0];
+						bitmapFill = bitmap;
 						bitmapRepeat = false;
 
 						hasFill = true;


### PR DESCRIPTION
When using hardware only bitmaps and shader fills, previously it tried to pass it to `createImagePattern`, which would end up passing `null` to the native binding code and cause an access violation

Repro:
```hx
package;

class Main extends openfl.display.Sprite 
{
	public function new() 
	{
		super();

		var shader = new openfl.display.GraphicsShader();
		
		var bmd = new openfl.display.BitmapData(100, 100, true, 0xFF3F64CC);

		bmd.disposeImage();

		shader.bitmap.input = bmd;

		graphics.beginShaderFill(shader);
		graphics.drawRect(0, 0, stage.stageWidth, stage.stageHeight);
		graphics.endFill();
	}
}

```