### PR TITLE
This only gets compiled if on haxe 4 anyways so why check twice

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -920,7 +920,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		// when using Haxe 4, this value doesn't seem to get initialized,
 		// so it is undefined, which breaks ObjectMap. this line changes it
 		// from undefined to 0, but won't mess with numeric value > 0.
-		untyped #if haxe4 js.Syntax.code #else __js__ #end ("$global.$haxeUID |= 0;");
+		untyped js.Syntax.code("$global.$haxeUID |= 0;");
 		#end
 
 		untyped Object.defineProperties(Stage.prototype, {


### PR DESCRIPTION
This is only going to get compiled if on haxe 4 anyways so why check twice.

also,
 ```hx
 untyped #if haxe4 js.Syntax.code #else __js__ #end
 ```
 is present a lot in the code.
I feel like it would probably be a good idea to make a function that just returns the proper value depending on the haxe version to make things look a lot neater.