### PR TITLE
Instead of constantly allocating the buffer, just update it if the byteLength is the same.

### DIFF
--- a/src/openfl/display3D/VertexBuffer3D.hx
+++ b/src/openfl/display3D/VertexBuffer3D.hx
@@ -60,6 +60,7 @@ class VertexBuffer3D
 	@:noCompletion private var __tempFloat32Array:Float32Array;
 	@:noCompletion private var __usage:Int;
 	@:noCompletion private var __vertexSize:Int;
+	@:noCompletion private var __byteLength:Int;
 
 	@:noCompletion private function new(context3D:Context3D, numVertices:Int, dataPerVertex:Int, bufferUsage:String)
 	{
@@ -82,6 +83,7 @@ class VertexBuffer3D
 	{
 		var gl = __context.gl;
 		gl.deleteBuffer(__id);
+		__byteLength = 0;
 	}
 
 	/**
@@ -129,7 +131,14 @@ class VertexBuffer3D
 		var gl = __context.gl;
 
 		__context.__bindGLArrayBuffer(__id);
-		gl.bufferData(gl.ARRAY_BUFFER, data, __usage);
+		
+		if(__byteLength != data.byteLength)
+		{
+			gl.bufferData(gl.ARRAY_BUFFER, data, __usage);
+			__byteLength = data.byteLength;
+		}else{
+			gl.bufferSubData(gl.ARRAY_BUFFER, 0, data);
+		}
 	}
 
 	/**


### PR DESCRIPTION
If the buffer is allocated and the size of the new buffer to be allocated is the same, update the buffer in memory instead of allocating a new one.