### PR TITLE
Use `gl.bufferSubData()` to update existing buffers.

### DIFF
--- a/src/openfl/display3D/IndexBuffer3D.hx
+++ b/src/openfl/display3D/IndexBuffer3D.hx
@@ -30,7 +30,7 @@ import openfl.Vector;
 {
 	@:noCompletion private var __context:Context3D;
 	@:noCompletion private var __id:GLBuffer;
-	@:noCompletion private var __memoryUsage:Int;
+	@:noCompletion private var __memoryUsage:Int = -1;
 	@:noCompletion private var __numIndices:Int;
 	@:noCompletion private var __tempUInt16Array:UInt16Array;
 	@:noCompletion private var __usage:Int;
@@ -96,7 +96,11 @@ import openfl.Vector;
 		if (data == null) return;
 		var gl = __context.gl;
 		__context.__bindGLElementArrayBuffer(__id);
-		gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, data, __usage);
+		if (__memoryUsage == data.byteLength)
+			gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0, data);
+		else
+			gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, data, __usage);
+		__memoryUsage = data.byteLength;
 	}
 
 	/**

--- a/src/openfl/display3D/VertexBuffer3D.hx
+++ b/src/openfl/display3D/VertexBuffer3D.hx
@@ -54,7 +54,7 @@ class VertexBuffer3D
 	@:noCompletion private var __context:Context3D;
 	@:noCompletion private var __data:Vector<Float>;
 	@:noCompletion private var __id:GLBuffer;
-	@:noCompletion private var __memoryUsage:Int;
+	@:noCompletion private var __memoryUsage:Int = -1;
 	@:noCompletion private var __numVertices:Int;
 	@:noCompletion private var __stride:Int;
 	@:noCompletion private var __tempFloat32Array:Float32Array;
@@ -129,7 +129,11 @@ class VertexBuffer3D
 		var gl = __context.gl;
 
 		__context.__bindGLArrayBuffer(__id);
-		gl.bufferData(gl.ARRAY_BUFFER, data, __usage);
+		if (__memoryUsage == data.byteLength)
+			gl.bufferSubData(gl.ARRAY_BUFFER, 0, data);
+		else
+			gl.bufferData(gl.ARRAY_BUFFER, data, __usage);
+		__memoryUsage = data.byteLength;
 	}
 
 	/**


### PR DESCRIPTION
Using `gl.bufferData()` deletes the old buffer and allocates a new one, which isn't necessary if the length stayed the same.