### PR TITLE
Allow music streaming on HTML5

### DIFF
--- a/src/openfl/utils/Assets.hx
+++ b/src/openfl/utils/Assets.hx
@@ -1,5 +1,6 @@
 package openfl.utils;
 
+import lime.media.AudioBuffer;
 import openfl.utils._internal.Log;
 import openfl.display.BitmapData;
 import openfl.display.MovieClip;
@@ -16,6 +17,9 @@ import lime.utils.Assets as LimeAssets;
 #if lime_vorbis
 import lime.media.AudioBuffer;
 import lime.media.vorbis.VorbisFile;
+#end
+#if lime_howlerjs
+import lime.media.howlerjs.Howl;
 #end
 
 /**
@@ -289,6 +293,24 @@ class Assets
 		{
 			// TODO: Streaming sound
 			return getSound(id, useCache);
+		}
+		#elseif lime_howlerjs
+		if (useCache && cache.enabled && cache.hasSound(id))
+		{
+			return cache.getSound(id);
+		}
+		else
+		{
+			var buffer = new AudioBuffer();
+			buffer.src = new Howl({src: [getPath(id)], html5: true});
+			var sound = Sound.fromAudioBuffer(buffer);
+
+			if (useCache && cache.enabled)
+			{
+				cache.setSound(id, sound);
+			}
+
+			return sound;
 		}
 		#else
 		// TODO: Streaming sound

--- a/src/openfl/utils/Assets.hx
+++ b/src/openfl/utils/Assets.hx
@@ -15,7 +15,6 @@ import lime.utils.AssetLibrary as LimeAssetLibrary;
 import lime.utils.Assets as LimeAssets;
 #end
 #if lime_vorbis
-import lime.media.AudioBuffer;
 import lime.media.vorbis.VorbisFile;
 #end
 #if lime_howlerjs

--- a/src/openfl/utils/Assets.hx
+++ b/src/openfl/utils/Assets.hx
@@ -838,6 +838,16 @@ class Assets
 	{
 		if (useCache == null) useCache = true;
 
+		if (useCache && cache.enabled && cache.hasSound(id))
+		{
+			var sound = cache.getSound(id);
+
+			if (isValidSound(sound))
+			{
+				return Future.withValue(sound);
+			}
+		}
+
 		#if lime
 		var promise = new Promise<Sound>();
 


### PR DESCRIPTION
Howler.js allows us to [stream audio by using HTML5 audio](https://github.com/goldfire/howler.js?tab=readme-ov-file#streaming-audio-for-live-audio-or-large-files) instead of using the default Web Audio. With this we can implement `Assets.getMusic()` on HTML5. The returned sound will be cached to avoid a re-download if played again via `Assets.getSound()`.

I'm a bit unsure with how this plays with the asynchronous nature of HTML5 and OpenFL's libraries. Loading a library seems to load all sounds normally, so this may only work if the music is stored in an unloaded library.