### PR TITLE
Fix Haxe 5 Compatibility

### DIFF
--- a/src/openfl/utils/Dictionary.hx
+++ b/src/openfl/utils/Dictionary.hx
@@ -241,6 +241,12 @@ abstract Dictionary<K, V>(IMap<K, V>)
 		return types.exists(Type.getClassName(key));
 	}
 
+	#if haxe5
+	public function size():Int {
+		return types.size();
+	}
+	#end
+
 	public function get(key:K):Null<V>
 	{
 		return values.get(Type.getClassName(key));
@@ -321,6 +327,12 @@ abstract Dictionary<K, V>(IMap<K, V>)
 	{
 		return indexOf(key) > -1;
 	}
+
+	#if haxe5
+	public function size():Int {
+		return floatKeys.length;
+	}
+	#end
 
 	public function get(key:K):Null<V>
 	{
@@ -503,6 +515,12 @@ abstract Dictionary<K, V>(IMap<K, V>)
 	{
 		return map.exists(cast key);
 	}
+
+	#if haxe5
+	public function size():Int {
+		return map.size();
+	}
+	#end
 
 	public function get(key:K):Null<V>
 	{


### PR DESCRIPTION
Due to the `IMap` interface being updated in Haxe 5 (https://github.com/HaxeFoundation/haxe/pull/11961), a new `size` function is needed.