### PR TITLE
Fixing Null access for SimpleButton

### DIFF
--- a/src/openfl/display/SimpleButton.hx
+++ b/src/openfl/display/SimpleButton.hx
@@ -217,6 +217,11 @@ class SimpleButton extends InteractiveObject
 			super.__getBounds(rect, matrix);
 		}
 
+		if (__currentState == null)
+		{
+			return;
+		}
+
 		var childWorldTransform = Matrix.__pool.get();
 
 		DisplayObject.__calculateAbsoluteTransform(__currentState.__transform, matrix, childWorldTransform);
@@ -366,7 +371,7 @@ class SimpleButton extends InteractiveObject
 	{
 		if (__downState != null && __currentState == __downState)
 		{
-			__currentState = __downState;
+			__currentState = downState;
 		}
 
 		return __downState = downState;


### PR DESCRIPTION
Fixing issue where a SimpleButton would cause a Null access if clicked when its parent had cacheAsBitmap enabled and the buttons down state was null.