### PR TITLE
replace deprecated `apple-mobile-web-app-capable` with `mobile-web-app-capable`

### DIFF
--- a/assets/templates/html5/template/index.html
+++ b/assets/templates/html5/template/index.html
@@ -7,7 +7,7 @@
 	<title>::APP_TITLE::</title>
 	
 	<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="mobile-web-app-capable" content="yes">
 	
 	::if favicons::::foreach (favicons)::
 	<link rel="::__current__.rel::" type="::__current__.type::" href="::__current__.href::">::end::::end::


### PR DESCRIPTION
chrome tosses a deprecation warning about this
<img width="773" height="69" alt="image" src="https://github.com/user-attachments/assets/4abba68f-4618-4c4f-b191-4242f08143f5" />

and from some reading from [flutter](https://github.com/flutter/flutter/issues/154596) and [next.js](https://github.com/vercel/next.js/issues/70272) it seems like `mobile-web-app-capable` works just fine across browsers. 

So this shouldn't have drastic repercussions just merely removing a deprecation warning in the template!