### PR TITLE
Keyboard: Fix `__getCharCode` to respect `Caps Lock` state for letter keys.

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1559,7 +1559,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		{
 			var keyLocation = Keyboard.__getKeyLocation(keyCode);
 			var keyCode = Keyboard.__convertKeyCode(keyCode);
-			var charCode = Keyboard.__getCharCode(keyCode, modifier.shiftKey);
+			var charCode = Keyboard.__getCharCode(keyCode, modifier.shiftKey, modifier.capsLock);
 
 			if (type == KeyboardEvent.KEY_UP && (keyCode == Keyboard.SPACE || keyCode == Keyboard.ENTER) && (__focus is Sprite))
 			{

--- a/src/openfl/ui/Keyboard.hx
+++ b/src/openfl/ui/Keyboard.hx
@@ -814,9 +814,16 @@ import lime.ui.KeyCode;
 	}
 	#end
 
-	@:noCompletion private static function __getCharCode(key:Int, shift:Bool = false):Int
+	@:noCompletion private static function __getCharCode(key:Int, shift:Bool = false, capsLock:Bool = false):Int
 	{
-		if (!shift)
+		var effectiveShift = shift;
+
+		if (key >= Keyboard.A && key <= Keyboard.Z)
+		{
+			effectiveShift = shift != capsLock; // XOR only for letters
+		}
+
+		if (!effectiveShift)
 		{
 			switch (key)
 			{


### PR DESCRIPTION
This PR updates the internal `__getCharCode` method to correctly interpret `Caps Lock` when determining the char code for letter keys `(A–Z)`.