### PR TITLE
Fix color transform overlay on graphic triangles.

### DIFF
--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -749,8 +749,8 @@ class Context3DGraphics
 								renderer.__setShaderBuffer(shaderBuffer);
 								renderer.applyMatrix(uMatrix);
 								renderer.applyBitmapData(bitmap, false, repeat);
-								renderer.applyAlpha(1);
-								renderer.applyColorTransform(null);
+								renderer.applyAlpha(graphics.__owner.__worldAlpha);
+								renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
 								renderer.__updateShaderBuffer(shaderBufferOffset);
 							}
 							else


### PR DESCRIPTION
This bug occurs when drawing triangles on `Graphics` using a shader that for some reason does not accept the parent sprite's color transform, although with drawTiles it always does.
https://github.com/openfl/openfl/blob/69ddfc6ba6266f231a9fd98083ca6e3cd017b27a/src/openfl/display/_internal/Context3DGraphics.hx#L752-L753

# Example code:
```haxe
import openfl.Vector;
import openfl.display.BitmapData;
import openfl.display.GraphicsShader;
import openfl.display.Sprite;

class Main
{
	public static function main()
	{
		// refs
		var stage = openfl.Lib.current.stage;
		var width = 640;
		var height = 480;

		// create Sprite
		var spr = new Sprite();
		stage.addChild(spr);

		// left side shader method
		var shader = new GraphicsShader();
		shader.data.bitmap.input = new BitmapData(1, 1, true, 0xFFFFFFFF);
		spr.graphics.beginShaderFill(shader);
		spr.graphics.drawTriangles(new Vector(0, false, [
			0.0,		0.0,
			width / 2,	0.0,
			0.0,		height
		]));
		spr.graphics.endFill();

		// right side bitmapdata method
		spr.graphics.beginBitmapFill(new BitmapData(1, 1, true, 0xFFFFFFFF));
		spr.graphics.drawTriangles(new Vector(0, false, [
			width,		0.0,
			width / 2,	0.0,
			width,		height
		]));
		spr.graphics.endFill();

		var transform = spr.transform;
		var coltransform = transform.colorTransform;

		// paint the sprite light red
		coltransform.greenMultiplier = coltransform.blueMultiplier = 0.5;

		// apply color
		transform.colorTransform = coltransform;
		spr.transform = transform;

		// transparent
		spr.alpha = 0.8;

		// expect two transparent light red triangles
	}
}
```
BEFORE | AFTER
--------|------
<img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/9b0fc339-4576-4c8c-ab3e-9f8da7ba8f89" /> | <img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/c7591f82-16f7-41a8-9f86-b68679c37aa1" />

