### PR TITLE
OpenFL9.5.0 This condition can cause issues with custom shader rendering exceptions

### DIFF
--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -715,7 +715,7 @@ class Context3DGraphics
 						uvDataLength = verticesLength;
 					}
 
-					if (bitmap != null || (uvDataLength == 0 && fill != null))
+					if (bitmap != null || shaderBuffer != null || (uvDataLength == 0 && fill != null))
 					{
 						var numVertices = Math.floor(verticesLength / 2);
 						var length = indicesLength > 0 ? indicesLength : numVertices;

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -715,111 +715,108 @@ class Context3DGraphics
 						uvDataLength = verticesLength;
 					}
 
-					if (bitmap != null || (uvDataLength == 0 && fill != null))
+					var numVertices = Math.floor(verticesLength / 2);
+					var length = indicesLength > 0 ? indicesLength : numVertices;
+
+					var hasUVTData = uvDataLength >= (numVertices * 3);
+					var vertLength = hasUVTData ? 4 : 2;
+					var uvStride = hasUVTData ? 3 : 2;
+
+					var dataPerVertex = vertLength + 2;
+					var vertexBuffer = hasUVTData ? graphics.__vertexBufferUVT : graphics.__vertexBuffer;
+					var bufferPosition = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
+
+					var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
+					var shader:Shader;
+
+					if (shaderBuffer != null && !maskRender)
 					{
-						var numVertices = Math.floor(verticesLength / 2);
-						var length = indicesLength > 0 ? indicesLength : numVertices;
+						shader = renderer.__initShaderBuffer(shaderBuffer);
 
-						var hasUVTData = uvDataLength >= (numVertices * 3);
-						var vertLength = hasUVTData ? 4 : 2;
-						var uvStride = hasUVTData ? 3 : 2;
-
-						var dataPerVertex = vertLength + 2;
-						var vertexBuffer = hasUVTData ? graphics.__vertexBufferUVT : graphics.__vertexBuffer;
-						var bufferPosition = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
-
-						var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
-						var shader:Shader;
-
-						if (shaderBuffer != null && !maskRender)
-						{
-							shader = renderer.__initShaderBuffer(shaderBuffer);
-
-							renderer.__setShaderBuffer(shaderBuffer);
-							renderer.applyMatrix(uMatrix);
-							renderer.applyBitmapData(bitmap, false, repeat);
-							renderer.applyAlpha(1);
-							renderer.applyColorTransform(null);
-							renderer.__updateShaderBuffer(shaderBufferOffset);
-						}
-						else if (bitmap != null)
-						{
-							shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
-							renderer.setShader(shader);
-							renderer.applyMatrix(uMatrix);
-							renderer.applyBitmapData(bitmap, smooth, repeat);
-							renderer.applyAlpha(graphics.__owner.__worldAlpha);
-							renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
-							renderer.updateShader();
-						}
-						else
-						{
-							shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
-							renderer.setShader(shader);
-							renderer.applyMatrix(uMatrix);
-							renderer.applyBitmapData(blankBitmapData, true, repeat);
-							#if lime
-							var color:ARGB = (fill : ARGB);
-							tempColorTransform.redOffset = color.r;
-							tempColorTransform.greenOffset = color.g;
-							tempColorTransform.blueOffset = color.b;
-							tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
-							renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
-							renderer.applyColorTransform(tempColorTransform);
-							#else
-							renderer.applyAlpha(graphics.__owner.__worldAlpha);
-							renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
-							#end
-							renderer.updateShader();
-						}
-
-						if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, bufferPosition,
-							hasUVTData ? FLOAT_4 : FLOAT_2);
-						if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, bufferPosition + vertLength,
-							FLOAT_2);
-
-						switch (culling)
-						{
-							case POSITIVE:
-								context.setCulling(FRONT);
-
-							case NEGATIVE:
-								context.setCulling(BACK);
-
-							case NONE:
-								context.setCulling(NONE);
-
-							default:
-						}
-
-						context.__drawTriangles(0, length);
-
-						shaderBufferOffset += length;
-						if (hasUVTData)
-						{
-							vertexBufferPositionUVT += (dataPerVertex * length);
-						}
-						else
-						{
-							vertexBufferPosition += (dataPerVertex * length);
-						}
-
-						// This code is here because other draw calls are not aware (currently) of the culling type and just generally expect it to use
-						// back face culling by default
-						switch (culling)
-						{
-							case POSITIVE, NONE:
-								context.setCulling(BACK);
-
-							default:
-						}
-
-						#if gl_stats
-						Context3DStats.incrementDrawCall(DrawCallContext.STAGE);
-						#end
-
-						renderer.__clearShader();
+						renderer.__setShaderBuffer(shaderBuffer);
+						renderer.applyMatrix(uMatrix);
+						renderer.applyBitmapData(bitmap, false, repeat);
+						renderer.applyAlpha(1);
+						renderer.applyColorTransform(null);
+						renderer.__updateShaderBuffer(shaderBufferOffset);
 					}
