### PR TITLE
CairoShape: check if graphics.__cairo is null before trying to draw

### DIFF
--- a/src/openfl/display/_internal/CairoShape.hx
+++ b/src/openfl/display/_internal/CairoShape.hx
@@ -42,7 +42,7 @@ class CairoShape
 			var height = graphics.__height;
 			var cairo = renderer.cairo;
 
-			if (cairo != null && graphics.__visible && width >= 1 && height >= 1)
+			if (cairo != null && graphics.__cairo != null && graphics.__visible && width >= 1 && height >= 1)
 			{
 				var transform = graphics.__worldTransform;
 				var scale9Grid = shape.__worldScale9Grid;


### PR DESCRIPTION
Fixes #2777 

CairoShape never checked if `graphics.__cairo` was null which would result in a crash when trying to access `graphics.__cairo.target`