### PR TITLE
SecureSocket clean up some minor code redundancy

### DIFF
--- a/src/openfl/net/SecureSocket.hx
+++ b/src/openfl/net/SecureSocket.hx
@@ -371,7 +371,6 @@ class SecureSocket extends Socket
 			try
 			{
 				secureSocket.handshake();
-				blocked = false;
 			}
 			catch (e:Error)
 			{


### PR DESCRIPTION
These are just minor changes and should not impact functionality in any way.

The first is removing the redundant `blocked` variable assignment from line 374.  That variable is initialised with a value of `false` on line 370, and nothing would change that by line 374, hence the additional assignment being redundant.

~~The second change I made is largely aesthetic only, and perhaps there's a reason it's being handled the way it was.  Please accept my apology if that's the case.  The `switch` condition looks at two cases which have an identical result.  Rather than handling them as two separate cases, they now occupy a single case for the purpose of code simplicity.~~

_Edit: Seems there may have been a reason for the switch cases being the way they were, it was failing the unit test on that._