### PR TITLE
Handle Shader Errors Properly.

### DIFF
--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -634,7 +634,8 @@ class Shader
 				{
 					if (__isGenerated) Reflect.setField(this, name, input);
 				}
-				catch (e:Dynamic) {}
+				catch (e:Dynamic)
+					Log.debug('Failed to set field $name: $e');
 			}
 			else if (!Reflect.hasField(__data, name) || Reflect.field(__data, name) == null)
 			{
@@ -705,7 +706,8 @@ class Shader
 						{
 							if (__isGenerated) Reflect.setField(this, name, parameter);
 						}
-						catch (e:Dynamic) {}
+						catch (e:Dynamic)
+							Log.debug('Failed to set field $name: $e');
 
 					case INT, INT2, INT3, INT4:
 						var parameter = new ShaderParameter<Int>();
@@ -723,7 +725,8 @@ class Shader
 						{
 							if (__isGenerated) Reflect.setField(this, name, parameter);
 						}
-						catch (e:Dynamic) {}
+						catch (e:Dynamic)
+							Log.debug('Failed to set field $name: $e');
 					default:
 						var parameter = new ShaderParameter<Float>();
 						parameter.name = name;
@@ -758,7 +761,8 @@ class Shader
 						{
 							if (__isGenerated) Reflect.setField(this, name, parameter);
 						}
-						catch (e:Dynamic) {}
+						catch (e:Dynamic)
+							Log.debug('Failed to set field $name: $e');
 				}
 			}
 

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -629,7 +629,12 @@ class Shader
 				}
 
 				Reflect.setField(__data, name, input);
-				if (__isGenerated) Reflect.setField(this, name, input);
+
+				try
+				{
+					if (__isGenerated) Reflect.setField(this, name, input);
+				}
+				catch (e:Dynamic) {}
 			}
 			else if (!Reflect.hasField(__data, name) || Reflect.field(__data, name) == null)
 			{
@@ -695,7 +700,12 @@ class Shader
 						}
 
 						Reflect.setField(__data, name, parameter);
-						if (__isGenerated) Reflect.setField(this, name, parameter);
+
+						try
+						{
+							if (__isGenerated) Reflect.setField(this, name, parameter);
+						}
+						catch (e:Dynamic) {}
 
 					case INT, INT2, INT3, INT4:
 						var parameter = new ShaderParameter<Int>();
@@ -706,9 +716,14 @@ class Shader
 						parameter.__isUniform = isUniform;
 						parameter.__length = length;
 						__paramInt.push(parameter);
-						Reflect.setField(__data, name, parameter);
-						if (__isGenerated) Reflect.setField(this, name, parameter);
 
+						Reflect.setField(__data, name, parameter);
+
+						try
+						{
+							if (__isGenerated) Reflect.setField(this, name, parameter);
+						}
+						catch (e:Dynamic) {}
 					default:
 						var parameter = new ShaderParameter<Float>();
 						parameter.name = name;
@@ -738,7 +753,12 @@ class Shader
 						}
 
 						Reflect.setField(__data, name, parameter);
-						if (__isGenerated) Reflect.setField(this, name, parameter);
+
+						try
+						{
+							if (__isGenerated) Reflect.setField(this, name, parameter);
+						}
+						catch (e:Dynamic) {}
 				}
 			}
 

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -635,7 +635,9 @@ class Shader
 					if (__isGenerated) Reflect.setField(this, name, input);
 				}
 				catch (e:Dynamic)
+				{
 					Log.debug('Failed to set field $name: $e');
+				}
 			}
 			else if (!Reflect.hasField(__data, name) || Reflect.field(__data, name) == null)
 			{
@@ -707,7 +709,9 @@ class Shader
 							if (__isGenerated) Reflect.setField(this, name, parameter);
 						}
 						catch (e:Dynamic)
+						{
 							Log.debug('Failed to set field $name: $e');
+						}
 
 					case INT, INT2, INT3, INT4:
 						var parameter = new ShaderParameter<Int>();
@@ -726,7 +730,9 @@ class Shader
 							if (__isGenerated) Reflect.setField(this, name, parameter);
 						}
 						catch (e:Dynamic)
+						{
 							Log.debug('Failed to set field $name: $e');
+						}
 					default:
 						var parameter = new ShaderParameter<Float>();
 						parameter.name = name;
@@ -762,7 +768,9 @@ class Shader
 							if (__isGenerated) Reflect.setField(this, name, parameter);
 						}
 						catch (e:Dynamic)
+						{
 							Log.debug('Failed to set field $name: $e');
+						}
 				}
 			}
 

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -12,6 +12,7 @@ import openfl.utils._internal.Log;
 import openfl.display3D.Context3D;
 import openfl.display3D.Program3D;
 import openfl.utils.ByteArray;
+import openfl.Lib;
 
 /**
 	// TODO: Document GLSL Shaders
@@ -119,6 +120,8 @@ import openfl.utils.ByteArray;
 @:access(openfl.display3D.Program3D)
 @:access(openfl.display.ShaderInput)
 @:access(openfl.display.ShaderParameter)
+@:access(openfl.display.Stage)
+@:access(openfl.events.UncaughtErrorEvents)
 // #if (!display && !macro)
 #if !macro
 @:autoBuild(openfl.utils._internal.ShaderMacro.build())
@@ -511,7 +514,22 @@ class Shader
 
 				// TODO
 				// program.uploadSources (vertex, fragment);
-				program.__glProgram = __createGLProgram(vertex, fragment);
+
+				if (Lib.current.stage.__uncaughtErrorEvents.__enabled)
+				{
+					try
+					{
+						program.__glProgram = __createGLProgram(vertex, fragment);
+					}
+					catch (e:Dynamic)
+					{
+						Lib.current.stage.__handleError(e);
+	
+						program.__glProgram = null;
+					}
+				}
+				else
+					program.__glProgram = __createGLProgram(vertex, fragment);
 
 				__context.__programs.set(id, program);
 			}

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -524,8 +524,6 @@ class Shader
 					catch (e:Dynamic)
 					{
 						Lib.current.stage.__handleError(e);
-	
-						program.__glProgram = null;
 					}
 				}
 				else


### PR DESCRIPTION
- Previously, uncaught shader errors couldn’t be caught because they weren’t handled where they occurred. Now, these errors are caught directly at the point where they happen.
- Previously, if the shader field couldn’t be set to `this` Shader instance, it could crash the program. Now, this issue is resolved, ensuring that runtime generated shaders would work properly without causing crashes.