### PR TITLE
Fix GL color transforms: apply world multipliers correctly

### DIFF
--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -760,10 +760,7 @@ class Context3DGraphics
 							renderer.applyBitmapData(blankBitmapData, true, repeat);
 							#if lime
 							var color:ARGB = (fill : ARGB);
-							tempColorTransform.redOffset = color.r;
-							tempColorTransform.greenOffset = color.g;
-							tempColorTransform.blueOffset = color.b;
-							tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
+							tempColorTransform.__setBaseColorTransform(color, graphics.__owner.__worldColorTransform);
 							renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
 							renderer.applyColorTransform(tempColorTransform);
 							#else
@@ -921,10 +918,7 @@ class Context3DGraphics
 									renderer.applyBitmapData(blankBitmapData, true, repeat);
 									#if lime
 									var color:ARGB = (fill : ARGB);
-									tempColorTransform.redOffset = color.r;
-									tempColorTransform.greenOffset = color.g;
-									tempColorTransform.blueOffset = color.b;
-									tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
+									tempColorTransform.__setBaseColorTransform(color, graphics.__owner.__worldColorTransform);
 									renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
 									renderer.applyColorTransform(tempColorTransform);
 									#else
@@ -1036,10 +1030,7 @@ class Context3DGraphics
 								renderer.applyBitmapData(blankBitmapData, true, repeat);
 								#if lime
 								var color:ARGB = (fill : ARGB);
-								tempColorTransform.redOffset = color.r;
-								tempColorTransform.greenOffset = color.g;
-								tempColorTransform.blueOffset = color.b;
-								tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
+								tempColorTransform.__setBaseColorTransform(color, graphics.__owner.__worldColorTransform);
 								renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
 								renderer.applyColorTransform(tempColorTransform);
 								#else

--- a/src/openfl/geom/ColorTransform.hx
+++ b/src/openfl/geom/ColorTransform.hx
@@ -4,6 +4,7 @@ package openfl.geom;
 import openfl.utils.ObjectPool;
 #if lime
 import openfl.utils._internal.Float32Array;
+import lime.math.ARGB;
 import lime.math.ColorMatrix;
 #end
 
@@ -242,6 +243,19 @@ class ColorTransform
 		greenOffset += ct.greenOffset;
 		blueOffset += ct.blueOffset;
 		alphaOffset += ct.alphaOffset;
+	}
+
+	@:noCompletion private function __setBaseColorTransform(fill:ARGB, world:ColorTransform):Void
+	{
+		redMultiplier = world.redMultiplier;
+		greenMultiplier = world.greenMultiplier;
+		blueMultiplier = world.blueMultiplier;
+		alphaMultiplier = world.alphaMultiplier;
+
+		redOffset = fill.r * world.redMultiplier + world.redOffset;
+		greenOffset = fill.g * world.greenMultiplier + world.greenOffset;
+		blueOffset = fill.b * world.blueMultiplier + world.blueOffset;
+		alphaOffset = fill.a * world.alphaMultiplier + world.alphaOffset;
 	}
 
 	@:noCompletion private function __identity():Void


### PR DESCRIPTION
ColorTransform multipliers were being ignored when drawing primitives in the GL Renderer.
I think this fixes it.

https://github.com/openfl/openfl/issues/2812