### PR TITLE
fix(template): remove warning by updating mobile-web-app meta tag

### DIFF
--- a/assets/templates/html5/template/index.html
+++ b/assets/templates/html5/template/index.html
@@ -7,7 +7,7 @@
 	<title>::APP_TITLE::</title>
 	
 	<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="mobile-web-app-capable" content="yes">
 	
 	::if favicons::::foreach (favicons)::
 	<link rel="::__current__.rel::" type="::__current__.type::" href="::__current__.href::">::end::::end::


### PR DESCRIPTION
<img width="566" alt="screenshot" src="https://github.com/user-attachments/assets/5ba72c9f-92c4-4491-80b9-f2dbae6a03de" />

On HTML5 targets, there is a warning in the console due to the use of the deprecated `"apple-mobile-web-app-capable"` meta tag

This PR replaces it with the modern and supported `<meta name="mobile-web-app-capable" content="yes">` to clean up the console output.