### PR TITLE
Add DatagramSocket broadcast capabilities for supported targets (cpp and neko).

### DIFF
--- a/src/openfl/net/DatagramSocket.hx
+++ b/src/openfl/net/DatagramSocket.hx
@@ -378,17 +378,17 @@ class DatagramSocket extends EventDispatcher
 			
 			if(isEphemeral){
 				socket = new DatagramSocket();
-				socket.bind(new Host(localAddress), 0);
+				socket.bind(address);
 			}
 			
-			socket.setBroadcast(true);			
+			socket.__udpSocket.setBroadcast(true);			
 
 			//TODO: allow reuse if not ephemeral
 			var broadcastAddress = new Address();
 			broadcastAddress.host = new Host(address).ip;
 			broadcastAddress.port = port;
 
-			socket.sendTo(cast bytes, offset, actualLength, broadcastAddress);
+			socket.__udpSocket.sendTo(cast bytes, offset, actualLength, broadcastAddress);
 			
 			if(isEphemeral) {
 				socket.close();

--- a/src/openfl/net/DatagramSocket.hx
+++ b/src/openfl/net/DatagramSocket.hx
@@ -347,7 +347,7 @@ class DatagramSocket extends EventDispatcher
 		@throws RangeError The port is not between 1 and 65535, inclusive,
 			or the offset or length are outside the bounds of the bytes array.
 	**/
-	public static inline function broadcast(socket:DatagramSocket, bytes:ByteArray, offset:UInt = 0, length:UInt = 0, address:String = "255.255.255.255", port:Int = 0):Void
+	public static inline function broadcast(socket:DatagramSocket = null, bytes:ByteArray, offset:UInt = 0, length:UInt = 0, address:String = "255.255.255.255", port:Int = 0):Void
 	{
         #if (cpp || neko)
 		if (bytes == null)
@@ -374,17 +374,25 @@ class DatagramSocket extends EventDispatcher
 
 		try
 		{
-			socket.setBroadcast(true);
+			var isEphemeral:Bool = socket == null;
+			
+			if(isEphemeral){
+				socket = new DatagramSocket();
+				socket.bind(new Host(localAddress), 0);
+			}
+			
+			socket.setBroadcast(true);			
 
-			socket.bind(new Host(localAddress), 0);
-
-			// Set up the destination broadcast address
+			//TODO: allow reuse if not ephemeral
 			var broadcastAddress = new Address();
 			broadcastAddress.host = new Host(address).ip;
 			broadcastAddress.port = port;
 
 			socket.sendTo(cast bytes, offset, actualLength, broadcastAddress);
-			socket.close();
+			
+			if(isEphemeral) {
+				socket.close();
+			}
 		}
 		catch (e:Dynamic)
 		{

--- a/src/openfl/net/DatagramSocket.hx
+++ b/src/openfl/net/DatagramSocket.hx
@@ -3,6 +3,7 @@ package openfl.net;
 #if (!flash && !html5)
 import haxe.io.Bytes;
 import haxe.io.Error;
+import openfl.errors.Error as OFLError;
 import openfl.errors.ArgumentError;
 import openfl.errors.IOError;
 import openfl.errors.IllegalOperationError;
@@ -396,10 +397,10 @@ class DatagramSocket extends EventDispatcher
 		}
 		catch (e:Dynamic)
 		{
-			throw new Error("Failed to broadcast datagram: " + e);
+			throw new IOError("Failed to broadcast datagram: " + e);
 		}
 		#else
-		throw new Error("Broadcast not supported on this platform");
+		throw new OFLError("Broadcast not supported on this platform");
 		#end
 	}
 

--- a/tests/socket/src/DatagramSocketTest.hx
+++ b/tests/socket/src/DatagramSocketTest.hx
@@ -4,6 +4,8 @@ import openfl.events.DatagramSocketDataEvent;
 import openfl.net.DatagramSocket;
 #if (sys || air)
 	import openfl.utils.ByteArray;
+	import openfl.errors.ArgumentError;
+	import openfl.errors.IllegalOperationError;
 #end
 import utest.Assert;
 import utest.Async;
@@ -113,6 +115,158 @@ class DatagramSocketTest extends Test
 		sockA.send(aBytes, 0, 0, sockB.localAddress, sockB.localPort);
 		sockB.send(bBytes, 0, 0, sockA.localAddress, sockA.localPort);
 	}
