### PR TITLE
CairoGraphics: Respect renderer's smoothing

### DIFF
--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -732,7 +732,7 @@ class CairoGraphics
 		var setStart = false;
 
 		cairo.fillRule = EVEN_ODD;
-		cairo.antialias = SUBPIXEL;
+		setSmoothing(true);
 
 		var hasPath:Bool = false;
 
@@ -1446,7 +1446,7 @@ class CairoGraphics
 					var t1:Float, t2:Float, t3:Float, t4:Float;
 					var dx:Float, dy:Float;
 
-					cairo.antialias = NONE;
+					setSmoothing(false);
 
 					while (i < l)
 					{
@@ -2253,6 +2253,18 @@ class CairoGraphics
 		}
 		#end
 	}
+
+	#if lime_cairo
+	private static function setSmoothing(smooth:Bool):Void
+	{
+		if (!allowSmoothing)
+		{
+			smooth = false;
+		}
+
+		cairo.antialias = smooth ? SUBPIXEL : NONE;
+	}
+	#end
 }
 
 private typedef NormalizedUVT =


### PR DESCRIPTION
Just like `CanvasGraphics`, adds a `setSmoothing()` function to `CairoGraphics` which disables smoothing if the renderer doesn't allow it. This fixes an issue where drawing a shape onto a bitmap resulted in a smoothed drawing regardless of whether the smoothing argument was true or not.