### PR TITLE
NetStream: Fix video element event listener type

### DIFF
--- a/src/openfl/net/NetStream.hx
+++ b/src/openfl/net/NetStream.hx
@@ -1208,7 +1208,7 @@ class NetStream extends EventDispatcher
 		__video.addEventListener("timeupdate", video_onTimeUpdate, false);
 		__video.addEventListener("loadstart", video_onLoadStart, false);
 		__video.addEventListener("stalled", video_onStalled, false);
-		__video.addEventListener("durationchanged", video_onDurationChanged, false);
+		__video.addEventListener("durationchange", video_onDurationChange, false);
 		__video.addEventListener("canplay", video_onCanPlay, false);
 		__video.addEventListener("canplaythrough", video_onCanPlayThrough, false);
 		__video.addEventListener("loadedmetadata", video_onLoadMetaData, false);
@@ -2129,7 +2129,7 @@ class NetStream extends EventDispatcher
 		__playStatus("NetStream.Play.canplaythrough");
 	}
 
-	@:noCompletion private function video_onDurationChanged(event:Dynamic):Void
+	@:noCompletion private function video_onDurationChange(event:Dynamic):Void
 	{
 		__playStatus("NetStream.Play.durationchanged");
 	}

--- a/src/openfl/net/NetStream.hx
+++ b/src/openfl/net/NetStream.hx
@@ -2131,7 +2131,7 @@ class NetStream extends EventDispatcher
 
 	@:noCompletion private function video_onDurationChange(event:Dynamic):Void
 	{
-		__playStatus("NetStream.Play.durationchanged");
+		__playStatus("NetStream.Play.durationchange");
 	}
 
 	@:noCompletion private function video_onEnd(event:Dynamic):Void


### PR DESCRIPTION
Change event listener type of the video element from "durationchanged" to "durationchange" to actually capture the event,
and change the listener method name accordingly.
see: [MDN#HTMLMediaElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/durationchange_event)