### PR TITLE
Add the `Shader` custom metadata to the code completion

### DIFF
--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -1,6 +1,7 @@
 package openfl.utils._internal;
 
 #if macro
+import haxe.macro.Compiler;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -18,6 +18,54 @@ class ShaderMacro
 
 	public static function build():Array<Field>
 	{
+		#if (haxe >= "4.3.0")
+		function makeMetadata(type:Int, frag:Bool)
+		{
+			var t = switch (type)
+			{
+				case 1: "Body";
+				case 2: "Header";
+				default: "Source";
+			}
+
+			var fr = (frag) ? "Fragment" : "Vertex";
+
+			var params = "Sets the " + fr.toLowerCase() + " " + t.toLowerCase() + ((t == "Source") ? "" : "pragma ") + "code of the `Shader` class.\n\n";
+
+			if (type == 0)
+			{
+				params = "`Warning`: this will override the source code of the extended class. to append the logic with the previous `Shader` classes, use `@:gl" 
+				+ fr + "Header` or `@:gl" + fr + "Body instead.";
+			}
+			else
+			{
+				params = "`Warning`: this will append all the previous classes that have called @:gl" + fr + t + ". to override the logic of the previous `Shader` classes, use  `@:gl" 
+				+ fr + "Source` instead.";
+			}
+
+			params += "\n\n if you want to use the `Header` or `Body` code block inside your source, you will need to instance `#pragma header` or `#pragma body` respectively to inject the code inside the source code";
+
+
+			Compiler.registerCustomMetadata(
+			{
+				metadata: ':gl$fr$t',
+				doc: 'Sets the ${fr.toLowerCase()} ${(t == "Source") ? "shader" :  t.toLowerCase() + " pragma code"} of the class',
+				targets: [Expr],
+				platforms: [Cross],
+				params: [t.toLowerCase() + " code: The code block as a `String`"]
+			});
+		}
+
+		makeMetadata(0, true);
+		makeMetadata(1, true);
+		makeMetadata(2, true);
+
+
+		makeMetadata(0, false);
+		makeMetadata(1, false);
+		makeMetadata(2, false);
+		#end
+		
 		var fields = Context.getBuildFields();
 
 		var glFragmentHeader = "";


### PR DESCRIPTION
This adds all the `Shader` metadata tags on the code completion when you're inside a `Shader` extended class.

Due to an issue with [vsHaxe](https://github.com/vshaxe/vshaxe/issues/580), any type of documentation is lost, but it can be perfectly used as a way to shortcut your code and in future VsHaxe versions it'll showcase the proper documentation, hopefully

![2025-07-24-18-26-41-_online-video-cutter com__1_](https://github.com/user-attachments/assets/e41d76fe-f80c-4127-b5c1-5195486e65b8)
