### PR TITLE
Fix: BitmapData.draw negative scaling

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -1979,8 +1979,8 @@ import js.html.CanvasRenderingContext2D;
 		}
 		#end
 
-		var width = __bounds.width * scaleX;
-		var height = __bounds.height * scaleY;
+		var width = Math.abs(__bounds.width * scaleX);
+		var height = Math.abs(__bounds.height * scaleY);
 
 		if (width < 1 || height < 1)
 		{


### PR DESCRIPTION
A very simple fix for drawing display objects to bitmap data with a matrix with negative a or d values for non-flash targets.

https://github.com/openfl/openfl/issues/2810