### PR TITLE
Fix Bubbles Default Events for openfl_pool_events

### DIFF
--- a/src/openfl/events/GameInputEvent.hx
+++ b/src/openfl/events/GameInputEvent.hx
@@ -60,6 +60,7 @@ import openfl.ui.GameInputDevice;
 	@:noCompletion private override function __init():Void
 	{
 		super.__init();
+		bubbles = true;
 		device = null;
 	}
 }

--- a/src/openfl/events/MouseEvent.hx
+++ b/src/openfl/events/MouseEvent.hx
@@ -720,10 +720,10 @@ class MouseEvent extends Event
 	@:noCompletion private override function __init():Void
 	{
 		super.__init();
+		bubbles = true;
 		shiftKey = false;
 		altKey = false;
 		ctrlKey = false;
-		bubbles = false;
 		relatedObject = null;
 		delta = 0;
 		localX = 0;

--- a/src/openfl/events/TouchEvent.hx
+++ b/src/openfl/events/TouchEvent.hx
@@ -533,6 +533,7 @@ class TouchEvent extends Event
 	@:noCompletion private override function __init():Void
 	{
 		super.__init();
+		bubbles = true;
 		touchPointID = 0;
 		isPrimaryTouchPoint = false;
 		localX = 0;

--- a/src/openfl/events/UncaughtErrorEvent.hx
+++ b/src/openfl/events/UncaughtErrorEvent.hx
@@ -198,6 +198,8 @@ class UncaughtErrorEvent extends ErrorEvent
 	@:noCompletion private override function __init():Void
 	{
 		super.__init();
+		bubbles = true;
+		cancelable = true;
 		error = null;
 	}
 }


### PR DESCRIPTION
Fixes events with bubbles true default not dispatching such as MouseEvent.MOUSE_UP for TextField not being dispatched for the last object stack