### PR TITLE
Misc/loaders modular fix

### DIFF
--- a/lib/flash-externs/src/flash/ui/KeyLocation.hx
+++ b/lib/flash-externs/src/flash/ui/KeyLocation.hx
@@ -3,10 +3,8 @@ package flash.ui;
 #if flash
 #if (haxe_ver >= 4.0) enum #else @:enum #end abstract KeyLocation(Int) from Int to Int from UInt to UInt
 {
-	// #if (flash && !doc_gen)
 	@:noCompletion @:dox(hide) public static inline var D_PAD = 4;
 
-	// #end
 	public var LEFT = 1;
 	public var NUM_PAD = 3;
 	public var RIGHT = 2;

--- a/src/openfl/Lib.hx
+++ b/src/openfl/Lib.hx
@@ -375,12 +375,12 @@ class Lib
 		The following code shows how you can invoke the VIP Access and Connect Pro
 		applications on Android:
 
-		```as3
+		```haxe
 		//Invoke the VIP Access Application.
-		navigateToURL(new URLRequest("vipaccess://com.verisign.mvip.main?action=securitycode"));
+		Lib.navigateToURL(new URLRequest("vipaccess://com.verisign.mvip.main?action=securitycode"));
 
 		//Invoke the Connect Pro Application.
-		navigateToURL(new URLRequest("connectpro://"));
+		Lib.navigateToURL(new URLRequest("connectpro://"));
 		```
 
 		@param	request	A URLRequest object that specifies the URL to navigate to.

--- a/src/openfl/Vector.hx
+++ b/src/openfl/Vector.hx
@@ -29,7 +29,7 @@ import haxe.Constraints.Function;
 	retrieved. The second line constructs an instance of the same Vector type (that is,
 	a Vector whose elements are all String objects) and assigns it to `v`.
 
-	```as3
+	```haxe
 	var v:Vector<String>;
 	v = new Vector<String>();
 	```
@@ -523,8 +523,8 @@ abstract Vector<T>(IVector<T>)
 		* a function that takes two arguments of the base type (T) of the Vector and
 		returns a Number:
 
-			```as3
-			function compare(x:T, y:T):Number {}
+			```haxe
+			function compare(x:T, y:T):Int {}
 			```
 
 			The logic of the function is that, given two elements `x` and `y`, the function

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -156,8 +156,6 @@ class BitmapData implements IBitmapDrawable
 	@SuppressWarnings("checkstyle:Dynamic")
 	public var image(default, null):#if lime Image #else Dynamic #end;
 
-	// #if !flash_doc_gen
-
 	/**
 		Defines whether the bitmap image is readable. Hardware-only bitmap images
 		do not support `getPixels`, `setPixels` and other
@@ -173,8 +171,6 @@ class BitmapData implements IBitmapDrawable
 		will need to be recreated if the current hardware rendering context is lost.
 	**/
 	@:beta public var readable(default, null):Bool;
-
-	// #end
 
 	/**
 		The rectangle that defines the size and location of the bitmap image. The
@@ -2401,12 +2397,10 @@ class BitmapData implements IBitmapDrawable
 	{
 		if (!readable) return false;
 
-		// #if !openfljs
 		if ((secondObject is Bitmap))
 		{
 			secondObject = cast(secondObject, Bitmap).__bitmapData;
 		}
-		// #end
 
 		if ((secondObject is Point))
 		{

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -874,10 +874,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 	/**
 		An object with properties pertaining to a display object's matrix, color
-		transform, and pixel bounds. The specific properties  -  matrix,
+		transform, and pixel bounds. The specific properties — matrix,
 		colorTransform, and three read-only properties
 		(`concatenatedMatrix`, `concatenatedColorTransform`,
-		and `pixelBounds`)  -  are described in the entry for the
+		and `pixelBounds`) — are described in the entry for the
 		Transform class.
 
 		Each of the transform object's properties is itself an object. This

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -260,12 +260,7 @@ class DisplayObjectContainer extends InteractiveObject
 			child.__setRenderDirty();
 			__setRenderDirty();
 
-			// #if !openfl_disable_event_pooling
-			// var event = Event.__pool.get();
-			// event.type = Event.ADDED;
-			// #else
 			var event = new Event(Event.ADDED);
-			// #end
 			event.bubbles = true;
 
 			event.target = child;

--- a/src/openfl/display/Loader.hx
+++ b/src/openfl/display/Loader.hx
@@ -147,7 +147,7 @@ class Loader extends DisplayObjectContainer
 
 	@:noCompletion private static function __init__()
 	{
-		Loader._registerDefaultLoaders();
+		Loader.__registerDefaultLoaders();
 	}
 
 	/**
@@ -208,7 +208,7 @@ class Loader extends DisplayObjectContainer
 		__unloaded = true;
 	}
 
-	@:noCompletion private static function _registerDefaultLoaders():Void
+	@:noCompletion private static function __registerDefaultLoaders():Void
 	{
 		var loaders = [new BitmapDataLoader(), new ScriptLoader(), new AssetManifestLoader()];
 

--- a/src/openfl/display/Loader.hx
+++ b/src/openfl/display/Loader.hx
@@ -147,16 +147,7 @@ class Loader extends DisplayObjectContainer
 
 	@:noCompletion private static function __init__()
 	{
-		var loaders = [new BitmapDataLoader(), new ScriptLoader(), new AssetManifestLoader()];
-
-		if (__registeredLoaders == null)
-		{
-			__registeredLoaders = loaders;
-		}
-		else
-		{
-			__registeredLoaders = loaders.concat(__registeredLoaders);
-		}
+		Loader._registerDefaultLoaders();
 	}
 
 	/**
@@ -215,6 +206,20 @@ class Loader extends DisplayObjectContainer
 		contentLoaderInfo = LoaderInfo.create(this);
 		uncaughtErrorEvents = contentLoaderInfo.uncaughtErrorEvents;
 		__unloaded = true;
+	}
+
+	@:noCompletion private static function _registerDefaultLoaders():Void
+	{
+		var loaders = [new BitmapDataLoader(), new ScriptLoader(), new AssetManifestLoader()];
+
+		if (__registeredLoaders == null)
+		{
+			__registeredLoaders = loaders;
+		}
+		else
+		{
+			__registeredLoaders = loaders.concat(__registeredLoaders);
+		}
 	}
 
 	public override function addChild(child:DisplayObject):DisplayObject

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -119,7 +119,6 @@ import openfl.utils.ByteArray;
 @:access(openfl.display3D.Program3D)
 @:access(openfl.display.ShaderInput)
 @:access(openfl.display.ShaderParameter)
-// #if (!display && !macro)
 #if !macro
 @:autoBuild(openfl.utils._internal.ShaderMacro.build())
 #end

--- a/src/openfl/display/SimpleButton.hx
+++ b/src/openfl/display/SimpleButton.hx
@@ -61,13 +61,13 @@ class SimpleButton extends InteractiveObject
 		button. For a basic button, set the `hitTestState` property to
 		the same display object as the `overState` property. If you do
 		not set the `hitTestState` property, the SimpleButton is
-		inactive  -  it does not respond to user input events.
+		inactive — it does not respond to user input events.
 	**/
 	public var hitTestState(get, set):DisplayObject;
 
 	/**
 		Specifies a display object that is used as the visual object for the
-		button over state  -  the state that the button is in when the pointer is
+		button over state — the state that the button is in when the pointer is
 		positioned over the button.
 	**/
 	public var overState(get, set):DisplayObject;
@@ -96,7 +96,7 @@ class SimpleButton extends InteractiveObject
 
 	/**
 		Specifies a display object that is used as the visual object for the
-		button up state  -  the state that the button is in when the pointer is
+		button up state — the state that the button is in when the pointer is
 		not positioned over the button.
 	**/
 	public var upState(get, set):DisplayObject;
@@ -459,7 +459,6 @@ class SimpleButton extends InteractiveObject
 			value.parent.removeChild(value);
 		}
 
-		// #if (js && html5 && dom)
 		#if (js && html5)
 		if (DisplayObject.__supportDOM && __previousStates == null)
 		{
@@ -469,7 +468,6 @@ class SimpleButton extends InteractiveObject
 
 		if (value != __currentState)
 		{
-			// #if (js && html5 && dom)
 			#if (js && html5)
 			if (DisplayObject.__supportDOM)
 			{

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -71,8 +71,8 @@ typedef Element = Dynamic;
 	The Stage object is not globally accessible. You need to access it
 	through the `stage` property of a DisplayObject instance.
 
-	The Stage class has several ancestor classes  -  DisplayObjectContainer,
-	InteractiveObject, DisplayObject, and EventDispatcher  -  from which it
+	The Stage class has several ancestor classes — DisplayObjectContainer,
+	InteractiveObject, DisplayObject, and EventDispatcher — from which it
 	inherits properties and methods. Many of these properties and methods are
 	either inapplicable to Stage objects, or require security checks when
 	called on a Stage object. The properties and methods that require security
@@ -1687,10 +1687,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 		if (!event.__preventDefault)
 		{
-			// #if mobile
 			Log.println(CallStack.toString(CallStack.exceptionStack()));
 			Log.println(Std.string(e));
-			// #end
 
 			#if (cpp && !cppia)
 			untyped __cpp__("throw e");
@@ -3822,13 +3820,10 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 				if (updateChildren)
 				{
-					// #if dom
 					if (DisplayObject.__supportDOM)
 					{
 						__wasDirty = true;
 					}
-
-					// #end
 
 					// __dirty = false;
 				}

--- a/src/openfl/display/Stage3D.hx
+++ b/src/openfl/display/Stage3D.hx
@@ -24,109 +24,37 @@ import js.Browser;
 #end
 
 /**
-	The Stage class represents the main drawing area.
-	For SWF content running in the browser (in Flash<sup>®</sup> Player), the
-	Stage represents the entire area where Flash content is shown. For content
-	running in AIR on desktop operating systems, each NativeWindow object has
-	a corresponding Stage object.
+	The Stage3D class provides a display area and a programmable rendering
+	context for drawing 2D and 3D graphics.
 
-	The Stage object is not globally accessible. You need to access it through
-	the `stage` property of a DisplayObject instance.
+	Stage3D provides a high-performance rendering surface for content rendered
+	using the `Context3D` class. This surface uses the graphics processing unit
+	(GPU) when possible. The runtime stage provides a fixed number of `Stage3D`
+	objects. The number of instances varies by the type of device. Desktop
+	computers typically provide four Stage3D instances.
 
-	The Stage class has several ancestor classes נDisplayObjectContainer,
-	InteractiveObject, DisplayObject, and EventDispatcher נfrom which it
-	inherits properties and methods. Many of these properties and methods are
-	either inapplicable to Stage objects, or require security checks when
-	called on a Stage object. The properties and methods that require security
-	checks are documented as part of the Stage class.
+	Content drawn to the `Stage3D` viewport is composited with other visible
+	graphics objects in a predefined order. The most distant are all
+	`StageVideo` surfaces. `Stage3D` comes next, with traditional Flash display
+	object content being rendered last, on top of all others. StageVideo and
+	Stage3D layers are rendered with no transparency; thus a viewport completely
+	obscures any other Stage3D or StageVideo viewports positioned underneath it.
+	Display list content is rendered with transparency.
 
-	In addition, the following inherited properties are inapplicable to Stage
-	objects. If you try to set them, an IllegalOperationError is thrown. These
-	properties may always be read, but since they cannot be set, they will
-	always contain default values.
+	**Note:** You can use the `visible` property of a Stage3D object to remove
+	it from the display temporarily, such as when playing a video using the
+	StageVideo class.
 
-	* `accessibilityProperties`
-	* `alpha`
-	* `blendMode`
-	* `cacheAsBitmap`
-	* `contextMenu`
-	* `filters`
-	* `focusRect`
-	* `loaderInfo`
-	* `mask`
-	* `mouseEnabled`
-	* `name`
-	* `opaqueBackground`
-	* `rotation`
-	* `scale9Grid`
-	* `scaleX`
-	* `scaleY`
-	* `scrollRect`
-	* `tabEnabled`
-	* `tabIndex`
-	* `transform`
-	* `visible`
-	* `x`
-	* `y`
+	A `Stage3D` object is retrieved from the Player stage using its `stage3Ds`
+	member. Use the Stage3D instance to request an associated rendering context
+	and to position the display on the runtime stage.
 
-	Some events that you might expect to be a part of the Stage class, such as
-	`enterFrame`, `exitFrame`, `frameConstructed`, and `render`, cannot be
-	Stage events because a reference to the Stage object cannot be guaranteed
-	to exist in every situation where these events are used. Because these
-	events cannot be dispatched by the Stage object, they are instead
-	dispatched by every DisplayObject instance, which means that you can add
-	an event listener to any DisplayObject instance to listen for these
-	events. These events, which are part of the DisplayObject class, are
-	called broadcast events to differentiate them from events that target a
-	specific DisplayObject instance. Two other broadcast events, `activate`
-	and `deactivate`, belong to DisplayObject's superclass, EventDispatcher.
-	The `activate` and `deactivate` events behave similarly to the
-	DisplayObject broadcast events, except that these two events are
-	dispatched not only by all DisplayObject instances, but also by all
-	EventDispatcher instances and instances of other EventDispatcher
-	subclasses. For more information on broadcast events, see the
-	DisplayObject class.
+	@event context3DCreate      Dispatched when a rendering context is created.
+	@event error             	Dispatched when a request for a rendering
+								context fails.
 
-	@event fullScreen             Dispatched when the Stage object enters, or
-								  leaves, full-screen mode. A change in
-								  full-screen mode can be initiated through
-								  Haxe code, or the user invoking a
-								  keyboard shortcut, or if the current focus
-								  leaves the full-screen window.
-	@event mouseLeave             Dispatched by the Stage object when the
-								  pointer moves out of the stage area. If the
-								  mouse button is pressed, the event is not
-								  dispatched.
-	@event orientationChange      Dispatched by the Stage object when the
-								  stage orientation changes.
-								  Orientation changes can occur when the user
-								  rotates the device, opens a slide-out
-								  keyboard, or when the `setAspectRatio()` is
-								  called.
-
-								  **Note:** If the `autoOrients` property is
-								  `false`, then the stage orientation does not
-								  change when a device is rotated. Thus,
-								  StageOrientationEvents are only dispatched
-								  for device rotation when `autoOrients` is
-								  `true`.
-	@event orientationChanging    Dispatched by the Stage object when the
-								  stage orientation begins changing.
-								  **Important:** orientationChanging events
-								  are not dispatched on Android devices.
-
-								  **Note:** If the `autoOrients` property is
-								  `false`, then the stage orientation does not
-								  change when a device is rotated. Thus,
-								  StageOrientationEvents are only dispatched
-								  for device rotation when `autoOrients` is
-								  `true`.
-	@event resize                 Dispatched when the `scaleMode` property of
-								  the Stage object is set to
-								  `StageScaleMode.NO_SCALE` and the SWF file
-								  is resized.
-	@event stageVideoAvailability Dispatched by the Stage object when the
-								  state of the stageVideos property changes.
+	@see `openfl.display.Stage`
+	@see `openfl.display3D.Context3D`
 **/
 #if !openfl_debug
 @:fileXml('tags="haxe,release"')

--- a/src/openfl/media/Sound.hx
+++ b/src/openfl/media/Sound.hx
@@ -30,7 +30,7 @@ import lime.media.AudioSource;
 	that object, close the sound stream, and access data about the sound, such
 	as information about the number of bytes in the stream and ID3 metadata.
 	More detailed control of the sound is performed through the sound source
-	 -  the SoundChannel or Microphone object for the sound  -  and through the
+	 -  the SoundChannel or Microphone object for the sound — and through the
 	properties in the SoundTransform class that control the output of the sound
 	to the computer's speakers.
 
@@ -369,7 +369,7 @@ class Sound extends EventDispatcher
 		@param target A ByteArray object in which the extracted sound samples
 					  are placed.
 		@param length The number of sound samples to extract. A sample
-					  contains both the left and right channels נthat is,
+					  contains both the left and right channels — that is,
 					  two 32-bit floating-point values.
 		@return The number of samples written to the ByteArray specified in
 				the `target` parameter.

--- a/src/openfl/net/NetConnection.hx
+++ b/src/openfl/net/NetConnection.hx
@@ -31,7 +31,7 @@ import openfl.events.NetStatusEvent;
 	object and define the callback methods on that object.
 
 	@event asyncError    Dispatched when an exception is thrown asynchronously
-						 נthat is, from native asynchronous code.
+						 — that is, from native asynchronous code.
 	@event ioError       Dispatched when an input or output error occurs that
 						 causes a network operation to fail.
 	@event netStatus     Dispatched when a NetConnection object is reporting

--- a/src/openfl/net/NetStream.hx
+++ b/src/openfl/net/NetStream.hx
@@ -81,7 +81,7 @@ import js.Browser;
 	`Sound.id3` property to read metadata from the sound file.
 
 	@event asyncError       Dispatched when an exception is thrown
-							asynchronously נthat is, from native
+							asynchronously — that is, from native
 							asynchronous code. This event is dispatched when a
 							server calls a method on the client that is not
 							defined.
@@ -603,7 +603,7 @@ class NetStream extends EventDispatcher
 	/**
 		The number of seconds of data currently in the buffer. You can use
 		this property with the `bufferTime` property to estimate how close the
-		buffer is to being full נfor example, to display feedback to a user
+		buffer is to being full — for example, to display feedback to a user
 		who is waiting for data to be loaded into the buffer.
 	**/
 	public var bufferLength(default, null):Float;
@@ -710,7 +710,7 @@ class NetStream extends EventDispatcher
 	/**
 		The number of bytes of data that have been loaded into the
 		application. You can use this property with the `bytesTotal` property
-		to estimate how close the buffer is to being full נfor example, to
+		to estimate how close the buffer is to being full — for example, to
 		display feedback to a user who is waiting for data to be loaded into
 		the buffer.
 	**/
@@ -1347,8 +1347,8 @@ class NetStream extends EventDispatcher
 		display the video on the stage.
 
 		You can use `snapshotMilliseconds` to send a single snapshot (by
-		providing a value of 0) or a series of snapshots נin effect,
-		time-lapse footage נby providing a positive number that adds a
+		providing a value of 0) or a series of snapshots — in effect,
+		time-lapse footage — by providing a positive number that adds a
 		trailer of the specified number of milliseconds to the video feed. The
 		trailer extends the display time of the video message. By repeatedly
 		calling `attachCamera()` with a positive value for
@@ -1376,7 +1376,7 @@ class NetStream extends EventDispatcher
 		1/300 (one per 300 seconds, or one every 5 minutes), and then issue a
 		`NetStream.attachCamera(source)` command, letting the camera capture
 		continuously for 500 minutes. The resulting file will play back in 500
-		minutes נthe same length of time that it took to record נwith
+		minutes — the same length of time that it took to record — with
 		each frame being displayed for 5 minutes.
 
 		Both techniques capture the same 500 frames, and both approaches are

--- a/src/openfl/net/SharedObject.hx
+++ b/src/openfl/net/SharedObject.hx
@@ -93,11 +93,11 @@ import sys.FileSystem;
 	space and to user privacy controls. Perform these checks when you call
 	`getLocal()` and `flush()`:
 
-	* `SharedObject.getLocal()`  -  Flash Player throws an
+	* `SharedObject.getLocal()` — Flash Player throws an
 	exception when a call to this method fails, such as when the user has
 	disabled third-party shared objects and the domain of your SWF file does
 	not match the domain in the browser address bar.
-	* `SharedObject.flush()`  -  Flash Player throws an
+	* `SharedObject.flush()` — Flash Player throws an
 	exception when a call to this method fails. It returns
 	`SharedObjectFlushStatus.FLUSHED` when it succeeds. It returns
 	`SharedObjectFlushStatus.PENDING` when additional storage space
@@ -206,7 +206,7 @@ class SharedObject extends EventDispatcher
 	/**
 		The collection of attributes assigned to the `data` property of
 		the object; these attributes can be shared and stored. Each attribute can
-		be an object of any ActionScript or JavaScript type  -  Array, Number,
+		be an object of any ActionScript or JavaScript type — Array, Number,
 		Boolean, ByteArray, XML, and so on. For example, the following lines
 		assign values to various aspects of a shared object:
 
@@ -398,7 +398,7 @@ class SharedObject extends EventDispatcher
 	/**
 		Immediately writes a locally persistent shared object to a local file. If
 		you don't use this method, Flash Player writes the shared object to a file
-		when the shared object session ends  -  that is, when the SWF file is
+		when the shared object session ends — that is, when the SWF file is
 		closed, when the shared object is garbage-collected because it no longer
 		has any references to it, or when you call
 		`SharedObject.clear()` or `SharedObject.close()`.

--- a/src/openfl/net/URLRequest.hx
+++ b/src/openfl/net/URLRequest.hx
@@ -323,7 +323,7 @@ import haxe.macro.Compiler;
 		see the description of the URLRequest class.
 
 		For content running in Adobe AIR, files in the application security
-		sandbox  -  files installed with the AIR application  -  can access URLs
+		sandbox — files installed with the AIR application — can access URLs
 		using any of the following URL schemes:
 
 		* `http` and `https`

--- a/src/openfl/system/Capabilities.hx
+++ b/src/openfl/system/Capabilities.hx
@@ -43,44 +43,43 @@ import sys.io.Process;
 	`GET` or `POST` HTTP method. The following example shows a server string
 	for a computer that has MP3 support and 1600 x 1200 pixel resolution and
 	that is running Windows XP with an input method editor (IME) installed:
-	<pre
-	xml:space="preserve">A=t&SA=t&SV=t&EV=t&MP3=t&AE=t&VE=t&ACC=f&PR=t&SP=t&
+
+	<pre xml:space="preserve">A=t&SA=t&SV=t&EV=t&MP3=t&AE=t&VE=t&ACC=f&PR=t&SP=t&
 	SB=f&DEB=t&V=WIN%209%2C0%2C0%2C0&M=Adobe%20Windows&
 	R=1600x1200&DP=72&COL=color&AR=1.0&OS=Windows%20XP&
 	L=en&PT=External&AVD=f&LFD=f&WD=f&IME=t</pre>
-	The following table lists the properties of the Capabilities class and
-	corresponding server strings: <adobetable><tgroup
-	<row><entry align="left">Capabilities class
-	property</entry><entry align="left">Server
-	string |
-		|`avHardwareDisable` | `AVD` |
-		|`hasAccessibility` | `ACC` |
-		|`hasAudio` | `A` |
-		|`hasAudioEncoder` | `AE` |
-		|`hasEmbeddedVideo` | `EV` |
-		|`hasIME` | `IME` |
-		|`hasMP3` | `MP3` |
-		|`hasPrinting` | `PR` |
-		|`hasScreenBroadcast` | `SB` |
-		|`hasScreenPlayback` | `SP` |
-		|`hasStreamingAudio` | `SA` |
-		|`hasStreamingVideo` | `SV` |
-		|`hasTLS` | `TLS` |
-		|`hasVideoEncoder` | `VE` |
-		|`isDebugger` | `DEB` |
-		|`language` | `L` |
-		|`localFileReadDisable` | `LFD` |
-		|`manufacturer` | `M` |
-		|`maxLevelIDC` | `ML` |
-		|`os` | `OS` |
-		|`pixelAspectRatio` | `AR` |
-		|`playerType` | `PT` |
-		|`screenColor` | `COL` |
-		|`screenDPI` | `DP` |
-		|`screenResolutionX` | `R` |
-		|`screenResolutionY` | `R` |
-		|`version` | `V` |
 
+	The following table lists the properties of the Capabilities class and
+	corresponding server strings:
+
+	| Capabilities class property | Server string |
+	|`avHardwareDisable` | `AVD` |
+	|`hasAccessibility` | `ACC` |
+	|`hasAudio` | `A` |
+	|`hasAudioEncoder` | `AE` |
+	|`hasEmbeddedVideo` | `EV` |
+	|`hasIME` | `IME` |
+	|`hasMP3` | `MP3` |
+	|`hasPrinting` | `PR` |
+	|`hasScreenBroadcast` | `SB` |
+	|`hasScreenPlayback` | `SP` |
+	|`hasStreamingAudio` | `SA` |
+	|`hasStreamingVideo` | `SV` |
+	|`hasTLS` | `TLS` |
+	|`hasVideoEncoder` | `VE` |
+	|`isDebugger` | `DEB` |
+	|`language` | `L` |
+	|`localFileReadDisable` | `LFD` |
+	|`manufacturer` | `M` |
+	|`maxLevelIDC` | `ML` |
+	|`os` | `OS` |
+	|`pixelAspectRatio` | `AR` |
+	|`playerType` | `PT` |
+	|`screenColor` | `COL` |
+	|`screenDPI` | `DP` |
+	|`screenResolutionX` | `R` |
+	|`screenResolutionY` | `R` |
+	|`version` | `V` |
 
 	There is also a `WD` server string that specifies whether windowless mode
 	is disabled. Windowless mode can be disabled in Flash Player due to
@@ -293,9 +292,9 @@ import sys.io.Process;
 
 	/**
 		Specifies the manufacturer of the running version of OpenFL, in the
-		format "_ManufacturerName_ _OSName_". The value for `_ManufacturerName_`
+		format _`"ManufacturerName OSName"`_. The value for _`ManufacturerName`_
 		is typically "OpenFL". When targeting Adobe Flash Player or AIR, the
-		value for `_ManufacturerName_` is "Adobe". The value for `_OSName_`
+		value for _`ManufacturerName`_ is "Adobe". The value for _`OSName`_
 		could be `"Windows"`, `"Macintosh"`, `"Linux"`, or another operating
 		system name. The server string is `M`.
 
@@ -377,13 +376,16 @@ import sys.io.Process;
 		* `"Desktop"` for the Adobe AIR runtime (except for SWF
 		content loaded by an HTML page, which has
 		`Capabilities.playerType` set to `"PlugIn"`)
-		* `"External"` for the external Flash Player<ph
-		outputclass="flashonly"> or in test mode
+		* `"External"` for the external Flash Player or in test mode
 		* `"PlugIn"` for the Flash Player browser plug-in (and for
 		SWF content loaded by an HTML page in an AIR application)
 		* `"StandAlone"` for the stand-alone Flash Player
 
 		The server string is `PT`.
+
+		_OpenFL target support:_ On native targets that are considered Haxe
+		`sys` targets, returns `"Desktop"`. On the HTML5 target, returns
+		`"PlugIn"`. On all other targets, returns `"StandAlone"`.
 	**/
 	public static var playerType(default, null) = #if web "PlugIn" #elseif sys "Desktop" #else "StandAlone" #end;
 
@@ -423,10 +425,11 @@ import sys.io.Process;
 		A URL-encoded string that specifies values for each Capabilities property.
 
 		The following example shows a URL-encoded string:
-		`A=t&SA=t&SV=t&EV=t&MP3=t&AE=t&VE=t&ACC=f&PR=t&SP=t&
+
+		<pre xml:space="preserve">A=t&SA=t&SV=t&EV=t&MP3=t&AE=t&VE=t&ACC=f&PR=t&SP=t&
 		SB=f&DEB=t&V=WIN%208%2C5%2C0%2C208&M=Adobe%20Windows&
 		R=1600x1200&DP=72&COL=color&AR=1.0&OS=Windows%20XP&
-		L=en&PT=External&AVD=f&LFD=f&WD=f`
+		L=en&PT=External&AVD=f&LFD=f&WD=f</pre>
 	**/
 	public static var serverString(default, null) = ""; // TODO
 
@@ -452,12 +455,15 @@ import sys.io.Process;
 		Specifies the Flash Player or Adobe<sup>®</sup> AIR<sup>®</sup> platform
 		and version information. The format of the version number is: _platform
 		majorVersion,minorVersion,buildNumber,internalBuildNumber_. Possible
-		values for _platform_ are `"WIN"`, ` `"MAC"`,
+		values for _platform_ are `"WIN"`, `"MAC"`,
 		`"LNX"`, and `"AND"`. Here are some examples of
-		version information: `WIN 9,0,0,0 // Flash
-		Player 9 for Windows MAC 7,0,25,0 // Flash Player 7 for Macintosh LNX
-		9,0,115,0 // Flash Player 9 for Linux AND 10,2,150,0 // Flash Player 10
-		for Android`
+		version information:
+
+		| Version String | Description |
+		| `WIN 9,0,0,0` | Flash Player 9 for Windows |
+		| `MAC 7,0,25,0` | Flash Player 7 for Macintosh |
+		| `LNX 9,0,115,0` | Flash Player 9 for Linux |
+		| `AND 10,2,150,0` | Flash Player 10 for Android |
 
 		Do _not_ use `Capabilities.version` to determine a
 		capability based on the operating system if a more specific capability

--- a/src/openfl/system/Security.hx
+++ b/src/openfl/system/Security.hx
@@ -80,7 +80,7 @@ class Security
 		uses exact domains for player settings. The default value for
 		`exactSettings` is `true`. If you change `exactSettings` from its
 		default value, do so before any events occur that require Flash Player
-		or AIR to choose player settings נfor example, using a camera or
+		or AIR to choose player settings — for example, using a camera or
 		microphone, or retrieving a persistent shared object.
 
 		If you previously published a version 6 SWF file and created
@@ -113,21 +113,21 @@ class Security
 		operating.
 		`Security.sandboxType` has one of the following values:
 
-		* `remote` (`Security.REMOTE`)הhis file is from an Internet URL and
+		* `remote` (`Security.REMOTE`) This file is from an Internet URL and
 		operates under domain-based sandbox rules.
-		* `localWithFile` (`Security.LOCAL_WITH_FILE`)הhis file is a local
+		* `localWithFile` (`Security.LOCAL_WITH_FILE`) This file is a local
 		file, has not been trusted by the user, and it is not a SWF file that
 		was published with a networking designation. The file may read from
 		local data sources but may not communicate with the Internet.
-		* `localWithNetwork` (`Security.LOCAL_WITH_NETWORK`)הhis SWF file
+		* `localWithNetwork` (`Security.LOCAL_WITH_NETWORK`) This SWF file
 		is a local file, has not been trusted by the user, and was published
 		with a networking designation. The SWF file can communicate with the
 		Internet but cannot read from local data sources.
-		* `localTrusted` (`Security.LOCAL_TRUSTED`)הhis file is a local
+		* `localTrusted` (`Security.LOCAL_TRUSTED`) This file is a local
 		file and has been trusted by the user, using either the Flash Player
 		Settings Manager or a FlashPlayerTrust configuration file. The file
 		can read from local data sources and communicate with the Internet.
-		* `application` (`Security.APPLICATION`)הhis file is running in an
+		* `application` (`Security.APPLICATION`) This file is running in an
 		AIR application, and it was installed with the package (AIR file) for
 		that application. By default, files in the AIR application sandbox can
 		cross-script any file from any domain (although files outside the AIR
@@ -151,14 +151,14 @@ class Security
 		sandbox can communicate with content in the application security
 		sandbox using a sandbox bridge.
 
-		If two SWF files are served from the same domain נfor example,
-		http://mysite.com/swfA.swf and http://mysite.com/swfB.swf נthen
+		If two SWF files are served from the same domain — for example,
+		http://mysite.com/swfA.swf and http://mysite.com/swfB.swf — then
 		swfA.swf can examine and modify variables, objects, properties,
 		methods, and so on in swfB.swf, and swfB.swf can do the same for
 		swfA.swf. This is called _cross-movie scripting_ or _cross-scripting_.
 
-		If two SWF files are served from different domains נfor example,
-		http://siteA.com/swfA.swf and http://siteB.com/siteB.swf נthen, by
+		If two SWF files are served from different domains — for example,
+		http://siteA.com/swfA.swf and http://siteB.com/siteB.swf — then, by
 		default, Flash Player does not allow swfA.swf to script swfB.swf, nor
 		swfB.swf to script swfA.swf. A SWF file gives permission to SWF files
 		from other domains by calling `Security.allowDomain()`. This is called
@@ -376,7 +376,7 @@ class Security
 		and your users, attempting to steal the credit card numbers that your
 		users enter into your shopping cart application. A middle party might,
 		for example, be an unscrupulous ISP used by some of your users, or a
-		malicious administrator at a user's workplace נanyone who has the
+		malicious administrator at a user's workplace — anyone who has the
 		ability to view or alter network packets transmitted over the public
 		Internet between your users and your servers. This situation is not
 		uncommon.

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -36,14 +36,7 @@ import js.html.DivElement;
 
 /**
 	The TextField class is used to create display objects for text display and
-	input. <ph outputclass="flexonly">You can use the TextField class to
-	perform low-level text rendering. However, in Flex, you typically use the
-	Label, Text, TextArea, and TextInput controls to process text. <ph
-	outputclass="flashonly">You can give a text field an instance name in the
-	Property inspector and use the methods and properties of the TextField
-	class to manipulate it with Haxe code. TextField instance names are
-	displayed in the Movie Explorer and in the Insert Target Path dialog box in
-	the Actions panel.
+	input.
 
 	To create a text field dynamically, use the `TextField()`
 	constructor.
@@ -459,8 +452,7 @@ class TextField extends InteractiveObject
 		enter only characters in the string into the text field. The string is
 		scanned from left to right. You can specify a range by using the hyphen
 		(-) character. Only user interaction is restricted; a script can put any
-		text into the text field. <ph outputclass="flashonly">This property does
-		not synchronize with the Embed font options in the Property inspector.
+		text into the text field.
 
 		If the string begins with a caret(^) character, all characters are
 		initially accepted and succeeding characters in the string are excluded
@@ -2851,11 +2843,7 @@ class TextField extends InteractiveObject
 
 	@:noCompletion private function get_htmlText():String
 	{
-		// #if (js && html5)
 		return __isHTML ? __htmlText : __text;
-		// #else
-		// return __text;
-		// #end
 	}
 
 	@:noCompletion private function set_htmlText(value:String):String

--- a/src/openfl/ui/Mouse.hx
+++ b/src/openfl/ui/Mouse.hx
@@ -10,7 +10,7 @@ import lime.ui.MouseCursor as LimeMouseCursor;
 	The methods of the Mouse class are used to hide and show the mouse pointer,
 	or to set the pointer to a specific style. The Mouse class is a top-level
 	class whose properties and methods you can access without using a
-	constructor. <ph outputclass="flashonly">The pointer is visible by default,
+	constructor. The pointer is visible by default,
 	but you can hide it and implement a custom pointer.
 **/
 #if !openfl_debug

--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -224,14 +224,12 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		the zlib compressed data format specification, those bytes (that is, the
 		portion containing the compressed version of the original data) are
 		compressed using the deflate algorithm. Consequently those bytes are
-		identical to the result of calling `compress(<ph
-		outputclass="javascript">air.CompressionAlgorithm.DEFLATE)` on the
-		original ByteArray. However, the result from `compress(<ph
-		outputclass="javascript">air.CompressionAlgorithm.ZLIB)` includes
-		the extra metadata, while the
-		`compress(CompressionAlgorithm.DEFLATE)` result includes only
-		the compressed version of the original ByteArray data and nothing
-		else.
+		identical to the result of calling
+		`compress(CompressionAlgorithm.DEFLATE)` on the original ByteArray.
+		However, the result from `compress(CompressionAlgorithm.ZLIB)` includes
+		the extra metadata, while the `compress(CompressionAlgorithm.DEFLATE)`
+		result includes only the compressed version of the original ByteArray
+		data and nothing else.
 
 		In order to use the deflate format to compress a ByteArray instance's
 		data in a specific format such as gzip or zip, you cannot simply call
@@ -2027,14 +2025,12 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		the zlib compressed data format specification, those bytes (that is, the
 		portion containing the compressed version of the original data) are
 		compressed using the deflate algorithm. Consequently those bytes are
-		identical to the result of calling `compress(<ph
-		outputclass="javascript">air.CompressionAlgorithm.DEFLATE)` on the
-		original ByteArray. However, the result from `compress(<ph
-		outputclass="javascript">air.CompressionAlgorithm.ZLIB)` includes
-		the extra metadata, while the
-		`compress(CompressionAlgorithm.DEFLATE)` result includes only
-		the compressed version of the original ByteArray data and nothing
-		else.
+		identical to the result of calling
+		`compress(CompressionAlgorithm.DEFLATE)` on the original ByteArray.
+		However, the result from `compress(CompressionAlgorithm.ZLIB)` includes
+		the extra metadata, while the `compress(CompressionAlgorithm.DEFLATE)`
+		result includes only the compressed version of the original ByteArray
+		data and nothing else.
 
 		In order to use the deflate format to compress a ByteArray instance's
 		data in a specific format such as gzip or zip, you cannot simply call

--- a/src/openfl/utils/_internal/ShaderMacro.hx
+++ b/src/openfl/utils/_internal/ShaderMacro.hx
@@ -150,7 +150,6 @@ class ShaderMacro
 				}
 			}
 
