### PR TITLE
Use numeric setTransform for broader browser compatibility

### DIFF
--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -364,7 +364,7 @@ class CanvasGraphics
 				var untransformedPath:Path2D = cast new Path2D();
 				untransformedPath.addPath(path, inverseMatrix);
 				context2.fillStyle = gradientFill;
-				context2.setTransform(gradientMatrix);
+				context2.setTransform(gradientMatrix.a, gradientMatrix.b, gradientMatrix.c, gradientMatrix.d, gradientMatrix.e, gradientMatrix.f);
 				context2.fill(untransformedPath);
 				return cast context.createPattern(canvas, 'no-repeat');
 		}


### PR DESCRIPTION
[`context2.setTransform(matrix)`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setTransform) uses the [`DOMMatrix`](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrix) overload that older browsers **don’t support**. This was the only use of that overload in the codebase.

### Why
1. **Compatibility.** `setTransform(a, b, c, d, e, f)` is widely supported; the object overload is not.
2. **Consistency.** Matches all other call sites in the codebase.

### Impact
1. No functional change — identical matrix values are applied.
2. Broader browser compatibility.


**For additional context:** this isn’t a theoretical cleanup. Sentry has been capturing real production exceptions from legacy browsers (not so much but anyway) where the single-argument setTransform(matrix) overload isn’t available. The stack traces point to this exact call site. After switching to the numeric form, the errors dropped to zero.

`Uncaught TypeError: Failed to execute 'setTransform' on 'CanvasRenderingContext2D': 6 arguments required, but only 1 present.`