### PR TITLE
Add pretty printing to shader errors and info

### DIFF
--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -349,12 +349,8 @@ class Shader
 	@:noCompletion private var __isEmptyLine = ~/^\W*$/;
 	@:noCompletion private function __logGLShaderInfo(isError:Bool, type:Int, infoLog:String, source:String):Void
 	{
-		var message = isError ? "Error" : "Info";
-		var typeName = (type == __context.gl.VERTEX_SHADER) ? "vertex" : "fragment";
-		message += ' compiling $typeName shader';
-		
+		var message = "";
 		var lines = source.split("\n");
-		var prettyLog = "";
 		var failingLine:String = null;
 		for (log in infoLog.split("\n"))
 		{
@@ -376,24 +372,24 @@ class Shader
 			if (lineNumber >= lines.length)
 			{
 				// EOF errors will not have a valid line
-				prettyLog += '\n\n $lineNumber | $info';
+				message += '\n\n $lineNumber | $info';
 			}
 			else
 			{
 				// Add the relevant line to each log
 				var line = lines[lineNumber - 1];
 				var indent = StringTools.lpad("|", " ", lineNumberStr.length + 3);
-				prettyLog += '\n\n $lineNumber | $line\n$indent ${info}';
+				message += '\n\n $lineNumber | $line\n$indent ${info}';
 			}
 		}
 
+		// If we couldn't parse the logs, output the old, verbose format
 		if (failingLine != null)
-			message += '\nFailed to simplify log:"$failingLine"\n$infoLog\n$source';
-		else
-			message += prettyLog;
-
-		if (isError) Log.error(message);
-		else Log.debug(message);
+			message = '\nFailed to simplify log:"$failingLine"\n$infoLog\n$source';
+		
+		var typeName = (type == __context.gl.VERTEX_SHADER) ? "vertex" : "fragment";
+		if (isError) Log.error('Error compiling $typeName shader $message');
+		else Log.debug('Info compiling $typeName shader $message');
 	}
 
 	@:noCompletion private function __createGLProgram(vertexSource:String, fragmentSource:String):GLProgram

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -413,13 +413,13 @@ class Shader
 		var linesBack = 0;
 		while (i-- > 0)
 		{
-			if (StringTools.contains(lines[i], "openfl_endregion"))
+			if (lines[i].indexOf("openfl_endregion") != -1)
 				nests++;
 			
 			if (nests == 0)
 				linesBack++;
 			
-			if (StringTools.contains(lines[i], "openfl_region"))
+			if (lines[i].indexOf("openfl_region") != -1)
 			{
 				if (nests == 0)
 					break;

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -336,7 +336,17 @@ class Shader
 		return shader;
 	}
 
-	private var __lineExtractor = ~/^\w+?: \d+:(\d+):(.+$)/;
+	/**
+	 * Retrieves the line number from a shader log line.
+	 */
+	@:noCompletion private var __lineExtractor = ~/^\w+?: \d+:(\d+):(.+$)/;
+	/**
+	 * Searches for strings that have only whitespace.
+	 * 
+	 * **Note:** Searching for all whitespace via `~/^\s*$/` caused false-negatives,
+	 * notably: `String.fromCharCode(0)` is `false` but `\W` is `true`.
+	 */
+	@:noCompletion private var __isEmptyLine = ~/^\W*$/;
 	@:noCompletion private function __logGLShaderInfo(isError:Bool, type:Int, infoLog:String, source:String):Void
 	{
 		var message = isError ? "Error" : "Info";
@@ -344,39 +354,43 @@ class Shader
 		message += ' compiling $typeName shader';
 		
 		var lines = source.split("\n");
-		var success = true;
 		var prettyLog = "";
+		var failingLine:String = null;
 		for (log in infoLog.split("\n"))
 		{
-			if (StringTools.trim(log) == "")
+			// ignore empty lines
+			if (__isEmptyLine.match(log))
 				continue;
 
 			// look for a line number
 			if (!__lineExtractor.match(log))
 			{
-				// Could not find line numbers
-				success = false;
+				// Could not find expected info, abort pretty formatting
+				failingLine = log;
 				break;
 			}
 
-			var lineNumber = Std.parseInt(__lineExtractor.matched(1));
-			var info = StringTools.trim(__lineExtractor.matched(2));
-			// EOF errors will not have a valid line
-			if (lineNumber > lines.length)
+			var lineNumberStr = __lineExtractor.matched(1);
+			var lineNumber = Std.parseInt(lineNumberStr);
+			var info = __lineExtractor.matched(2);
+			if (lineNumber >= lines.length)
 			{
-				prettyLog += '\n\nLine $lineNumber: $info';
-				continue;
+				// EOF errors will not have a valid line
+				prettyLog += '\n\n $lineNumber | $info';
 			}
-
-			// Add the relevant line to each log
-			var line = StringTools.trim(lines[lineNumber - 1]);
-			prettyLog += '\n\nLine $lineNumber: $info\n\t$line';
+			else
+			{
+				// Add the relevant line to each log
+				var line = lines[lineNumber - 1];
+				var indent = StringTools.lpad("|", " ", lineNumberStr.length + 3);
+				prettyLog += '\n\n $lineNumber | $line\n$indent ${info}';
+			}
 		}
 
-		if (success)
-			message += prettyLog;
+		if (failingLine != null)
+			message += '\nFailed to simplify log:"$failingLine"\n$infoLog\n$source';
 		else
-			message += "\nFailed to simplify log info, showing full source\n" + infoLog + "\n" + source;
+			message += prettyLog;
 
 		if (isError) Log.error(message);
 		else Log.debug(message);

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -326,19 +326,61 @@ class Shader
 		gl.compileShader(shader);
 		var shaderInfoLog = gl.getShaderInfoLog(shader);
 		var hasInfoLog = shaderInfoLog != null && StringTools.trim(shaderInfoLog) != "";
-		var compileStatus = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+		var isError = gl.getShaderParameter(shader, gl.COMPILE_STATUS) == 0;
 
-		if (hasInfoLog || compileStatus == 0)
+		if (hasInfoLog || isError)
 		{
-			var message = (compileStatus == 0) ? "Error" : "Info";
-			message += (type == gl.VERTEX_SHADER) ? " compiling vertex shader" : " compiling fragment shader";
-			message += "\n" + shaderInfoLog;
-			message += "\n" + source;
-			if (compileStatus == 0) Log.error(message);
-			else if (hasInfoLog) Log.debug(message);
+			__logGLShaderInfo(isError, type, shaderInfoLog, source);
 		}
 
 		return shader;
+	}
+
+	private var __lineExtractor = ~/^\w+?: \d+:(\d+):(.+$)/;
+	@:noCompletion private function __logGLShaderInfo(isError:Bool, type:Int, infoLog:String, source:String):Void
+	{
+		var message = isError ? "Error" : "Info";
+		var typeName = (type == __context.gl.VERTEX_SHADER) ? "vertex" : "fragment";
+		message += ' compiling $typeName shader';
+		
+		var lines = source.split("\n");
+		var success = true;
+		var prettyLog = "";
+		for (log in infoLog.split("\n"))
+		{
+			if (StringTools.trim(log) == "")
+				continue;
+
+			// look for a line number
+			if (!__lineExtractor.match(log))
+			{
+				// Could not find line numbers
+				success = false;
+				break;
+			}
+
+			var lineNumber = Std.parseInt(__lineExtractor.matched(1));
+			// Note lines is zero-based while lineNumber is 1-based
+			if (lines.length <= lineNumber - 1)
+			{
+				// Invalid line number
+				success = false;
+				break;
+			}
+
+			// Add the relevant line to each log
+			var info = StringTools.trim(__lineExtractor.matched(2));
+			var line = StringTools.trim(lines[lineNumber - 1]);
+			prettyLog += '\n\nLine $lineNumber: $info\n\t$line';
+		}
+
+		if (success)
+			message += prettyLog;
+		else
+			message += "\nFailed to simplify log info, showing full source\n" + infoLog + "\n" + source;
+
+		if (isError) Log.error(message);
+		else Log.debug(message);
 	}
 
 	@:noCompletion private function __createGLProgram(vertexSource:String, fragmentSource:String):GLProgram

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -339,7 +339,13 @@ class Shader
 	/**
 	 * Retrieves the line number from a shader log line.
 	 */
+	#if windows
+	// 0(5) : whatever
+	@:noCompletion private var __lineExtractor = ~/^\d+\((\d+)\) : (.+$)/;
+	#else // (html5 || macos || linux)
+	// ERROR: 0:5:whatever
 	@:noCompletion private var __lineExtractor = ~/^\w+?: \d+:(\d+):(.+$)/;
+	#end
 	/**
 	 * Searches for strings that have only whitespace.
 	 * 

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -165,11 +165,6 @@ class Shader
 	public var glVertexSource(get, set):String;
 
 	/**
-		Used internally to show files that caused shader errors.
-	 */
-	private var __shaderLocation:String = null;
-
-	/**
 		The precision of math operations performed by the shader.
 		The set of possible values for the `precisionHint` property is defined
 		by the constants in the ShaderPrecision class.
@@ -390,7 +385,12 @@ class Shader
 				// Add the relevant line to each log
 				var line = lines[lineNumber - 1];
 				var indent = StringTools.lpad("|", " ", lineNumberStr.length + 3);
+				#if haxe4 
+				var pos = getSourcePos(lines, lineNumber - 1);
+				message += '\n\n${pos.file}:${pos.lineNumber}\n ${pos.lineNumber} | $line\n$indent ${info}';
+				#else
 				message += '\n\n $lineNumber | $line\n$indent ${info}';
+				#end
 			}
 		}
 
@@ -401,11 +401,37 @@ class Shader
 		var typeName = (type == __context.gl.VERTEX_SHADER) ? "vertex" : "fragment";
 		if (isError)
 		{
-			var logMessage = 'Error compiling $typeName shader';
-			if (__shaderLocation != null) logMessage += ': $__shaderLocation';
-			Log.error('$logMessage $message');
+			Log.error('Error compiling $typeName shader $message');
 		}
 		else Log.debug('Info compiling $typeName shader $message');
+	}
+	
+	function getSourcePos(lines:Array<String>, lineNumber:Int):{file:String, lineNumber:Int}
+	{
+		var nests = 0;
+		var i = lineNumber;
+		var linesBack = 0;
+		while (i-- > 0)
+		{
+			if (StringTools.contains(lines[i], "openfl_endregion"))
+				nests++;
+			
+			if (nests == 0)
+				linesBack++;
+			
+			if (StringTools.contains(lines[i], "openfl_region"))
+			{
+				if (nests == 0)
+					break;
+				nests--;
+			}
+		}
+		
+		var sourceData = lines[i].split("// { openfl_region       ")[1].split(":");
+		return {
+			file: sourceData[0],
+			lineNumber: Std.parseInt(sourceData[1]) + linesBack - 1
+		};
 	}
 
 	@:noCompletion private function __createGLProgram(vertexSource:String, fragmentSource:String):GLProgram

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -399,7 +399,12 @@ class Shader
 			message = '\nFailed to simplify log:"$failingLine"\n$infoLog\n$source';
 		
 		var typeName = (type == __context.gl.VERTEX_SHADER) ? "vertex" : "fragment";
-		if (isError) Log.error('Error compiling $typeName shader: $__shaderLocation $message');
+		if (isError)
+		{
+			var logMessage = 'Error compiling $typeName shader';
+			if (__shaderLocation != null) logMessage += ': $__shaderLocation';
+			Log.error('$logMessage $message');
+		}
 		else Log.debug('Info compiling $typeName shader $message');
 	}
 

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -360,16 +360,15 @@ class Shader
 			}
 
 			var lineNumber = Std.parseInt(__lineExtractor.matched(1));
-			// Note lines is zero-based while lineNumber is 1-based
-			if (lines.length <= lineNumber - 1)
+			var info = StringTools.trim(__lineExtractor.matched(2));
+			// EOF errors will not have a valid line
+			if (lineNumber > lines.length)
 			{
-				// Invalid line number
-				success = false;
-				break;
+				prettyLog += '\n\nLine $lineNumber: $info';
+				continue;
 			}
 
 			// Add the relevant line to each log
-			var info = StringTools.trim(__lineExtractor.matched(2));
 			var line = StringTools.trim(lines[lineNumber - 1]);
 			prettyLog += '\n\nLine $lineNumber: $info\n\t$line';
 		}

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -165,6 +165,11 @@ class Shader
 	public var glVertexSource(get, set):String;
 
 	/**
+		Used internally to show files that caused shader errors.
+	 */
+	private var __shaderLocation:String = null;
+
+	/**
 		The precision of math operations performed by the shader.
 		The set of possible values for the `precisionHint` property is defined
 		by the constants in the ShaderPrecision class.
@@ -394,7 +399,7 @@ class Shader
 			message = '\nFailed to simplify log:"$failingLine"\n$infoLog\n$source';
 		
 		var typeName = (type == __context.gl.VERTEX_SHADER) ? "vertex" : "fragment";
-		if (isError) Log.error('Error compiling $typeName shader $message');
+		if (isError) Log.error('Error compiling $typeName shader: $__shaderLocation $message');
 		else Log.debug('Info compiling $typeName shader $message');
 	}
 

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -1,7 +1,6 @@
 package openfl.utils._internal;
 
 #if macro
-import haxe.display.Position;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -185,6 +185,13 @@ class ShaderMacro
 								__glFragmentSource = $v{glFragmentSource};
 							});
 						}
+						
+						final loc = pos.toLocation();
+						final locString = '${loc.file}:${loc.range.start.line}';
+						block.push(macro
+						{
+							__shaderLocation = $v{locString};
+						});
 
 						block.push(Context.parse("__isGenerated = true", pos));
 						block.push(Context.parse("__initGL ()", pos));

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -186,8 +186,8 @@ class ShaderMacro
 							});
 						}
 						
-						final loc = pos.toLocation();
-						final locString = '${loc.file}:${loc.range.start.line}';
+						var loc = pos.toLocation();
+						var locString = '${loc.file}:${loc.range.start.line}';
 						block.push(macro
 						{
 							__shaderLocation = $v{locString};

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -321,7 +321,7 @@ abstract GlMetas(Array<Map<String, MetadataEntry>>)
 	
 	inline function getFirst(name:String):Null<String>
 	{
-		var meta = Lambda.find(this, (item)->item.exists(name));
+		var meta = Lambda.find(this, function (item) { return item.exists(name); });
 		return meta == null ? null : metaToString(meta[name]);
 	}
 

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -1,6 +1,7 @@
 package openfl.utils._internal;
 
 #if macro
+import haxe.display.Position;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
@@ -20,41 +21,12 @@ class ShaderMacro
 	{
 		var fields = Context.getBuildFields();
 
-		var glFragmentHeader = "";
-		var glFragmentBody = "";
-		var glVertexHeader = "";
-		var glVertexBody = "";
-
-		var glFragmentSource:String = null;
-		var glVertexSource:String = null;
+		var glMetas = new GlMetas();
 
 		for (field in fields)
 		{
-			for (meta in field.meta)
-			{
-				switch (meta.name)
-				{
-					case "glFragmentSource", ":glFragmentSource":
-						glFragmentSource = meta.params[0].getValue();
-
-					case "glVertexSource", ":glVertexSource":
-						glVertexSource = meta.params[0].getValue();
-
-					case "glFragmentHeader", ":glFragmentHeader":
-						glFragmentHeader = meta.params[0].getValue();
-
-					case "glFragmentBody", ":glFragmentBody":
-						glFragmentBody = meta.params[0].getValue();
-
-					case "glVertexHeader", ":glVertexHeader":
-						glVertexHeader = meta.params[0].getValue();
-
-					case "glVertexBody", ":glVertexBody":
-						glVertexBody = meta.params[0].getValue();
-
-					default:
-				}
-			}
+			if (field.name == "new" && field.meta != null)
+				glMetas.add(field.meta);
 		}
 
 		var pos = Context.currentPos();
@@ -69,50 +41,17 @@ class ShaderMacro
 
 			for (field in parentFields)
 			{
-				for (meta in field.meta.get())
-				{
-					switch (meta.name)
-					{
-						case "glFragmentSource", ":glFragmentSource":
-							if (glFragmentSource == null) glFragmentSource = meta.params[0].getValue();
-
-						case "glVertexSource", ":glVertexSource":
-							if (glVertexSource == null) glVertexSource = meta.params[0].getValue();
-
-						case "glFragmentHeader", ":glFragmentHeader":
-							glFragmentHeader = meta.params[0].getValue() + "\n" + glFragmentHeader;
-
-						case "glFragmentBody", ":glFragmentBody":
-							glFragmentBody = meta.params[0].getValue() + "\n" + glFragmentBody;
-
-						case "glVertexHeader", ":glVertexHeader":
-							glVertexHeader = meta.params[0].getValue() + "\n" + glVertexHeader;
-
-						case "glVertexBody", ":glVertexBody":
-							glVertexBody = meta.params[0].getValue() + "\n" + glVertexBody;
-
-						default:
-					}
-				}
+				if (field.name == "new")
+					glMetas.add(field.meta.get());
 			}
 
 			parent = parent.superClass != null ? parent.superClass.t.get() : null;
 		}
 
+		var glFragmentSource = glMetas.constructFragmentSource();
+		var glVertexSource = glMetas.constructVertexSource();
 		if (glVertexSource != null || glFragmentSource != null)
 		{
-			if (glFragmentSource != null && glFragmentHeader != null && glFragmentBody != null)
-			{
-				glFragmentSource = StringTools.replace(glFragmentSource, "#pragma header", glFragmentHeader);
-				glFragmentSource = StringTools.replace(glFragmentSource, "#pragma body", glFragmentBody);
-			}
-
-			if (glVertexSource != null && glVertexHeader != null && glVertexBody != null)
-			{
-				glVertexSource = StringTools.replace(glVertexSource, "#pragma header", glVertexHeader);
-				glVertexSource = StringTools.replace(glVertexSource, "#pragma body", glVertexBody);
-			}
-
 			var shaderDataFields:Array<Field> = [];
 			var uniqueFields:Array<Field> = [];
 
@@ -185,15 +124,6 @@ class ShaderMacro
 								__glFragmentSource = $v{glFragmentSource};
 							});
 						}
-						
-						#if haxe4
-						var loc = pos.toLocation();
-						var locString = '${loc.file}:${loc.range.start.line}';
-						block.push(macro
-						{
-							__shaderLocation = $v{locString};
-						});
-						#end
 
 						block.push(Context.parse("__isGenerated = true", pos));
 						block.push(Context.parse("__initGL ()", pos));
@@ -333,6 +263,90 @@ class ShaderMacro
 			position = regex.matchedPos();
 			lastMatch = position.pos + position.len;
 		}
+	}
+}
+
+/**
+	Stores metadata and uses them to constructa  glsl shader, with important logging info
+ */
+abstract GlMetas(Array<Map<String, MetadataEntry>>)
+{
+	inline static var GL_FRAGMENT_SOURCE = "glFragmentSource";
+	inline static var GL_FRAGMENT_HEADER = "glFragmentHeader";
+	inline static var GL_FRAGMENT_BODY = "glFragmentBody";
+	inline static var GL_VERTEX_SOURCE = "glVertexSource";
+	inline static var GL_VERTEX_HEADER = "glVertexHeader";
+	inline static var GL_VERTEX_BODY = "glVertexBody";
+	
+	static var names = [GL_FRAGMENT_SOURCE, GL_FRAGMENT_HEADER, GL_FRAGMENT_BODY, GL_VERTEX_SOURCE, GL_VERTEX_HEADER, GL_VERTEX_BODY];
+
+	inline public function new ()
+	{
+		this = [];
+	}
+	
+	public function add(metas:Metadata)
+	{
+		var result = new Map<String, MetadataEntry>();
+
+		for (meta in metas)
+		{
+			var metaName = meta.name.split(":").join("");
+			if (names.contains(metaName))
+				result[metaName] = meta;
+		}
+		
+		this.push(result);
+	}
+	
+	public function constructFragmentSource():Null<String>
+	{
+		return construct(getFirst(GL_FRAGMENT_SOURCE), concatAll(GL_FRAGMENT_HEADER), concatAll(GL_FRAGMENT_BODY));
+	}
+	
+	public function constructVertexSource():Null<String>
+	{
+		return construct(getFirst(GL_VERTEX_SOURCE), concatAll(GL_VERTEX_HEADER), concatAll(GL_VERTEX_BODY));
+	}
+	
+	function construct(source, header, body):Null<String>
+	{
+		if (source != null && header != null && body != null)
+		{
+			source = StringTools.replace(source, "#pragma header", header);
+			source = StringTools.replace(source, "#pragma body", body);
+		}
+		return source;
+	}
+	
+	inline function getFirst(name:String):Null<String>
+	{
+		var meta = Lambda.find(this, (item)->item.exists(name));
+		return meta == null ? null : metaToString(meta[name]);
+	}
+
+	inline function concatAll(name:String):Null<String>
+	{
+		return Lambda.fold(this, function (item, result)
+		{
+			if (!item.exists(name))
+				return result;
+			
+			return '${metaToString(item[name])}\n$result';
+		}, "");
+	}
+	
+	inline function metaToString(meta:MetadataEntry):String
+	{
+		#if haxe4
+		var loc = meta.params[0].pos.toLocation();
+		var name = meta.name.split(":").join("");
+		return '// { openfl_region       $name - ${loc.file}:${loc.range.start.line}\n'
+			+  '${meta.params[0].getValue()}\n'
+			+  '// } openfl_endregion    $name - ${loc.file}:${loc.range.end.line}';
+		#else
+		return meta.params[0].getValue();
+		#end
 	}
 }
 #end

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -186,12 +186,14 @@ class ShaderMacro
 							});
 						}
 						
