### PR TITLE
Add ETC2 support to TextureBase.hx

### DIFF
--- a/src/openfl/display3D/textures/TextureBase.hx
+++ b/src/openfl/display3D/textures/TextureBase.hx
@@ -103,6 +103,7 @@ class TextureBase extends EventDispatcher
 			#if (js && html5)
 			var dxtExtension = gl.getExtension("WEBGL_compressed_texture_s3tc");
 			var etc1Extension = gl.getExtension("WEBGL_compressed_texture_etc1");
+			var etc2Extension = gl.getExtension("WEBGL_compressed_texture_etc");
 			// WEBGL_compressed_texture_pvrtc is not available on iOS Safari
 			var pvrtcExtension = gl.getExtension("WEBKIT_WEBGL_compressed_texture_pvrtc");
 			#else
@@ -127,6 +128,26 @@ class TextureBase extends EventDispatcher
 				__compressedFormatsAlpha[ATFGPUFormat.ETC1] = etc1Extension.ETC1_RGB8_OES;
 				#end
 			}
+
+			#if (js && html5)
+			if (etc2Extension != null)
+			{
+				if ((etc2Extension : Dynamic).COMPRESSED_RGB8_ETC2 != null) __compressedFormats[ATFGPUFormat.ETC2] = (etc2Extension : Dynamic)
+					.COMPRESSED_RGB8_ETC2;
+				else if ((gl : Dynamic).COMPRESSED_RGB8_ETC2 != null) __compressedFormats[ATFGPUFormat.ETC2] = (gl : Dynamic).COMPRESSED_RGB8_ETC2;
+
+				if ((etc2Extension : Dynamic).COMPRESSED_RGBA8_ETC2_EAC != null) __compressedFormatsAlpha[ATFGPUFormat.ETC2] = (etc2Extension : Dynamic)
+					.COMPRESSED_RGBA8_ETC2_EAC;
+				else if ((gl : Dynamic).COMPRESSED_RGBA8_ETC2_EAC != null) __compressedFormatsAlpha[ATFGPUFormat.ETC2] = (gl : Dynamic)
+					.COMPRESSED_RGBA8_ETC2_EAC;
+			}
+			else
+			{
+				// Fallback: WebGL2 ETC2 may not use an extension object
+				if ((gl : Dynamic).COMPRESSED_RGB8_ETC2 != null) __compressedFormats[ATFGPUFormat.ETC2] = (gl : Dynamic).COMPRESSED_RGB8_ETC2;
+				if ((gl : Dynamic).COMPRESSED_RGBA8_ETC2_EAC != null) __compressedFormatsAlpha[ATFGPUFormat.ETC2] = (gl : Dynamic).COMPRESSED_RGBA8_ETC2_EAC;
+			}
+			#end
 
 			if (pvrtcExtension != null)
 			{


### PR DESCRIPTION
Using this update to TextureBase.hx, ETC2 is now working in the Android browser in my tests.

The code checks for ETC2 enums (COMPRESSED_RGB8_ETC2, COMPRESSED_RGBA8_ETC2_EAC) directly on the ETC2 extension object if available, or falls back to checking the GL context itself.
This allows both WebGL 1 (via the extension) and WebGL 2 (where I believe ETC2 formats can exist directly on the GL context).

For your testing, I've created a simple web-app that uses an ATF containing _only_ ETC2 content, and plays a running cat when it works.  The asset was created using TexturePacker 6.0.1, not the official `png2atf` tool.

[https://b-interactive.github.io/openfl-etc2-test/](https://b-interactive.github.io/openfl-etc2-test/)