### PR TITLE
Assets: mark hardware-only BitmapData as valid

### DIFF
--- a/src/openfl/utils/Assets.hx
+++ b/src/openfl/utils/Assets.hx
@@ -483,7 +483,7 @@ class Assets
 			return false;
 		}
 		#else
-		return (bitmapData != null && #if !lime_hybrid bitmapData.image != null #else bitmapData.__handle != null #end);
+		return (bitmapData != null && #if !lime_hybrid bitmapData.image != null || (!bitmapData.readable && bitmapData.__texture != null) #else bitmapData.__handle != null #end);
 		#end
 		#else
 		return true;


### PR DESCRIPTION
To determine if a `BitmapData` instance is valid, `isValidBitmapData()` only checked to see if `bitmapData.image` wasn't null. This means that bitmaps that have had `disposeImage()` called on them were incorrectly marked as invalid because they got rid of the image buffer but kept the hardware texture.