### PR TITLE
Allow openfl to be used in cppia scripts

### DIFF
--- a/src/openfl/text/_internal/TextLayout.hx
+++ b/src/openfl/text/_internal/TextLayout.hx
@@ -160,7 +160,7 @@ class TextLayout
 			__hbBuffer.addUTF8(text, 0, -1);
 			#elseif (hl)
 			__hbBuffer.addUTF16(text, text.length, 0, -1);
-			#else
+			#elseif (!cppia)
 			__hbBuffer.addUTF16(untyped __cpp__('(uintptr_t){0}', text.wc_str()), text.length, 0, -1);
 			#end
 


### PR DESCRIPTION
There is a small usage of C++ code in openfl's text layout that made the usage of openfl in a cppia script impossible. This pull request wraps said code under `#if !cppia`, which makes openfl usable in cppia scripts. Though I'm not entirely sure if the conditional is purely only false when the compiler compiles the haxe code to cppia bytecode, so I will double check that.