### PR TITLE
Issue fix: https://github.com/openfl/lime/issues/1983 (runtime pixel ratio check)

### DIFF
--- a/assets/templates/html5/template/index.html
+++ b/assets/templates/html5/template/index.html
@@ -25,8 +25,8 @@
 	</script>
 	
 	<style>
-		html,body { outline: none; margin: 0; padding: 0; height: 100%; overflow: hidden; }
-		#openfl-content { outline: none; ::if (WIN_BACKGROUND)::background: #000000; ::end::width: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_WIDTH::px::else::100%::end::; height: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_HEIGHT::px::else::100%::end::; }
+		html,body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+		#openfl-content { ::if (WIN_BACKGROUND)::background: #000000; ::end::width: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_WIDTH::px::else::100%::end::; height: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_HEIGHT::px::else::100%::end::; }
 ::foreach assets::::if (type == "font")::::if (cssFontFace)::::cssFontFace::::else::
 		@font-face {
 			font-family: '::fontName::';

--- a/assets/templates/html5/template/index.html
+++ b/assets/templates/html5/template/index.html
@@ -25,8 +25,8 @@
 	</script>
 	
 	<style>
-		html,body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
-		#openfl-content { ::if (WIN_BACKGROUND)::background: #000000; ::end::width: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_WIDTH::px::else::100%::end::; height: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_HEIGHT::px::else::100%::end::; }
+		html,body { outline: none; margin: 0; padding: 0; height: 100%; overflow: hidden; }
+		#openfl-content { outline: none; ::if (WIN_BACKGROUND)::background: #000000; ::end::width: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_WIDTH::px::else::100%::end::; height: ::if (WIN_RESIZABLE)::100%::elseif (WIN_WIDTH > 0)::::WIN_HEIGHT::px::else::100%::end::; }
 ::foreach assets::::if (type == "font")::::if (cssFontFace)::::cssFontFace::::else::
 		@font-face {
 			font-family: '::fontName::';

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1202,8 +1202,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	@:noCompletion private function __createRenderer():Void
 	{
 		#if lime
-		var windowWidth = Math.ceil(window.width * window.scale);
-		var windowHeight = Math.ceil(window.height * window.scale);
+		var windowWidth = Std.int(window.width * window.scale);
+		var windowHeight = Std.int(window.height * window.scale);
 
 		switch (window.context.type)
 		{
@@ -3277,8 +3277,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		var cacheWidth = stageWidth;
 		var cacheHeight = stageHeight;
 
-		var windowWidth = Math.ceil(window.width * window.scale);
-		var windowHeight = Math.ceil(window.height * window.scale);
+		var windowWidth = Std.int(window.width * window.scale);
+		var windowHeight = Std.int(window.height * window.scale);
 
 		__displayMatrix.identity();
 
@@ -3307,8 +3307,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				stageWidth = windowWidth;
 				stageHeight = windowHeight;
 				#else
-				stageWidth = Math.ceil(windowWidth / window.scale);
-				stageHeight = Math.ceil(windowHeight / window.scale);
+				stageWidth = Math.round(windowWidth / window.scale);
+				stageHeight = Math.round(windowHeight / window.scale);
 
 				__displayMatrix.scale(window.scale, window.scale);
 				#end
@@ -3338,10 +3338,10 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						var scaledWidth = stageWidth * scale;
 						var scaledHeight = stageHeight * scale;
 
-						var visibleWidth = stageWidth - Math.floor((scaledWidth - windowWidth) / scale);
-						var visibleHeight = stageHeight - Math.floor((scaledHeight - windowHeight) / scale);
-						var visibleX = Math.floor((stageWidth - visibleWidth) / 2);
-						var visibleY = Math.floor((stageHeight - visibleHeight) / 2);
+						var visibleWidth = stageWidth - Math.round((scaledWidth - windowWidth) / scale);
+						var visibleHeight = stageHeight - Math.round((scaledHeight - windowHeight) / scale);
+						var visibleX = Math.round((stageWidth - visibleWidth) / 2);
+						var visibleY = Math.round((stageHeight - visibleHeight) / 2);
 
 						__displayMatrix.translate(-visibleX, -visibleY);
 						__displayMatrix.scale(scale, scale);
@@ -3358,10 +3358,10 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						var scaledWidth = stageWidth * scale;
 						var scaledHeight = stageHeight * scale;
 
-						var visibleWidth = stageWidth - Math.floor((scaledWidth - windowWidth) / scale);
-						var visibleHeight = stageHeight - Math.floor((scaledHeight - windowHeight) / scale);
-						var visibleX = Math.floor((stageWidth - visibleWidth) / 2);
-						var visibleY = Math.floor((stageHeight - visibleHeight) / 2);
+						var visibleWidth = stageWidth - Math.round((scaledWidth - windowWidth) / scale);
+						var visibleHeight = stageHeight - Math.round((scaledHeight - windowHeight) / scale);
+						var visibleX = Math.round((stageWidth - visibleWidth) / 2);
+						var visibleY = Math.round((stageHeight - visibleHeight) / 2);
 
 						__displayMatrix.translate(-visibleX, -visibleY);
 						__displayMatrix.scale(scale, scale);

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1202,8 +1202,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 	@:noCompletion private function __createRenderer():Void
 	{
 		#if lime
-		var windowWidth = Std.int(window.width * window.scale);
-		var windowHeight = Std.int(window.height * window.scale);
+		var windowWidth = Math.ceil(window.width * window.scale);
+		var windowHeight = Math.ceil(window.height * window.scale);
 
 		switch (window.context.type)
 		{
@@ -3277,8 +3277,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		var cacheWidth = stageWidth;
 		var cacheHeight = stageHeight;
 
-		var windowWidth = Std.int(window.width * window.scale);
-		var windowHeight = Std.int(window.height * window.scale);
+		var windowWidth = Math.ceil(window.width * window.scale);
+		var windowHeight = Math.ceil(window.height * window.scale);
 
 		__displayMatrix.identity();
 
@@ -3307,8 +3307,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 				stageWidth = windowWidth;
 				stageHeight = windowHeight;
 				#else
-				stageWidth = Math.round(windowWidth / window.scale);
-				stageHeight = Math.round(windowHeight / window.scale);
+				stageWidth = Math.ceil(windowWidth / window.scale);
+				stageHeight = Math.ceil(windowHeight / window.scale);
 
 				__displayMatrix.scale(window.scale, window.scale);
 				#end
@@ -3338,10 +3338,10 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						var scaledWidth = stageWidth * scale;
 						var scaledHeight = stageHeight * scale;
 
-						var visibleWidth = stageWidth - Math.round((scaledWidth - windowWidth) / scale);
-						var visibleHeight = stageHeight - Math.round((scaledHeight - windowHeight) / scale);
-						var visibleX = Math.round((stageWidth - visibleWidth) / 2);
-						var visibleY = Math.round((stageHeight - visibleHeight) / 2);
+						var visibleWidth = stageWidth - Math.floor((scaledWidth - windowWidth) / scale);
+						var visibleHeight = stageHeight - Math.floor((scaledHeight - windowHeight) / scale);
+						var visibleX = Math.floor((stageWidth - visibleWidth) / 2);
+						var visibleY = Math.floor((stageHeight - visibleHeight) / 2);
 
 						__displayMatrix.translate(-visibleX, -visibleY);
 						__displayMatrix.scale(scale, scale);
@@ -3358,10 +3358,10 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 						var scaledWidth = stageWidth * scale;
 						var scaledHeight = stageHeight * scale;
 
-						var visibleWidth = stageWidth - Math.round((scaledWidth - windowWidth) / scale);
-						var visibleHeight = stageHeight - Math.round((scaledHeight - windowHeight) / scale);
-						var visibleX = Math.round((stageWidth - visibleWidth) / 2);
-						var visibleY = Math.round((stageHeight - visibleHeight) / 2);
+						var visibleWidth = stageWidth - Math.floor((scaledWidth - windowWidth) / scale);
+						var visibleHeight = stageHeight - Math.floor((scaledHeight - windowHeight) / scale);
+						var visibleX = Math.floor((stageWidth - visibleWidth) / 2);
+						var visibleY = Math.floor((stageHeight - visibleHeight) / 2);
 
 						__displayMatrix.translate(-visibleX, -visibleY);
 						__displayMatrix.scale(scale, scale);

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -3268,6 +3268,12 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 	@:noCompletion private function __resize():Void
 	{
+
+		if (__renderer != null)
+		{
+			__renderer.__pixelRatio = #if openfl_disable_hdpi 1 #else window.scale #end;
+		}
+
 		var cacheWidth = stageWidth;
 		var cacheHeight = stageHeight;
 


### PR DESCRIPTION
The __renderer's pixel ratio is currently set only once in Stage.hx constructor, but it may change in runtime and the renderer should update its __pixelRatio accordingly.

See details here: https://github.com/openfl/lime/issues/1983