### PR TITLE
Fallback to regular sound if audio streaming isn't supported

### DIFF
--- a/src/openfl/utils/Assets.hx
+++ b/src/openfl/utils/Assets.hx
@@ -279,10 +279,17 @@ class Assets
 	{
 		#if (lime_vorbis && lime > "7.9.0")
 		var path = getPath(id);
-		// TODO: What if it is a WAV or non-Vorbis file?
 		var vorbisFile = VorbisFile.fromFile(path);
-		var buffer = AudioBuffer.fromVorbisFile(vorbisFile);
-		return Sound.fromAudioBuffer(buffer);
+		if (vorbisFile != null)
+		{
+			var buffer = AudioBuffer.fromVorbisFile(vorbisFile);
+			return Sound.fromAudioBuffer(buffer);
+		}
+		else
+		{
+			// TODO: Streaming sound
+			return getSound(id, useCache);
+		}
 		#else
 		// TODO: Streaming sound
 		return getSound(id, useCache);


### PR DESCRIPTION
When running on a platform with `lime_vorbis` enabled, `Assets.getMusic()` always attempted to stream the music using VorbisFile. However, trying to play something like a WAV resulted in nothing because `Assets.getMusic()` always assumed Vorbis was used