-			// #if !display
 			for (field in fields)
 			{
 				switch (field.name)
@@ -192,7 +191,6 @@ class ShaderMacro
 					default:
 				}
 			}
-			// #end
 
 			fields = fields.concat(uniqueFields);
 		}


### PR DESCRIPTION
Edge case here…
Using Haxe-modular library I discovered that code from the __init__ function in the Loader.hx class was being duplicated into modules created by the haxe-modular library (when no OpenFL classes were necessary), and then causing errors. 

```
var loaders = [new openfl_display__$internal_BitmapDataLoader(),new openfl_display__$internal_ScriptLoader(),new openfl_display__$internal_AssetManifestLoader()];
if(openfl_display_Loader.__registeredLoaders == null) {
	openfl_display_Loader.__registeredLoaders = loaders;
} else {
	openfl_display_Loader.__registeredLoaders = loaders.concat(openfl_display_Loader.__registeredLoaders);
}
```

Per their [documentation](https://github.com/elsassph/haxe-modular/blob/master/doc/start.md) it was a known behaviour of haxe-modular, i.e. "assume that __init__ code could be duplicated in all the bundles, unless you only use calls to static methods."
I [raised the issue](https://github.com/elsassph/haxe-modular/issues/118#issuecomment-3694581546) and Philippe recommended this as a solution, which seems to work.