+					else if (bitmap != null)
+					{
+						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
+						renderer.setShader(shader);
+						renderer.applyMatrix(uMatrix);
+						renderer.applyBitmapData(bitmap, smooth, repeat);
+						renderer.applyAlpha(graphics.__owner.__worldAlpha);
+						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
+						renderer.updateShader();
+					}
+					else
+					{
+						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
+						renderer.setShader(shader);
+						renderer.applyMatrix(uMatrix);
+						renderer.applyBitmapData(blankBitmapData, true, repeat);
+						#if lime
+						var color:ARGB = (fill : ARGB);
+						tempColorTransform.redOffset = color.r;
+						tempColorTransform.greenOffset = color.g;
+						tempColorTransform.blueOffset = color.b;
+						tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
+						renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
+						renderer.applyColorTransform(tempColorTransform);
+						#else
+						renderer.applyAlpha(graphics.__owner.__worldAlpha);
+						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
+						#end
+						renderer.updateShader();
+					}
+
+					if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, bufferPosition,
+						hasUVTData ? FLOAT_4 : FLOAT_2);
+					if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, bufferPosition + vertLength,
+						FLOAT_2);
+
+					switch (culling)
+					{
+						case POSITIVE:
+							context.setCulling(FRONT);
+
+						case NEGATIVE:
+							context.setCulling(BACK);
+
+						case NONE:
+							context.setCulling(NONE);
+
+						default:
+					}
+
+					context.__drawTriangles(0, length);
+
+					shaderBufferOffset += length;
+					if (hasUVTData)
+					{
+						vertexBufferPositionUVT += (dataPerVertex * length);
+					}
+					else
+					{
+						vertexBufferPosition += (dataPerVertex * length);
+					}
+
+					// This code is here because other draw calls are not aware (currently) of the culling type and just generally expect it to use
+					// back face culling by default
+					switch (culling)
+					{
+						case POSITIVE, NONE:
+							context.setCulling(BACK);
+
+						default:
+					}
+
+					#if gl_stats
+					Context3DStats.incrementDrawCall(DrawCallContext.STAGE);
+					#end
+
+					renderer.__clearShader();
 				}
 
 				for (type in graphics.__commands.types)

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -715,108 +715,111 @@ class Context3DGraphics
 						uvDataLength = verticesLength;
 					}
 
