### PR TITLE
add Uniform Arrays to Shaders

### DIFF
--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -126,6 +126,11 @@ import openfl.utils.ByteArray;
 class Shader
 {
 	/**
+		the version of the shader `#version <version>`.
+	**/
+	public var version:String = '120';
+
+	/**
 		The raw shader bytecode for this Shader instance.
 	**/
 	public var byteCode(null, default):ByteArray;
@@ -485,9 +490,11 @@ class Shader
 			var gl = __context.gl;
 
 			#if (js && html5)
-			var prefix = (precisionHint == FULL ? "precision mediump float;\n" : "precision lowp float;\n");
+			var prefix = (precisionHint == FULL ? 'version $version' + "\nprecision mediump float;\n" : "precision lowp float;\n");
 			#else
-			var prefix = "#ifdef GL_ES\n"
+			var prefix = "#version "
+				+ version
+				+ "\n#ifdef GL_ES\n"
 				+ (precisionHint == FULL ? "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
 					+ "precision highp float;\n"
 					+ "#else\n"
@@ -573,21 +580,22 @@ class Shader
 
 	@:noCompletion private function __processGLData(source:String, storageType:String):Void
 	{
-		var lastMatch = 0, position, regex, name, type;
+		var lastMatch = 0, position, regex, name, type, arrLength:Int;
 
 		if (storageType == "uniform")
 		{
-			regex = ~/uniform ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
+			regex = ~/uniform ([A-Za-z0-9]+) ([A-Za-z0-9_]+)(?:\[(\d+)\])?/;
 		}
 		else
 		{
-			regex = ~/attribute ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
+			regex = ~/attribute ([A-Za-z0-9]+) ([A-Za-z0-9_]+)(?:\[(\d+)\])?/;
 		}
 
 		while (regex.matchSub(source, lastMatch))
 		{
 			type = regex.matched(1);
 			name = regex.matched(2);
+			arrLength = Std.parseInt(regex.matched(3) ?? '0');
 
 			if (StringTools.startsWith(name, "gl_"))
 			{
@@ -619,51 +627,62 @@ class Shader
 			{
 				var parameterType:ShaderParameterType = switch (type)
 				{
-					case "bool": BOOL;
-					case "double", "float": FLOAT;
-					case "int", "uint": INT;
-					case "bvec2": BOOL2;
-					case "bvec3": BOOL3;
-					case "bvec4": BOOL4;
-					case "ivec2", "uvec2": INT2;
-					case "ivec3", "uvec3": INT3;
-					case "ivec4", "uvec4": INT4;
-					case "vec2", "dvec2": FLOAT2;
-					case "vec3", "dvec3": FLOAT3;
-					case "vec4", "dvec4": FLOAT4;
-					case "mat2", "mat2x2": MATRIX2X2;
-					case "mat2x3": MATRIX2X3;
-					case "mat2x4": MATRIX2X4;
-					case "mat3x2": MATRIX3X2;
-					case "mat3", "mat3x3": MATRIX3X3;
-					case "mat3x4": MATRIX3X4;
-					case "mat4x2": MATRIX4X2;
-					case "mat4x3": MATRIX4X3;
-					case "mat4", "mat4x4": MATRIX4X4;
+					case "bool": arrLength > 0 ? BOOLV : BOOL;
+					case "double", "float": arrLength > 0 ? FLOATV : FLOAT;
+					case "int", "uint": arrLength > 0 ? INTV : INT;
+					case "bvec2": arrLength > 0 ? BOOL2V : BOOL2;
+					case "bvec3": arrLength > 0 ? BOOL3V : BOOL3;
+					case "bvec4": arrLength > 0 ? BOOL4V : BOOL4;
+					case "ivec2", "uvec2": arrLength > 0 ? INT2V : INT2;
+					case "ivec3", "uvec3": arrLength > 0 ? INT3V : INT3;
+					case "ivec4", "uvec4": arrLength > 0 ? INT4V : INT4;
+					case "vec2", "dvec2": arrLength > 0 ? FLOAT2V : FLOAT2;
+					case "vec3", "dvec3": arrLength > 0 ? FLOAT3V : FLOAT3;
+					case "vec4", "dvec4": arrLength > 0 ? FLOAT4V : FLOAT4;
+					case "mat2", "mat2x2": arrLength > 0 ? MATRIX2X2V : MATRIX2X2;
+					case "mat2x3": arrLength > 0 ? MATRIX2X3V : MATRIX2X3;
+					case "mat2x4": arrLength > 0 ? MATRIX2X4V : MATRIX2X4;
+					case "mat3x2": arrLength > 0 ? MATRIX3X2V : MATRIX3X2;
+					case "mat3", "mat3x3": arrLength > 0 ? MATRIX3X3V : MATRIX3X3;
+					case "mat3x4": arrLength > 0 ? MATRIX3X4V : MATRIX3X4;
+					case "mat4x2": arrLength > 0 ? MATRIX4X2V : MATRIX4X2;
+					case "mat4x3": arrLength > 0 ? MATRIX4X3V : MATRIX4X3;
+					case "mat4", "mat4x4": arrLength > 0 ? MATRIX4X4V : MATRIX4X4;
 					default: null;
 				}
 
 				var length = switch (parameterType)
 				{
-					case BOOL2, INT2, FLOAT2: 2;
-					case BOOL3, INT3, FLOAT3: 3;
-					case BOOL4, INT4, FLOAT4, MATRIX2X2: 4;
-					case MATRIX3X3: 9;
-					case MATRIX4X4: 16;
+					case BOOL2, BOOL2V, INT2, INT2V, FLOAT2, FLOAT2V, MATRIX2X2: 2;
+					case BOOL3, BOOL3V, INT3, INT3V, FLOAT3, FLOAT3V, MATRIX3X3: 3;
+					case BOOL4, BOOL4V, INT4, INT4V, FLOAT4, FLOAT4V, MATRIX4X4, MATRIX2X2V: 4;
+
+					case MATRIX2X3, MATRIX4X3: 3;
+					case MATRIX2X4, MATRIX3X4: 4;
+					case MATRIX3X2, MATRIX4X2: 2;
+
+					case MATRIX3X3V: 9;
+					case MATRIX4X4V: 16;
+					case MATRIX2X3V, MATRIX3X2V: 6;
+					case MATRIX2X4V, MATRIX4X2V: 8;
+					case MATRIX3X4V, MATRIX4X3V: 12;
 					default: 1;
 				}
 
 				var arrayLength = switch (parameterType)
 				{
-					case MATRIX2X2: 2;
-					case MATRIX3X3: 3;
-					case MATRIX4X4: 4;
+					case MATRIX2X2, MATRIX2X3, MATRIX2X4: 2;
+					case MATRIX3X3, MATRIX3X2, MATRIX3X4: 3;
+					case MATRIX4X4, MATRIX4X2, MATRIX4X3: 4;
+					case FLOATV, FLOAT2V, FLOAT3V, FLOAT4V, INTV, INT2V, INT3V, INT4V, BOOLV, BOOL2V, BOOL3V, BOOL4V, MATRIX2X2V, MATRIX2X3V, MATRIX2X4V,
+						MATRIX3X2V, MATRIX3X3V, MATRIX3X4V, MATRIX4X2V, MATRIX4X3V, MATRIX4X4V: arrLength;
 					default: 1;
 				}
+				length *= arrayLength;
 
 				switch (parameterType)
 				{
-					case BOOL, BOOL2, BOOL3, BOOL4:
+					case BOOL, BOOL2, BOOL3, BOOL4, BOOLV, BOOL2V, BOOL3V, BOOL4V:
 						var parameter = new ShaderParameter<Bool>();
 						parameter.name = name;
 						parameter.type = parameterType;
@@ -681,7 +700,7 @@ class Shader
 						Reflect.setField(__data, name, parameter);
 						if (__isGenerated) Reflect.setField(this, name, parameter);
 
-					case INT, INT2, INT3, INT4:
+					case INT, INT2, INT3, INT4, INTV, INT2V, INT3V, INT4V:
 						var parameter = new ShaderParameter<Int>();
 						parameter.name = name;
 						parameter.type = parameterType;
@@ -699,7 +718,7 @@ class Shader
 						parameter.type = parameterType;
 						parameter.__arrayLength = arrayLength;
 						#if lime
-						if (arrayLength > 0) parameter.__uniformMatrix = new Float32Array(arrayLength * arrayLength);
+						if (arrayLength > 0) parameter.__uniformMatrix = new Float32Array(length);
 						#end
 						parameter.__isFloat = true;
 						parameter.__isUniform = isUniform;

--- a/src/openfl/display/ShaderParameter.hx
+++ b/src/openfl/display/ShaderParameter.hx
@@ -1,5 +1,7 @@
 package openfl.display;
 
+import lime.graphics.WebGL2RenderContext;
+import lime.utils.Int32Array;
 #if !flash
 import openfl.utils._internal.Float32Array;
 import openfl.display3D.Context3D;
@@ -93,6 +95,7 @@ import openfl.display3D.Context3D;
 #if (!js && !display)
 @:generic
 #end
+@:cppFileCode('#define LIME_GLES3_API')
 @:final class ShaderParameter<T> /*implements Dynamic*/
 {
 	/**
@@ -210,6 +213,15 @@ import openfl.display3D.Context3D;
 						gl.uniform3i(index, boolValue[0] ? 1 : 0, boolValue[1] ? 1 : 0, boolValue[2] ? 1 : 0);
 					case BOOL4:
 						gl.uniform4i(index, boolValue[0] ? 1 : 0, boolValue[1] ? 1 : 0, boolValue[2] ? 1 : 0, boolValue[3] ? 1 : 0);
+					case BOOLV:
+						gl.uniform1iv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
+					case BOOL2V:
+						gl.uniform2iv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
+					case BOOL3V:
+						gl.uniform3iv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
+					case BOOL4V:
+						gl.uniform4iv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
+
 					case FLOAT:
 						gl.uniform1f(index, floatValue[0]);
 					case FLOAT2:
@@ -218,6 +230,14 @@ import openfl.display3D.Context3D;
 						gl.uniform3f(index, floatValue[0], floatValue[1], floatValue[2]);
 					case FLOAT4:
 						gl.uniform4f(index, floatValue[0], floatValue[1], floatValue[2], floatValue[3]);
+					case FLOATV:
+						gl.uniform1fv(index, new Float32Array(floatValue));
+					case FLOAT2V:
+						gl.uniform2fv(index, new Float32Array(floatValue));
+					case FLOAT3V:
+						gl.uniform3fv(index, new Float32Array(floatValue));
+					case FLOAT4V:
+						gl.uniform4fv(index, new Float32Array(floatValue));
 
 					case MATRIX2X2:
 						for (i in 0...4)
@@ -225,6 +245,9 @@ import openfl.display3D.Context3D;
 							__uniformMatrix[i] = floatValue[i];
 						}
 						gl.uniformMatrix2fv(index, false, __uniformMatrix);
+
+					case MATRIX2X2V:
+						gl.uniformMatrix2fv(index, false, new Float32Array(floatValue));
 
 					// case MATRIX2X3:
 					// case MATRIX2X4:
@@ -237,6 +260,9 @@ import openfl.display3D.Context3D;
 						}
 						gl.uniformMatrix3fv(index, false, __uniformMatrix);
 
+					case MATRIX3X3V:
+						gl.uniformMatrix3fv(index, false, new Float32Array(floatValue));
+
 					// case MATRIX3X4:
 					// case MATRIX4X2:
 					// case MATRIX4X3:
@@ -248,6 +274,9 @@ import openfl.display3D.Context3D;
 						}
 						gl.uniformMatrix4fv(index, false, __uniformMatrix);
 
+					case MATRIX4X4V:
+						gl.uniformMatrix4fv(index, false, new Float32Array(floatValue));
+
 					case INT:
 						gl.uniform1i(index, intValue[0]);
 					case INT2:
@@ -256,6 +285,14 @@ import openfl.display3D.Context3D;
 						gl.uniform3i(index, intValue[0], intValue[1], intValue[2]);
 					case INT4:
 						gl.uniform4i(index, intValue[0], intValue[1], intValue[2], intValue[3]);
+					case INTV:
+						gl.uniform1iv(index, new Int32Array(intValue));
+					case INT2V:
+						gl.uniform2iv(index, new Int32Array(intValue));
+					case INT3V:
+						gl.uniform3iv(index, new Int32Array(intValue));
+					case INT4V:
+						gl.uniform4iv(index, new Int32Array(intValue));
 
 					default:
 				}
@@ -281,12 +318,33 @@ import openfl.display3D.Context3D;
 					case FLOAT4:
 						gl.uniform4f(index, 0, 0, 0, 0);
 
+					case INTV, BOOLV:
+						gl.uniform1iv(index, new Int32Array([for (i in 0...__length) 0]));
+					case INT2V, BOOL2V:
+						gl.uniform2iv(index, new Int32Array([for (i in 0...__length) 0]));
+					case INT3V, BOOL3V:
+						gl.uniform3iv(index, new Int32Array([for (i in 0...__length) 0]));
+					case INT4V, BOOL4V:
+						gl.uniform4iv(index, new Int32Array([for (i in 0...__length) 0]));
+
+					case FLOATV:
+						gl.uniform1fv(index, new Float32Array([for (i in 0...__length) 0]));
+					case FLOAT2V:
+						gl.uniform2fv(index, new Float32Array([for (i in 0...__length) 0]));
+					case FLOAT3V:
+						gl.uniform3fv(index, new Float32Array([for (i in 0...__length) 0]));
+					case FLOAT4V:
+						gl.uniform4fv(index, new Float32Array([for (i in 0...__length) 0]));
+
 					case MATRIX2X2:
 						for (i in 0...4)
 						{
 							__uniformMatrix[i] = 0;
 						}
 						gl.uniformMatrix2fv(index, false, __uniformMatrix);
+
+					case MATRIX2X2V:
+						gl.uniformMatrix2fv(index, false, new Float32Array([for (i in 0...__length) 0]));
 
 					// case MATRIX2X3:
 					// case MATRIX2X4:
@@ -299,6 +357,9 @@ import openfl.display3D.Context3D;
 						}
 						gl.uniformMatrix3fv(index, false, __uniformMatrix);
 
+					case MATRIX3X3V:
+						gl.uniformMatrix3fv(index, false, new Float32Array([for (i in 0...__length) 0]));
+
 					// case MATRIX3X4:
 					// case MATRIX4X2:
 					// case MATRIX4X3:
@@ -309,6 +370,9 @@ import openfl.display3D.Context3D;
 							__uniformMatrix[i] = 0;
 						}
 						gl.uniformMatrix4fv(index, false, __uniformMatrix);
+
+					case MATRIX4X4V:
+						gl.uniformMatrix4fv(index, false, new Float32Array([for (i in 0...__length) 0]));
 
 					default:
 				}
@@ -335,6 +399,14 @@ import openfl.display3D.Context3D;
 							gl.vertexAttrib3f(index, boolValue[0] ? 1 : 0, boolValue[1] ? 1 : 0, boolValue[2] ? 1 : 0);
 						case BOOL4:
 							gl.vertexAttrib4f(index, boolValue[0] ? 1 : 0, boolValue[1] ? 1 : 0, boolValue[2] ? 1 : 0, boolValue[3] ? 1 : 0);
+						case BOOLV:
+							gl.vertexAttrib1fv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
+						case BOOL2V:
+							gl.vertexAttrib2fv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
+						case BOOL3V:
+							gl.vertexAttrib3fv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
+						case BOOL4V:
+							gl.vertexAttrib4fv(index, new Int32Array([for (v in boolValue) v ? 1 : 0]));
 						case FLOAT:
 							gl.vertexAttrib1f(index, floatValue[0]);
 						case FLOAT2:
@@ -343,13 +415,20 @@ import openfl.display3D.Context3D;
 							gl.vertexAttrib3f(index, floatValue[0], floatValue[1], floatValue[2]);
 						case FLOAT4:
 							gl.vertexAttrib4f(index, floatValue[0], floatValue[1], floatValue[2], floatValue[3]);
+						case FLOATV:
+							gl.vertexAttrib1fv(index, floatValue);
+						case FLOAT2V, MATRIX2X2V:
+							gl.vertexAttrib2fv(index, floatValue);
+						case FLOAT3V, MATRIX3X3V:
+							gl.vertexAttrib3fv(index, floatValue);
+						case FLOAT4V, MATRIX4X4V:
+							gl.vertexAttrib4fv(index, floatValue);
 
 						case MATRIX2X2:
 							for (i in 0...2)
 							{
 								gl.vertexAttrib2f(index + i, floatValue[i * 2], floatValue[i * 2 + 1]);
 							}
-
 						case MATRIX3X3:
 							for (i in 0...3)
 							{
@@ -370,6 +449,16 @@ import openfl.display3D.Context3D;
 							gl.vertexAttrib3f(index, intValue[0], intValue[1], intValue[2]);
 						case INT4:
 							gl.vertexAttrib4f(index, intValue[0], intValue[1], intValue[2], intValue[3]);
+
+						case INTV:
+							gl.vertexAttrib1fv(index, intValue);
+						case INT2V:
+							gl.vertexAttrib2fv(index, intValue);
+						case INT3V:
+							gl.vertexAttrib3fv(index, intValue);
+						case INT4V:
+							gl.vertexAttrib4fv(index, intValue);
+
 						default:
 					}
 				}
@@ -385,6 +474,33 @@ import openfl.display3D.Context3D;
 							gl.vertexAttrib3f(index, 0, 0, 0);
 						case BOOL4, FLOAT4, INT4:
 							gl.vertexAttrib4f(index, 0, 0, 0, 0);
+
+						case BOOLV:
+							gl.vertexAttrib1fv(index, new Int32Array([for (i in 0...__length) 0]));
+						case BOOL2V:
+							gl.vertexAttrib2fv(index, new Int32Array([for (i in 0...__length) 0]));
+						case BOOL3V:
+							gl.vertexAttrib3fv(index, new Int32Array([for (i in 0...__length) 0]));
+						case BOOL4V:
+							gl.vertexAttrib4fv(index, new Int32Array([for (i in 0...__length) 0]));
+
+						case INTV:
+							gl.vertexAttrib1fv(index, new Int32Array([for (i in 0...__length) 0]));
+						case INT2V:
+							gl.vertexAttrib2fv(index, new Int32Array([for (i in 0...__length) 0]));
+						case INT3V:
+							gl.vertexAttrib3fv(index, new Int32Array([for (i in 0...__length) 0]));
+						case INT4V:
+							gl.vertexAttrib4fv(index, new Int32Array([for (i in 0...__length) 0]));
+
+						case FLOATV:
+							gl.vertexAttrib1fv(index, new Float32Array([for (i in 0...__length) 0]));
+						case FLOAT2V, MATRIX2X2V:
+							gl.vertexAttrib2fv(index, new Float32Array([for (i in 0...__length) 0]));
+						case FLOAT3V, MATRIX3X3V:
+							gl.vertexAttrib3fv(index, new Float32Array([for (i in 0...__length) 0]));
+						case FLOAT4V, MATRIX4X4V:
+							gl.vertexAttrib4fv(index, new Float32Array([for (i in 0...__length) 0]));
 
 						case MATRIX2X2:
 							for (i in 0...2)
@@ -450,6 +566,24 @@ import openfl.display3D.Context3D;
 					case FLOAT4:
 						gl.uniform4f(index, buffer[position], buffer[position + 1], buffer[position + 2], buffer[position + 3]);
 
+					case INTV, BOOLV:
+						gl.uniform1iv(index, buffer.subarray(position, position + __length));
+					case INT2V, BOOL2V:
+						gl.uniform2iv(index, buffer.subarray(position, position + __length));
+					case INT3V, BOOL3V:
+						gl.uniform3iv(index, buffer.subarray(position, position + __length));
+					case INT4V, BOOL4V:
+						gl.uniform4iv(index, buffer.subarray(position, position + __length));
+
+					case FLOATV:
+						gl.uniform1fv(index, buffer.subarray(position, position + __length));
+					case FLOAT2V:
+						gl.uniform2fv(index, buffer.subarray(position, position + __length));
+					case FLOAT3V:
+						gl.uniform3fv(index, buffer.subarray(position, position + __length));
+					case FLOAT4V:
+						gl.uniform4fv(index, buffer.subarray(position, position + __length));
+
 					case MATRIX2X2:
 						for (i in 0...4)
 						{
@@ -457,7 +591,16 @@ import openfl.display3D.Context3D;
 						}
 						gl.uniformMatrix2fv(index, false, __uniformMatrix);
 
+					case MATRIX2X2V:
+						gl.uniformMatrix2fv(index, false, buffer.subarray(position, position + __length));
+					// matrix AxB is not supported by lime
 					// case MATRIX2X3:
+					// 	for (i in 0...6)
+					// 	{
+					// 		__uniformMatrix[i] = buffer[position + i];
+					// 	}
+					// 	var _gl:WebGL2RenderContext = cast gl;
+					// 	_gl.uniformMatrix2x3fv(index, false, __uniformMatrix);
 					// case MATRIX2X4:
 					// case MATRIX3X2:
 
@@ -468,6 +611,8 @@ import openfl.display3D.Context3D;
 						}
 						gl.uniformMatrix3fv(index, false, __uniformMatrix);
 
+					case MATRIX3X3V:
+						gl.uniformMatrix3fv(index, false, buffer.subarray(position, position + __length));
 					// case MATRIX3X4:
 					// case MATRIX4X2:
 					// case MATRIX4X3:
@@ -479,6 +624,8 @@ import openfl.display3D.Context3D;
 						}
 						gl.uniformMatrix4fv(index, false, __uniformMatrix);
 
+					case MATRIX4X4V:
+						gl.uniformMatrix4fv(index, false, buffer.subarray(position, position + __length));
 					default:
 				}
 			}
@@ -505,18 +652,31 @@ import openfl.display3D.Context3D;
 						case BOOL4, FLOAT4, INT4:
 							gl.vertexAttrib4f(index, buffer[position], buffer[position + 1], buffer[position + 2], buffer[position + 3]);
 
+						case FLOATV, INTV, BOOLV:
+							gl.vertexAttrib1fv(index, buffer.subarray(position, position + __length));
+						case FLOAT2V, INT2V, BOOL2V:
+							gl.vertexAttrib2fv(index, buffer.subarray(position, position + __length));
+						case FLOAT3V, INT3V, BOOL3V:
+							gl.vertexAttrib3fv(index, buffer.subarray(position, position + __length));
+						case FLOAT4V, INT4V, BOOL4V:
+							gl.vertexAttrib4fv(index, buffer.subarray(position, position + __length));
+
 						case MATRIX2X2:
 							for (i in 0...2)
 							{
 								gl.vertexAttrib2f(index + i, buffer[position + i * 2], buffer[position + i * 2 + 1]);
 							}
 
+						case MATRIX2X2V:
+							gl.vertexAttrib2fv(index, buffer.subarray(position, position + __length));
 						case MATRIX3X3:
 							for (i in 0...3)
 							{
 								gl.vertexAttrib3f(index + i, buffer[position + i * 3], buffer[position + i * 3 + 1], buffer[position + i * 3 + 2]);
 							}
 
+						case MATRIX3X3V:
+							gl.vertexAttrib3fv(index, buffer.subarray(position, position + __length));
 						case MATRIX4X4:
 							for (i in 0...4)
 							{
@@ -524,6 +684,8 @@ import openfl.display3D.Context3D;
 									buffer[position + i * 4 + 3]);
 							}
 
+						case MATRIX4X4V:
+							gl.vertexAttrib4fv(index, buffer.subarray(position, position + __length));
 						default:
 					}
 				}
@@ -540,24 +702,39 @@ import openfl.display3D.Context3D;
 						case BOOL4, FLOAT4, INT4:
 							gl.vertexAttrib4f(index, 0, 0, 0, 0);
 
+						case FLOATV, INTV, BOOLV:
+							gl.vertexAttrib1fv(index, new Float32Array([for (i in 0...__length) 0]));
+						case FLOAT2V, INT2V, BOOL2V:
+							gl.vertexAttrib2fv(index, new Float32Array([for (i in 0...__length) 0]));
+						case FLOAT3V, INT3V, BOOL3V:
+							gl.vertexAttrib3fv(index, new Float32Array([for (i in 0...__length) 0]));
+						case FLOAT4V, INT4V, BOOL4V:
+							gl.vertexAttrib4fv(index, new Float32Array([for (i in 0...__length) 0]));
+
 						case MATRIX2X2:
 							for (i in 0...2)
 							{
 								gl.vertexAttrib2f(index + i, 0, 0);
 							}
 
+						case MATRIX2X2V:
+							gl.vertexAttrib2fv(index, new Float32Array([for (i in 0...__length) 0]));
 						case MATRIX3X3:
 							for (i in 0...3)
 							{
 								gl.vertexAttrib3f(index + i, 0, 0, 0);
 							}
 
+						case MATRIX3X3V:
+							gl.vertexAttrib3fv(index, new Float32Array([for (i in 0...__length) 0]));
 						case MATRIX4X4:
 							for (i in 0...4)
 							{
 								gl.vertexAttrib4f(index + i, 0, 0, 0, 0);
 							}
 
+						case MATRIX4X4V:
+							gl.vertexAttrib4fv(index, new Float32Array([for (i in 0...__length) 0]));
 						default:
 					}
 				}

--- a/src/openfl/display/ShaderParameterType.hx
+++ b/src/openfl/display/ShaderParameterType.hx
@@ -27,10 +27,22 @@ package openfl.display;
 	public var BOOL = 0;
 
 	/**
+		Indicates that the shader parameter is defined as a `bool[...]` value,
+		equivalent to an Array of Boolean instances in ActionScript.
+	**/
+	public var BOOLV = 21;
+
+	/**
 		Indicates that the shader parameter is defined as a `bool2` value,
 		equivalent to an Array of two Boolean instances in ActionScript.
 	**/
 	public var BOOL2 = 1;
+
+	/**
+		Indicates that the shader parameter is defined as a `bool2[...]` value,
+		equivalent to an Array of 2 pairs of Boolean instances in ActionScript.
+	**/
+	public var BOOL2V = 22;
 
 	/**
 		Indicates that the shader parameter is defined as a `bool3` value,
@@ -39,10 +51,22 @@ package openfl.display;
 	public var BOOL3 = 2;
 
 	/**
+		Indicates that the shader parameter is defined as a `bool3[...]` value,
+		equivalent to an Array of 3 triples of Boolean instances in ActionScript.
+	**/
+	public var BOOL3V = 23;
+
+	/**
 		Indicates that the shader parameter is defined as a `bool4` value,
 		equivalent to an Array of four Boolean instances in ActionScript.
 	**/
 	public var BOOL4 = 3;
+
+	/**
+		Indicates that the shader parameter is defined as a `bool4[...]` value,
+		equivalent to an Array of 4 quadruplets of Boolean instances in ActionScript.
+	**/
+	public var BOOL4V = 24;
 
 	/**
 		Indicates that the shader parameter is defined as a `float` value,
@@ -61,10 +85,22 @@ package openfl.display;
 	public var FLOAT = 4;
 
 	/**
+		Indicates that the shader parameter is defined as a `float[...]` value,
+		equivalent to an Array of Number instances in ActionScript.
+	**/
+	public var FLOATV = 25;
+
+	/**
 		Indicates that the shader parameter is defined as a `float2` value,
 		equivalent to an Array of two Number instances in ActionScript.
 	**/
 	public var FLOAT2 = 5;
+
+	/**
+		Indicates that the shader parameter is defined as a `float2[...]` value,
+		equivalent to an Array of 2 pairs of Number instances in ActionScript.
+	**/
+	public var FLOAT2V = 26;
 
 	/**
 		Indicates that the shader parameter is defined as a `float3` value,
@@ -73,10 +109,22 @@ package openfl.display;
 	public var FLOAT3 = 6;
 
 	/**
+		Indicates that the shader parameter is defined as a `float3[...]` value,
+		equivalent to an Array of 3 triplets of Number instances in ActionScript.
+	**/
+	public var FLOAT3V = 27;
+
+	/**
 		Indicates that the shader parameter is defined as a `float4` value,
 		equivalent to an Array of four Number instances in ActionScript.
 	**/
 	public var FLOAT4 = 7;
+
+	/**
+		Indicates that the shader parameter is defined as a `float4[...]` value,
+		equivalent to an Array of 4 quadruplets of Number instances in ActionScript.
+	**/
+	public var FLOAT4V = 28;
 
 	/**
 		Indicates that the shader parameter is defined as an `int` value,
@@ -95,22 +143,46 @@ package openfl.display;
 	public var INT = 8;
 
 	/**
+		Indicates that the shader parameter is defined as an `int[...]` value,
+		equivalent to an Array of int or uint instances in ActionScript.
+	**/
+	public var INTV = 29;
+
+	/**
 		Indicates that the shader parameter is defined as an `int2` value,
 		equivalent to an Array of two int or uint instances in ActionScript.
 	**/
 	public var INT2 = 9;
 
 	/**
+		Indicates that the shader parameter is defined as an `int2[...]` value,
+		equivalent to an Array of 2 pairs of int or uint instances in ActionScript.
+	**/
+	public var INT2V = 30;
+
+	/**
 		Indicates that the shader parameter is defined as an `int3` value,
 		equivalent to an Array of three int or uint instances in ActionScript.
 	**/
-	public var INT3 = 10;
+	public var INT3 = 31;
+
+	/**
+		Indicates that the shader parameter is defined as an `int3[...]` value,
+		equivalent to an Array of 3 triplets of int or uint instances in ActionScript.
+	**/
+	public var INT3V = 32;
 
 	/**
 		Indicates that the shader parameter is defined as an `int4` value,
 		equivalent to an Array of four int or uint instances in ActionScript.
 	**/
 	public var INT4 = 11;
+
+	/**
+		Indicates that the shader parameter is defined as an `int4[...]` value,
+		equivalent to an Array of 4 quadruplets of int or uint instances in ActionScript.
+	**/
+	public var INT4V = 33;
 
 	/**
 		Indicates that the shader parameter is defined as a `float2x2` value,
@@ -120,11 +192,23 @@ package openfl.display;
 	public var MATRIX2X2 = 12;
 
 	/**
+		Indicates that the shader parameter is defined as a `float2x2[...]` value,
+		equivalent to an Array of 2 2x2 matrices of Number instances in ActionScript. 
+	**/
+	public var MATRIX2X2V = 34;
+
+	/**
 		Indicates that the shader parameter is defined as a `float2x3` value,
 		equivalent to a 2-by-3 matrix. This matrix is represented as an Array
 		of six Float instances in Haxe.
 	**/
 	public var MATRIX2X3 = 13;
+
+	/**
+		Indicates that the shader parameter is defined as a `float2x3[...]` value,
+		equivalent to an Array of 2 2x3 matrices of Float instances in Haxe.
+	**/
+	public var MATRIX2X3V = 35;
 
 	/**
 		Indicates that the shader parameter is defined as a `float2x4` value,
@@ -134,11 +218,23 @@ package openfl.display;
 	public var MATRIX2X4 = 14;
 
 	/**
+		Indicates that the shader parameter is defined as a `float2x4[...]` value,
+		equivalent to an Array of 2 2x4 matrices of Float instances in Haxe.
+	**/
+	public var MATRIX2X4V = 36;
+
+	/**
 		Indicates that the shader parameter is defined as a `float3x2` value,
 		equivalent to a 3-by-2 matrix. This matrix is represented as an Array
 		of six Float instances in Haxe.
 	**/
 	public var MATRIX3X2 = 15;
+
+	/**
+		Indicates that the shader parameter is defined as a `float3x2[...]` value,
+		equivalent to an Array of 3 3x2 matrices of Float instances in Haxe.
+	**/
+	public var MATRIX3X2V = 37;
 
 	/**
 		Indicates that the shader parameter is defined as a `float3x3` value,
@@ -148,11 +244,23 @@ package openfl.display;
 	public var MATRIX3X3 = 16;
 
 	/**
+		Indicates that the shader parameter is defined as a `float3x3[...]` value,
+		equivalent to an Array of 3 3x3 matrices of Number instances in ActionScript.
+	**/
+	public var MATRIX3X3V = 38;
+
+	/**
 		Indicates that the shader parameter is defined as a `float3x4` value,
 		equivalent to a 3-by-4 matrix. This matrix is represented as an Array
 		of twelve Float instances in Haxe.
 	**/
 	public var MATRIX3X4 = 17;
+
+	/**
+		Indicates that the shader parameter is defined as a `float3x4[...]` value,
+		equivalent to an Array of 3 3x4 matrices of Float instances in Haxe.
+	**/
+	public var MATRIX3X4V = 39;
 
 	/**
 		Indicates that the shader parameter is defined as a `float4x2` value,
@@ -162,6 +270,12 @@ package openfl.display;
 	public var MATRIX4X2 = 18;
 
 	/**
+		Indicates that the shader parameter is defined as a `float4x2[...]` value,
+		equivalent to an Array of 4 4x2 matrices of Float instances in Haxe.
+	**/
+	public var MATRIX4X2V = 40;
+
+	/**
 		Indicates that the shader parameter is defined as a `float4x3` value,
 		equivalent to a 4-by-3 matrix. This matrix is represented as an Array
 		of twelve Float instances in Haxe.
@@ -169,11 +283,23 @@ package openfl.display;
 	public var MATRIX4X3 = 19;
 
 	/**
+		Indicates that the shader parameter is defined as a `float4x3[...]` value,
+		equivalent to an Array of 4 4x3 matrices of Float instances in Haxe.
+	**/
+	public var MATRIX4X3V = 41;
+
+	/**
 		Indicates that the shader parameter is defined as a `float4x4` value,
 		equivalent to a 4-by-4 matrix. This matrix is represented as an Array
 		of 16 Number instances in ActionScript.
 	**/
 	public var MATRIX4X4 = 20;
+
+	/**
+		Indicates that the shader parameter is defined as a `float4x4[...]` value,
+		equivalent to an Array of 4 4x4 matrices of Number instances in ActionScript.
+	**/
+	public var MATRIX4X4V = 42;
 
 	@:from private static function fromString(value:String):ShaderParameterType
 	{
@@ -187,10 +313,18 @@ package openfl.display;
 			case "float2": FLOAT2;
 			case "float3": FLOAT3;
 			case "float4": FLOAT4;
+			case "float[]": FLOATV;
+			case "float2[]": FLOAT2V;
+			case "float3[]": FLOAT3V;
+			case "float4[]": FLOAT4V;
 			case "int": INT;
 			case "int2": INT2;
 			case "int3": INT3;
 			case "int4": INT4;
+			case "int[]": INTV;
+			case "int2[]": INT2V;
+			case "int3[]": INT3V;
+			case "int4[]": INT4V;
 			case "matrix2x2": MATRIX2X2;
 			case "matrix2x3": MATRIX2X3;
 			case "matrix2x4": MATRIX2X4;
@@ -200,6 +334,15 @@ package openfl.display;
 			case "matrix4x2": MATRIX4X2;
 			case "matrix4x3": MATRIX4X3;
 			case "matrix4x4": MATRIX4X4;
+			case "matrix2x2[]": MATRIX2X2V;
+			case "matrix2x3[]": MATRIX2X3V;
+			case "matrix2x4[]": MATRIX2X4V;
+			case "matrix3x2[]": MATRIX3X2V;
+			case "matrix3x3[]": MATRIX3X3V;
+			case "matrix3x4[]": MATRIX3X4V;
+			case "matrix4x2[]": MATRIX4X2V;
+			case "matrix4x3[]": MATRIX4X3V;
+			case "matrix4x4[]": MATRIX4X4V;
 			default: null;
 		}
 	}
@@ -212,14 +355,26 @@ package openfl.display;
 			case ShaderParameterType.BOOL2: "bool2";
 			case ShaderParameterType.BOOL3: "bool3";
 			case ShaderParameterType.BOOL4: "bool4";
+			case ShaderParameterType.BOOLV: "bool[]";
+			case ShaderParameterType.BOOL2V: "bool2[]";
+			case ShaderParameterType.BOOL3V: "bool3[]";
+			case ShaderParameterType.BOOL4V: "bool4[]";
 			case ShaderParameterType.FLOAT: "float";
 			case ShaderParameterType.FLOAT2: "float2";
 			case ShaderParameterType.FLOAT3: "float3";
 			case ShaderParameterType.FLOAT4: "float4";
+			case ShaderParameterType.FLOATV: "float[]";
+			case ShaderParameterType.FLOAT2V: "float2[]";
+			case ShaderParameterType.FLOAT3V: "float3[]";
+			case ShaderParameterType.FLOAT4V: "float4[]";
 			case ShaderParameterType.INT: "int";
 			case ShaderParameterType.INT2: "int2";
 			case ShaderParameterType.INT3: "int3";
 			case ShaderParameterType.INT4: "int4";
+			case ShaderParameterType.INTV: "int[]";
+			case ShaderParameterType.INT2V: "int2[]";
+			case ShaderParameterType.INT3V: "int3[]";
+			case ShaderParameterType.INT4V: "int4[]";
 			case ShaderParameterType.MATRIX2X2: "matrix2x2";
 			case ShaderParameterType.MATRIX2X3: "matrix2x3";
 			case ShaderParameterType.MATRIX2X4: "matrix2x4";
@@ -229,6 +384,15 @@ package openfl.display;
 			case ShaderParameterType.MATRIX4X2: "matrix4x2";
 			case ShaderParameterType.MATRIX4X3: "matrix4x3";
 			case ShaderParameterType.MATRIX4X4: "matrix4x4";
+			case ShaderParameterType.MATRIX2X2V: "matrix2x2[]";
+			case ShaderParameterType.MATRIX2X3V: "matrix2x3[]";
+			case ShaderParameterType.MATRIX2X4V: "matrix2x4[]";
+			case ShaderParameterType.MATRIX3X2V: "matrix3x2[]";
+			case ShaderParameterType.MATRIX3X3V: "matrix3x3[]";
+			case ShaderParameterType.MATRIX3X4V: "matrix3x4[]";
+			case ShaderParameterType.MATRIX4X2V: "matrix4x2[]";
+			case ShaderParameterType.MATRIX4X3V: "matrix4x3[]";
+			case ShaderParameterType.MATRIX4X4V: "matrix4x4[]";
 			default: null;
 		}
 	}
@@ -240,14 +404,26 @@ package openfl.display;
 	public var BOOL2 = "bool2";
 	public var BOOL3 = "bool3";
 	public var BOOL4 = "bool4";
+	public var BOOLV = "bool[]";
+	public var BOOL2V = "bool2[]";
+	public var BOOL3V = "bool3[]";
+	public var BOOL4V = "bool4[]";
 	public var FLOAT = "float";
 	public var FLOAT2 = "float2";
 	public var FLOAT3 = "float3";
 	public var FLOAT4 = "float4";
+	public var FLOATV = "float[]";
+	public var FLOAT2V = "float2[]";
+	public var FLOAT3V = "float3[]";
+	public var FLOAT4V = "float4[]";
 	public var INT = "int";
 	public var INT2 = "int2";
 	public var INT3 = "int3";
 	public var INT4 = "int4";
+	public var INTV = "int[]";
+	public var INT2V = "int2[]";
+	public var INT3V = "int3[]";
+	public var INT4V = "int4[]";
 	public var MATRIX2X2 = "matrix2x2";
 	public var MATRIX2X3 = "matrix2x3";
 	public var MATRIX2X4 = "matrix2x4";
@@ -257,6 +433,15 @@ package openfl.display;
 	public var MATRIX4X2 = "matrix4x2";
 	public var MATRIX4X3 = "matrix4x3";
 	public var MATRIX4X4 = "matrix4x4";
+	public var MATRIX2X2V = "matrix2x2[]";
+	public var MATRIX2X3V = "matrix2x3[]";
+	public var MATRIX2X4V = "matrix2x4[]";
+	public var MATRIX3X2V = "matrix3x2[]";
+	public var MATRIX3X3V = "matrix3x3[]";
+	public var MATRIX3X4V = "matrix3x4[]";
+	public var MATRIX4X2V = "matrix4x2[]";
+	public var MATRIX4X3V = "matrix4x3[]";
+	public var MATRIX4X4V = "matrix4x4[]";
 }
 #end
 #else

--- a/src/openfl/display/ShaderParameterType.hx
+++ b/src/openfl/display/ShaderParameterType.hx
@@ -164,13 +164,13 @@ package openfl.display;
 		Indicates that the shader parameter is defined as an `int3` value,
 		equivalent to an Array of three int or uint instances in ActionScript.
 	**/
-	public var INT3 = 31;
+	public var INT3 = 10;
 
 	/**
 		Indicates that the shader parameter is defined as an `int3[...]` value,
 		equivalent to an Array of 3 triplets of int or uint instances in ActionScript.
 	**/
-	public var INT3V = 32;
+	public var INT3V = 31;
 
 	/**
 		Indicates that the shader parameter is defined as an `int4` value,
@@ -182,7 +182,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as an `int4[...]` value,
 		equivalent to an Array of 4 quadruplets of int or uint instances in ActionScript.
 	**/
-	public var INT4V = 33;
+	public var INT4V = 32;
 
 	/**
 		Indicates that the shader parameter is defined as a `float2x2` value,
@@ -195,7 +195,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float2x2[...]` value,
 		equivalent to an Array of 2 2x2 matrices of Number instances in ActionScript. 
 	**/
-	public var MATRIX2X2V = 34;
+	public var MATRIX2X2V = 33;
 
 	/**
 		Indicates that the shader parameter is defined as a `float2x3` value,
@@ -208,7 +208,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float2x3[...]` value,
 		equivalent to an Array of 2 2x3 matrices of Float instances in Haxe.
 	**/
-	public var MATRIX2X3V = 35;
+	public var MATRIX2X3V = 34;
 
 	/**
 		Indicates that the shader parameter is defined as a `float2x4` value,
@@ -221,7 +221,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float2x4[...]` value,
 		equivalent to an Array of 2 2x4 matrices of Float instances in Haxe.
 	**/
-	public var MATRIX2X4V = 36;
+	public var MATRIX2X4V = 35;
 
 	/**
 		Indicates that the shader parameter is defined as a `float3x2` value,
@@ -234,7 +234,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float3x2[...]` value,
 		equivalent to an Array of 3 3x2 matrices of Float instances in Haxe.
 	**/
-	public var MATRIX3X2V = 37;
+	public var MATRIX3X2V = 36;
 
 	/**
 		Indicates that the shader parameter is defined as a `float3x3` value,
@@ -247,7 +247,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float3x3[...]` value,
 		equivalent to an Array of 3 3x3 matrices of Number instances in ActionScript.
 	**/
-	public var MATRIX3X3V = 38;
+	public var MATRIX3X3V = 37;
 
 	/**
 		Indicates that the shader parameter is defined as a `float3x4` value,
@@ -260,7 +260,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float3x4[...]` value,
 		equivalent to an Array of 3 3x4 matrices of Float instances in Haxe.
 	**/
-	public var MATRIX3X4V = 39;
+	public var MATRIX3X4V = 38;
 
 	/**
 		Indicates that the shader parameter is defined as a `float4x2` value,
@@ -273,7 +273,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float4x2[...]` value,
 		equivalent to an Array of 4 4x2 matrices of Float instances in Haxe.
 	**/
-	public var MATRIX4X2V = 40;
+	public var MATRIX4X2V = 39;
 
 	/**
 		Indicates that the shader parameter is defined as a `float4x3` value,
@@ -286,7 +286,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float4x3[...]` value,
 		equivalent to an Array of 4 4x3 matrices of Float instances in Haxe.
 	**/
-	public var MATRIX4X3V = 41;
+	public var MATRIX4X3V = 40;
 
 	/**
 		Indicates that the shader parameter is defined as a `float4x4` value,
@@ -299,7 +299,7 @@ package openfl.display;
 		Indicates that the shader parameter is defined as a `float4x4[...]` value,
 		equivalent to an Array of 4 4x4 matrices of Number instances in ActionScript.
 	**/
-	public var MATRIX4X4V = 42;
+	public var MATRIX4X4V = 41;
 
 	@:from private static function fromString(value:String):ShaderParameterType
 	{

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -204,15 +204,15 @@ class ShaderMacro
 	{
 		if (source == null) return;
 
-		var lastMatch = 0, position, regex, field:Field, name, type;
+		var lastMatch = 0, position, regex, field:Field, name, type, arrLength:Int;
 
 		if (storageType == "uniform")
 		{
-			regex = ~/uniform ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
+			regex = ~/uniform ([A-Za-z0-9]+) ([A-Za-z0-9_]+)(?:\[(\d+)\])?/;
 		}
 		else
 		{
-			regex = ~/attribute ([A-Za-z0-9]+) ([A-Za-z0-9_]+)/;
+			regex = ~/attribute ([A-Za-z0-9]+) ([A-Za-z0-9_]+)(?:\[(\d+)\])?/;
 		}
 
 		var fieldAccess:Access;
@@ -221,6 +221,7 @@ class ShaderMacro
 		{
 			type = regex.matched(1);
 			name = regex.matched(2);
+			arrLength = Std.parseInt(regex.matched(3) ?? '0');
 
 			if (StringTools.startsWith(name, "gl_"))
 			{
@@ -250,27 +251,27 @@ class ShaderMacro
 			{
 				var parameterType:openfl.display.ShaderParameterType = switch (type)
 				{
-					case "bool": BOOL;
-					case "double", "float": FLOAT;
-					case "int", "uint": INT;
-					case "bvec2": BOOL2;
-					case "bvec3": BOOL3;
-					case "bvec4": BOOL4;
-					case "ivec2", "uvec2": INT2;
-					case "ivec3", "uvec3": INT3;
-					case "ivec4", "uvec4": INT4;
-					case "vec2", "dvec2": FLOAT2;
-					case "vec3", "dvec3": FLOAT3;
-					case "vec4", "dvec4": FLOAT4;
-					case "mat2", "mat2x2": MATRIX2X2;
-					case "mat2x3": MATRIX2X3;
-					case "mat2x4": MATRIX2X4;
-					case "mat3x2": MATRIX3X2;
-					case "mat3", "mat3x3": MATRIX3X3;
-					case "mat3x4": MATRIX3X4;
-					case "mat4x2": MATRIX4X2;
-					case "mat4x3": MATRIX4X3;
-					case "mat4", "mat4x4": MATRIX4X4;
+					case "bool": arrLength > 0 ? BOOLV : BOOL;
+					case "double", "float": arrLength > 0 ? FLOATV : FLOAT;
+					case "int", "uint": arrLength > 0 ? INTV : INT;
+					case "bvec2": arrLength > 0 ? BOOL2V : BOOL2;
+					case "bvec3": arrLength > 0 ? BOOL3V : BOOL3;
+					case "bvec4": arrLength > 0 ? BOOL4V : BOOL4;
+					case "ivec2", "uvec2": arrLength > 0 ? INT2V : INT2;
+					case "ivec3", "uvec3": arrLength > 0 ? INT3V : INT3;
+					case "ivec4", "uvec4": arrLength > 0 ? INT4V : INT4;
+					case "vec2", "dvec2": arrLength > 0 ? FLOAT2V : FLOAT2;
+					case "vec3", "dvec3": arrLength > 0 ? FLOAT3V : FLOAT3;
+					case "vec4", "dvec4": arrLength > 0 ? FLOAT4V : FLOAT4;
+					case "mat2", "mat2x2": arrLength > 0 ? MATRIX2X2V : MATRIX2X2;
+					case "mat2x3": arrLength > 0 ? MATRIX2X3V : MATRIX2X3;
+					case "mat2x4": arrLength > 0 ? MATRIX2X4V : MATRIX2X4;
+					case "mat3x2": arrLength > 0 ? MATRIX3X2V : MATRIX3X2;
+					case "mat3", "mat3x3": arrLength > 0 ? MATRIX3X3V : MATRIX3X3;
+					case "mat3x4": arrLength > 0 ? MATRIX3X4V : MATRIX3X4;
+					case "mat4x2": arrLength > 0 ? MATRIX4X2V : MATRIX4X2;
+					case "mat4x3": arrLength > 0 ? MATRIX4X3V : MATRIX4X3;
+					case "mat4", "mat4x4": arrLength > 0 ? MATRIX4X4V : MATRIX4X4;
 					default: null;
 				}
 


### PR DESCRIPTION
basically adds support to uniform float, int, vec, ivec, mat and bool arrays
and an extra variable so the user can specify what shader version they would like to use