+						#if haxe4
 						var loc = pos.toLocation();
 						var locString = '${loc.file}:${loc.range.start.line}';
 						block.push(macro
 						{
 							__shaderLocation = $v{locString};
 						});
+						#end
 
 						block.push(Context.parse("__isGenerated = true", pos));
 						block.push(Context.parse("__initGL ()", pos));

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -291,7 +291,7 @@ abstract GlMetas(Array<Map<String, MetadataEntry>>)
 		for (meta in metas)
 		{
 			var metaName = meta.name.split(":").join("");
-			if (names.contains(metaName))
+			if (names.indexOf(metaName) != -1)
 				result[metaName] = meta;
 		}
 		


### PR DESCRIPTION
Fixes #2763

Example shader that causes errors:
```hx
package vfx;

class TestShader extends flixel.system.FlxAssets.FlxShader
{
    @:glFragmentSource('
#pragma header

void main()
{
    vec4 color = flixel_texture2D(bitmap, openfl_TextureCoordv);
    
    // 0 should be 0.0
    if (color.a > 0)
    {
        // brg should be vec4
        color = color.brg;
    }
    // color_ should be color
    gl_FragColor = color_;
}
    ')
    public function new()
    {
        super();
    }
}
```

The error message:
```
Uncaught exception: [openfl.display.Shader] ERROR: Error compiling fragment shader: source/vfx/TestShader.hx:3

Line 52: '>' does not operate on 'float' and 'int'
        if (color.a > 0)

Line 55: Incompatible types (vec4 and vec3) in assignment (and no available implicit conversion)
        color = color.brg;

Line 58: Use of undeclared identifier 'color_'
        gl_FragColor = color_;
```