-					var numVertices = Math.floor(verticesLength / 2);
-					var length = indicesLength > 0 ? indicesLength : numVertices;
-
-					var hasUVTData = uvDataLength >= (numVertices * 3);
-					var vertLength = hasUVTData ? 4 : 2;
-					var uvStride = hasUVTData ? 3 : 2;
-
-					var dataPerVertex = vertLength + 2;
-					var vertexBuffer = hasUVTData ? graphics.__vertexBufferUVT : graphics.__vertexBuffer;
-					var bufferPosition = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
-
-					var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
-					var shader:Shader;
-
-					if (shaderBuffer != null && !maskRender)
+					if (bitmap != null || (uvDataLength == 0 && fill != null))
 					{
-						shader = renderer.__initShaderBuffer(shaderBuffer);
+						var numVertices = Math.floor(verticesLength / 2);
+						var length = indicesLength > 0 ? indicesLength : numVertices;
 
-						renderer.__setShaderBuffer(shaderBuffer);
-						renderer.applyMatrix(uMatrix);
-						renderer.applyBitmapData(bitmap, false, repeat);
-						renderer.applyAlpha(1);
-						renderer.applyColorTransform(null);
-						renderer.__updateShaderBuffer(shaderBufferOffset);
-					}
-					else if (bitmap != null)
-					{
-						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
-						renderer.setShader(shader);
-						renderer.applyMatrix(uMatrix);
-						renderer.applyBitmapData(bitmap, smooth, repeat);
-						renderer.applyAlpha(graphics.__owner.__worldAlpha);
-						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
-						renderer.updateShader();
-					}
-					else
-					{
-						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
-						renderer.setShader(shader);
-						renderer.applyMatrix(uMatrix);
-						renderer.applyBitmapData(blankBitmapData, true, repeat);
-						#if lime
-						var color:ARGB = (fill : ARGB);
-						tempColorTransform.redOffset = color.r;
-						tempColorTransform.greenOffset = color.g;
-						tempColorTransform.blueOffset = color.b;
-						tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
-						renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
-						renderer.applyColorTransform(tempColorTransform);
-						#else
-						renderer.applyAlpha(graphics.__owner.__worldAlpha);
-						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
+						var hasUVTData = uvDataLength >= (numVertices * 3);
+						var vertLength = hasUVTData ? 4 : 2;
+						var uvStride = hasUVTData ? 3 : 2;
+
+						var dataPerVertex = vertLength + 2;
+						var vertexBuffer = hasUVTData ? graphics.__vertexBufferUVT : graphics.__vertexBuffer;
+						var bufferPosition = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
+
+						var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
+						var shader:Shader;
+
+						if (shaderBuffer != null && !maskRender)
+						{
+							shader = renderer.__initShaderBuffer(shaderBuffer);
+
+							renderer.__setShaderBuffer(shaderBuffer);
+							renderer.applyMatrix(uMatrix);
+							renderer.applyBitmapData(bitmap, false, repeat);
+							renderer.applyAlpha(1);
+							renderer.applyColorTransform(null);
+							renderer.__updateShaderBuffer(shaderBufferOffset);
+						}
+						else if (bitmap != null)
+						{
+							shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
+							renderer.setShader(shader);
+							renderer.applyMatrix(uMatrix);
+							renderer.applyBitmapData(bitmap, smooth, repeat);
+							renderer.applyAlpha(graphics.__owner.__worldAlpha);
+							renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
+							renderer.updateShader();
+						}
+						else
+						{
+							shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
+							renderer.setShader(shader);
+							renderer.applyMatrix(uMatrix);
+							renderer.applyBitmapData(blankBitmapData, true, repeat);
+							#if lime
+							var color:ARGB = (fill : ARGB);
+							tempColorTransform.redOffset = color.r;
+							tempColorTransform.greenOffset = color.g;
+							tempColorTransform.blueOffset = color.b;
+							tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
+							renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
+							renderer.applyColorTransform(tempColorTransform);
+							#else
+							renderer.applyAlpha(graphics.__owner.__worldAlpha);
+							renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
+							#end
+							renderer.updateShader();
+						}
+
+						if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, bufferPosition,
+							hasUVTData ? FLOAT_4 : FLOAT_2);
+						if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, bufferPosition + vertLength,
+							FLOAT_2);
+
+						switch (culling)
+						{
+							case POSITIVE:
+								context.setCulling(FRONT);
+
+							case NEGATIVE:
+								context.setCulling(BACK);
+
+							case NONE:
+								context.setCulling(NONE);
+
+							default:
+						}
+
+						context.__drawTriangles(0, length);
+
+						shaderBufferOffset += length;
+						if (hasUVTData)
+						{
+							vertexBufferPositionUVT += (dataPerVertex * length);
+						}
+						else
+						{
+							vertexBufferPosition += (dataPerVertex * length);
+						}
+
+						// This code is here because other draw calls are not aware (currently) of the culling type and just generally expect it to use
+						// back face culling by default
+						switch (culling)
+						{
+							case POSITIVE, NONE:
+								context.setCulling(BACK);
+
+							default:
+						}
+
+						#if gl_stats
+						Context3DStats.incrementDrawCall(DrawCallContext.STAGE);
 						#end
-						renderer.updateShader();
+
+						renderer.__clearShader();
 					}
-
-					if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, bufferPosition,
-						hasUVTData ? FLOAT_4 : FLOAT_2);
-					if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, bufferPosition + vertLength,
-						FLOAT_2);
-
-					switch (culling)
-					{
-						case POSITIVE:
-							context.setCulling(FRONT);
-
-						case NEGATIVE:
-							context.setCulling(BACK);
-
-						case NONE:
-							context.setCulling(NONE);
-
-						default:
-					}
-
-					context.__drawTriangles(0, length);
-
-					shaderBufferOffset += length;
-					if (hasUVTData)
-					{
-						vertexBufferPositionUVT += (dataPerVertex * length);
-					}
-					else
-					{
-						vertexBufferPosition += (dataPerVertex * length);
-					}
-
-					// This code is here because other draw calls are not aware (currently) of the culling type and just generally expect it to use
-					// back face culling by default
-					switch (culling)
-					{
-						case POSITIVE, NONE:
-							context.setCulling(BACK);
-
-						default:
-					}
-
-					#if gl_stats
-					Context3DStats.incrementDrawCall(DrawCallContext.STAGE);
-					#end
-
-					renderer.__clearShader();
 				}
 
 				for (type in graphics.__commands.types)


### PR DESCRIPTION
If the custom shader does not use the default bitmap shader bitmap parameters, it will cause the shader to fail to render properly.

I noticed that the old version does not have this condition, and there is also a null judgment for the bitmap in the condition, so there should not be any blocking conditions.