+
+	public function test_enableBroadcast_defaultValue()
+	{
+		sockA = makeSocket();
+		Assert.isFalse(sockA.enableBroadcast);
+	}
+
+	#if (cpp || neko)
+	public function test_enableBroadcast_setter()
+	{
+		sockA = makeSocket();
+		
+		// Should not throw on supported platforms
+		sockA.enableBroadcast = true;
+		Assert.isTrue(sockA.enableBroadcast);
+		
+		sockA.enableBroadcast = false;
+		Assert.isFalse(sockA.enableBroadcast);
+	}
+
+	public function test_broadcastSend_requiresEnableBroadcast()
+	{
+		sockA = makeSocket();
+		var bytes = new ByteArray();
+		bytes.writeUTFBytes("BROADCAST");
+		
+		// Should throw error when trying to send to broadcast without enabling it
+		var caught = false;
+		try
+		{
+			sockA.send(bytes, 0, 0, "255.255.255.255", 9999);
+		}
+		catch (e:ArgumentError)
+		{
+			caught = true;
+			Assert.isTrue(e.message.indexOf("broadcast") > -1);
+		}
+		Assert.isTrue(caught);
+	}
+
+	public function test_broadcastSend_withEnableBroadcast()
+	{
+		sockA = makeSocket();
+		sockA.enableBroadcast = true;
+		
+		var bytes = new ByteArray();
+		bytes.writeUTFBytes("BROADCAST");
+		
+		// Should not throw when broadcast is enabled (though packet may not be delivered)
+		// We can't easily test actual broadcast reception in unit tests
+		try
+		{
+			sockA.send(bytes, 0, 0, "255.255.255.255", 9999);
+			Assert.pass();
+		}
+		catch (e:Dynamic)
+		{
+			// Some systems may not allow broadcast even when enabled
+			// This is acceptable as long as we don't get our validation error
+			if (Std.isOfType(e, ArgumentError) && e.message.indexOf("broadcast") > -1)
+			{
+				Assert.fail("Should not get broadcast validation error when broadcast is enabled");
+			}
+		}
+	}
+
+	public function test_broadcastAddressDetection()
+	{
+		sockA = makeSocket();
+		var bytes = new ByteArray();
+		bytes.writeUTFBytes("TEST");
+		
+		// Test various broadcast addresses
+		var broadcastAddresses = ["255.255.255.255", "192.168.1.255", "10.0.0.255"];
+		
+		for (addr in broadcastAddresses)
+		{
+			var caught = false;
+			try
+			{
+				sockA.send(bytes, 0, 0, addr, 9999);
+			}
+			catch (e:ArgumentError)
+			{
+				caught = true;
+				Assert.isTrue(e.message.indexOf("broadcast") > -1);
+			}
+			Assert.isTrue(caught, 'Should detect $addr as broadcast address');
+		}
+	}
+
+	public function test_regularSend_stillWorks()
+	{
+		sockA = makeSocket();
+		sockB = makeSocket();
+		
+		// Enable broadcast on A but send to regular address
+		sockA.enableBroadcast = true;
+		
+		var bytes = new ByteArray();
+		bytes.writeUTFBytes("REGULAR");
+		
+		// Should work normally
+		try
+		{
+			sockA.send(bytes, 0, 0, sockB.localAddress, sockB.localPort);
+			Assert.pass();
+		}
+		catch (e:Dynamic)
+		{
+			Assert.fail("Regular send should work when broadcast is enabled");
+		}
+	}
+	#else
+	public function test_enableBroadcast_unsupportedPlatform()
+	{
+		sockA = makeSocket();
+		
+		// Should throw error on unsupported platforms
+		var caught = false;
+		try
+		{
+			sockA.enableBroadcast = true;
+		}
+		catch (e:IllegalOperationError)
+		{
+			caught = true;
+			Assert.isTrue(e.message.indexOf("not supported") > -1);
+		}
+		Assert.isTrue(caught);
+	}
+
+	public function test_broadcastSend_unsupportedPlatform()
+	{
+		sockA = makeSocket();
+		var bytes = new ByteArray();
+		bytes.writeUTFBytes("BROADCAST");
+		
+		// Should throw error when trying to send to broadcast on unsupported platform
+		var caught = false;
+		try
+		{
+			sockA.send(bytes, 0, 0, "255.255.255.255", 9999);
+		}
+		catch (e:IllegalOperationError)
+		{
+			caught = true;
+			Assert.isTrue(e.message.indexOf("not supported") > -1);
+		}
+		Assert.isTrue(caught);
+	}
+	#end
 
 	#else
 	/*  Non-sys targets (html5, mobile) – DatagramSocket unavailable. */


### PR DESCRIPTION
Currently, OpenFL's `DatagramSocket` does not support sending UDP broadcast packets. However, the underlying Haxe `sys.net.UdpSocket`, in my testing, is able to support broadcast for limited number of targets, such as cpp and neko.  HashLink currently does not support it.

This patch adds OpenFL DatagramSocket broadcast capabilities for cpp and neko targets.  Exposing this functionality will enable devs to send broadcast packets (e.g., for LAN discovery, multiplayer games, etc.) with a standard OpenFL API.  I'm needing it for Art-Net node discovery, and Art-Net DMX broadcast purposes.

## Usage ##

In this patch, broadcast is not enabled by default.  A user can enable broadcasts for supported targets by:
```haxe
socket.enableBroadcast = true;
```

A broadcast is made using the existing API, but specifying a destination address of `"255.255.255.255"`. eg:
```haxe
socket.send(bytes, 0, bytes.length, "255.255.255.255", port);
```

## Error handling and tests ##

A useful error will be thrown for non-supported targets (not cpp/neko).
> UDP broadcast is not supported on this platform. Supported platforms: cpp, neko

A useful error is also thrown if one attempts broadcast without enabling it:
> Cannot send to broadcast address. Set enableBroadcast to true first.

Unit tests have been provided and tested.
`tests/socket/src/DatagramSocketTest.hx`

## My dev system ##
Arch based Linux
Haxe 4.3.7
OpenFL git develop current
Lime git develop current

## Targets tested ##
- **cpp**: Supported.
- **neko**: Supported.
- **HashLink**: Not supported
- **others**: Untested (but presumed unsupported)