### PR TITLE
CanvasGraphics: Fix crash when using hardware only bitmaps and shader fills

### DIFF
--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -939,7 +939,17 @@ class CanvasGraphics
 					if (shaderBuffer.inputCount > 0)
 					{
 						bitmapFill = shaderBuffer.inputs[0];
-						context.fillStyle = createBitmapFill(bitmapFill, shaderBuffer.inputWrap[0] != CLAMP, shaderBuffer.inputFilter[0] != NEAREST);
+						if (bitmapFill.readable)
+						{
+							context.fillStyle = createBitmapFill(bitmapFill, shaderBuffer.inputWrap[0] != CLAMP, shaderBuffer.inputFilter[0] != NEAREST);
+						}
+						else
+						{
+							// if it's hardware-only BitmapData, fall back to
+							// drawing solid black because we have no software
+							// pixels to work with
+							context.fillStyle = "#" + StringTools.hex(0, 6);
+						}
 						hasFill = true;
 
 						pendingMatrix = null;


### PR DESCRIPTION
This is the same thing as #2756 but for CanvasGraphics, wasn't aware the issue was there as well