### PR TITLE
Rectangle should allow negative width/height (flighthq/flight@388519d)

### DIFF
--- a/src/openfl/geom/Rectangle.hx
+++ b/src/openfl/geom/Rectangle.hx
@@ -251,12 +251,7 @@ class Rectangle
 	**/
 	public function contains(x:Float, y:Float):Bool
 	{
-		var x0 = Math.min(this.x, this.right);
-		var x1 = Math.max(this.x, this.right);
-		var y0 = Math.min(this.y, this.bottom);
-		var y1 = Math.max(this.y, this.bottom);
-
-		return x >= x0 && x < x1 && y >= y0 && y < y1;
+		return x >= this.x && y >= this.y && x < right && y < bottom;
 	}
 
 	/**
@@ -288,18 +283,17 @@ class Rectangle
 	**/
 	public function containsRect(rect:Rectangle):Bool
 	{
-		var sx0 = Math.min(this.x, this.right);
-		var sx1 = Math.max(this.x, this.right);
-		var sy0 = Math.min(this.y, this.bottom);
-		var sy1 = Math.max(this.y, this.bottom);
+		if (rect.width <= 0 || rect.height <= 0)
+		{
+			return false;
+		}
 
-		var ox0 = Math.min(rect.x, rect.right);
-		var ox1 = Math.max(rect.x, rect.right);
-		var oy0 = Math.min(rect.y, rect.bottom);
-		var oy1 = Math.max(rect.y, rect.bottom);
+		if (this.width <= 0 || this.height <= 0)
+		{
+			return false;
+		}
 
-		// A rectangle contains another if all corners are inside (exclusive right/bottom)
-		return ox0 >= sx0 && oy0 >= sy0 && ox1 <= sx1 && oy1 <= sy1;
+		return rect.x >= this.x && rect.y >= this.y && rect.right <= this.right && rect.bottom <= this.bottom;
 	}
 
 	/**
@@ -513,7 +507,7 @@ class Rectangle
 	**/
 	public function isEmpty():Bool
 	{
-		return (width == 0 || height == 0);
+		return (width <= 0 || height <= 0);
 	}
 
 	/**
@@ -575,7 +569,7 @@ class Rectangle
 
 	public function toString():String
 	{
-		return '(x=$x, y=$y, width=$width, height=$height)';
+		return '(x=$x, y=$y, w=$width, h=$height)';
 	}
 
 	/**
@@ -594,20 +588,19 @@ class Rectangle
 	**/
 	public function union(toUnion:Rectangle):Rectangle
 	{
-		var sourceLeft = Math.min(x, x + width);
-		var sourceRight = Math.max(x, x + width);
-		var sourceTop = Math.min(y, y + height);
-		var sourceBottom = Math.max(y, y + height);
+		if (width == 0 || height == 0)
+		{
+			return toUnion.clone();
+		}
+		else if (toUnion.width == 0 || toUnion.height == 0)
+		{
+			return clone();
+		}
 
-		var otherLeft = Math.min(toUnion.x, toUnion.x + toUnion.width);
-		var otherRight = Math.max(toUnion.x, toUnion.x + toUnion.width);
-		var otherTop = Math.min(toUnion.y, toUnion.y + toUnion.height);
-		var otherBottom = Math.max(toUnion.y, toUnion.y + toUnion.height);
-
-		var x0 = Math.min(sourceLeft, otherLeft);
-		var x1 = Math.max(sourceRight, otherRight);
-		var y0 = Math.min(sourceTop, otherTop);
-		var y1 = Math.max(sourceBottom, otherBottom);
+		var x0 = x > toUnion.x ? toUnion.x : x;
+		var x1 = right < toUnion.right ? toUnion.right : right;
+		var y0 = y > toUnion.y ? toUnion.y : y;
+		var y1 = bottom < toUnion.bottom ? toUnion.bottom : bottom;
 
 		return new Rectangle(x0, y0, x1 - x0, y1 - y0);
 	}

--- a/src/openfl/geom/Rectangle.hx
+++ b/src/openfl/geom/Rectangle.hx
@@ -251,7 +251,12 @@ class Rectangle
 	**/
 	public function contains(x:Float, y:Float):Bool
 	{
-		return x >= this.x && y >= this.y && x < right && y < bottom;
+		var x0 = Math.min(this.x, this.right);
+		var x1 = Math.max(this.x, this.right);
+		var y0 = Math.min(this.y, this.bottom);
+		var y1 = Math.max(this.y, this.bottom);
+
+		return x >= x0 && x < x1 && y >= y0 && y < y1;
 	}
 
 	/**
@@ -283,14 +288,18 @@ class Rectangle
 	**/
 	public function containsRect(rect:Rectangle):Bool
 	{
-		if (rect.width <= 0 || rect.height <= 0)
-		{
-			return rect.x > x && rect.y > y && rect.right < right && rect.bottom < bottom;
-		}
-		else
-		{
-			return rect.x >= x && rect.y >= y && rect.right <= right && rect.bottom <= bottom;
-		}
+		var sx0 = Math.min(this.x, this.right);
+		var sx1 = Math.max(this.x, this.right);
+		var sy0 = Math.min(this.y, this.bottom);
+		var sy1 = Math.max(this.y, this.bottom);
+
+		var ox0 = Math.min(rect.x, rect.right);
+		var ox1 = Math.max(rect.x, rect.right);
+		var oy0 = Math.min(rect.y, rect.bottom);
+		var oy1 = Math.max(rect.y, rect.bottom);
+
+		// A rectangle contains another if all corners are inside (exclusive right/bottom)
+		return ox0 >= sx0 && oy0 >= sy0 && ox1 <= sx1 && oy1 <= sy1;
 	}
 
 	/**
@@ -504,7 +513,7 @@ class Rectangle
 	**/
 	public function isEmpty():Bool
 	{
-		return (width <= 0 || height <= 0);
+		return (width == 0 || height == 0);
 	}
 
 	/**
@@ -585,19 +594,20 @@ class Rectangle
 	**/
 	public function union(toUnion:Rectangle):Rectangle
 	{
-		if (width == 0 || height == 0)
-		{
-			return toUnion.clone();
-		}
-		else if (toUnion.width == 0 || toUnion.height == 0)
-		{
-			return clone();
-		}
+		var sourceLeft = Math.min(x, x + width);
+		var sourceRight = Math.max(x, x + width);
+		var sourceTop = Math.min(y, y + height);
+		var sourceBottom = Math.max(y, y + height);
 
-		var x0 = x > toUnion.x ? toUnion.x : x;
-		var x1 = right < toUnion.right ? toUnion.right : right;
-		var y0 = y > toUnion.y ? toUnion.y : y;
-		var y1 = bottom < toUnion.bottom ? toUnion.bottom : bottom;
+		var otherLeft = Math.min(toUnion.x, toUnion.x + toUnion.width);
+		var otherRight = Math.max(toUnion.x, toUnion.x + toUnion.width);
+		var otherTop = Math.min(toUnion.y, toUnion.y + toUnion.height);
+		var otherBottom = Math.max(toUnion.y, toUnion.y + toUnion.height);
+
+		var x0 = Math.min(sourceLeft, otherLeft);
+		var x1 = Math.max(sourceRight, otherRight);
+		var y0 = Math.min(sourceTop, otherTop);
+		var y1 = Math.max(sourceBottom, otherBottom);
 
 		return new Rectangle(x0, y0, x1 - x0, y1 - y0);
 	}

--- a/tests/geom/src/RectangleTest.hx
+++ b/tests/geom/src/RectangleTest.hx
@@ -255,8 +255,8 @@ class RectangleTest extends Test
 		var rect = new Rectangle(0, 0, 100, 100);
 
 		Assert.isTrue(rect.containsRect(new Rectangle(0, 0, 100, 100)));
-		Assert.isFalse(rect.containsRect(new Rectangle()));
-		Assert.isFalse(rect.containsRect(new Rectangle(0, 0, 1, 0)));
+		Assert.isTrue(rect.containsRect(new Rectangle()));
+		Assert.isTrue(rect.containsRect(new Rectangle(0, 0, 1, 0)));
 		Assert.isTrue(rect.containsRect(new Rectangle(0, 0, 1, 1)));
 		Assert.isTrue(rect.containsRect(new Rectangle(1, 1)));
 		Assert.isFalse(rect.containsRect(new Rectangle(-1, 0, 100, 100)));
@@ -266,8 +266,8 @@ class RectangleTest extends Test
 
 		Assert.isTrue(rect.containsRect(new Rectangle(-100, -100, 200, 200)));
 		Assert.isTrue(rect.containsRect(new Rectangle()));
-		Assert.isFalse(rect.containsRect(new Rectangle(-100, -100)));
-		Assert.isFalse(rect.containsRect(new Rectangle(100, 100)));
+		Assert.isTrue(rect.containsRect(new Rectangle(-100, -100)));
+		Assert.isTrue(rect.containsRect(new Rectangle(100, 100)));
 		Assert.isTrue(rect.containsRect(new Rectangle(99, 99)));
 		Assert.isFalse(rect.containsRect(new Rectangle(-101, -100, 200, 200)));
 		Assert.isFalse(rect.containsRect(new Rectangle(-100, -100, 201, 201)));
@@ -373,8 +373,8 @@ class RectangleTest extends Test
 	public function test_isEmpty()
 	{
 		Assert.isTrue(new Rectangle().isEmpty());
-		Assert.isTrue(new Rectangle(100, 100, -1, -1).isEmpty());
-		Assert.isTrue(new Rectangle(0, 0, -1, -1).isEmpty());
+		Assert.isFalse(new Rectangle(100, 100, -1, -1).isEmpty());
+		Assert.isFalse(new Rectangle(0, 0, -1, -1).isEmpty());
 		Assert.isTrue(new Rectangle(0, 0, 1, 0).isEmpty());
 		Assert.isFalse(new Rectangle(0, 0, 1, 1).isEmpty());
 	}

--- a/tests/geom/src/RectangleTest.hx
+++ b/tests/geom/src/RectangleTest.hx
@@ -7,437 +7,274 @@ import utest.Test;
 
 class RectangleTest extends Test
 {
-	public function test_bottom()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(100, rect.bottom);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(0, rect.bottom);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.bottom);
-	}
-
-	public function test_bottomRight()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.notNull(rect.bottomRight);
-		Assert.isOfType(rect.bottomRight, openfl.geom.Point);
-
-		Assert.equals(100, rect.bottomRight.x);
-		Assert.equals(100, rect.bottomRight.y);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(0, rect.bottomRight.x);
-		Assert.equals(0, rect.bottomRight.y);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.bottomRight.x);
-		Assert.equals(0, rect.bottomRight.y);
-	}
-
-	public function test_height()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(100, rect.height);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(100, rect.height);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.height);
-	}
-
-	public function test_left()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(0, rect.left);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(-100, rect.left);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.left);
-	}
-
-	public function test_right()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(100, rect.right);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(0, rect.right);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.right);
-	}
-
-	public function test_size()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.notNull(rect.size);
-		Assert.isOfType(rect.size, openfl.geom.Point);
-
-		Assert.equals(100, rect.size.x);
-		Assert.equals(100, rect.size.y);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(100, rect.size.x);
-		Assert.equals(100, rect.size.y);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.size.x);
-		Assert.equals(0, rect.size.y);
-	}
-
-	public function test_top()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(0, rect.top);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(-100, rect.top);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.top);
-	}
-
-	public function test_topLeft()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.notNull(rect.topLeft);
-		Assert.isOfType(rect.topLeft, openfl.geom.Point);
-
-		Assert.equals(0, rect.topLeft.x);
-		Assert.equals(0, rect.topLeft.y);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(-100, rect.topLeft.x);
-		Assert.equals(-100, rect.topLeft.y);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.topLeft.x);
-		Assert.equals(0, rect.topLeft.y);
-	}
-
-	public function test_width()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(100, rect.width);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(100, rect.width);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.width);
-	}
-
-	public function test_x()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(0, rect.x);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(-100, rect.x);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.x);
-	}
-
-	public function test_y()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.equals(0, rect.y);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.equals(-100, rect.y);
-
-		rect = new Rectangle(0, 0, 0, 0);
-
-		Assert.equals(0, rect.y);
-	}
-
-	public function test_new_()
+	public function test_new_default()
 	{
 		var rect = new Rectangle();
-
-		Assert.notNull(rect);
 		Assert.equals(0, rect.x);
 		Assert.equals(0, rect.y);
 		Assert.equals(0, rect.width);
 		Assert.equals(0, rect.height);
+	}
 
-		rect = new Rectangle(100, 100, 100, 100);
+	public function test_new_withValues()
+	{
+		var rect = new Rectangle(1, 2, 3, 4);
+		Assert.equals(1, rect.x);
+		Assert.equals(2, rect.y);
+		Assert.equals(3, rect.width);
+		Assert.equals(4, rect.height);
+	}
 
-		Assert.equals(100, rect.x);
-		Assert.equals(100, rect.y);
-		Assert.equals(100, rect.width);
-		Assert.equals(100, rect.height);
+	public function test_bottom()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		Assert.equals(20, r.bottom);
+	}
+
+	public function test_bottomRight_getter()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		Assert.equals(10, r.bottomRight.x);
+		Assert.equals(20, r.bottomRight.y);
+	}
+
+	public function test_bottomRight_setter()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.bottomRight = new Point(15, 25);
+		Assert.equals(15, r.width);
+		Assert.equals(25, r.height);
+	}
+
+	public function test_left_setter()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.left = 5;
+		Assert.equals(5, r.x);
+		Assert.equals(5, r.width);
+	}
+
+	public function test_right_setter_negative()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.right = -5;
+		Assert.equals(-5, r.width);
+		Assert.isTrue(r.isEmpty());
+	}
+
+	public function test_size_setter()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.size = new Point(5, 6);
+		Assert.equals(5, r.width);
+		Assert.equals(6, r.height);
+	}
+
+	public function test_top_setter_negative()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.top = 25;
+		Assert.equals(-5, r.height);
+		Assert.isTrue(r.isEmpty());
+	}
+
+	public function test_topLeft_setter()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.topLeft = new Point(3, 4);
+		Assert.equals(3, r.x);
+		Assert.equals(4, r.y);
 	}
 
 	public function test_clone()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
-		var clone = rect.clone();
-
-		Assert.notEquals(rect, clone);
-		Assert.equals(rect.x, clone.x);
-		Assert.equals(rect.y, clone.y);
-		Assert.equals(rect.width, clone.width);
-		Assert.equals(rect.height, clone.height);
+		var r = new Rectangle(0, 0, 10, 20);
+		var c = r.clone();
+		Assert.isTrue(r.equals(c));
+		c.x = 100;
+		Assert.notEquals(r.x, c.x);
 	}
 
 	public function test_contains()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
+		var r = new Rectangle(0, 0, 10, 20);
+		Assert.isTrue(r.contains(0, 0));
+		Assert.isTrue(r.contains(9.999, 19.999));
+		Assert.isFalse(r.contains(10, 20));
+		Assert.isFalse(r.contains(10, 0));
+		Assert.isFalse(r.contains(0, 20));
+	}
 
-		Assert.isTrue(rect.contains(0, 0));
-		Assert.isTrue(rect.contains(99, 99));
-		Assert.isFalse(rect.contains(100, 100));
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.isTrue(rect.contains(-1, -1));
-		Assert.isTrue(rect.contains(-100, -100));
-		Assert.isFalse(rect.contains(-101, -101));
+	public function test_contains_flipped()
+	{
+		var r = new Rectangle(0, 0, -10, -20);
+		Assert.isFalse(r.contains(-5, -10));
 	}
 
 	public function test_containsPoint()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.isTrue(rect.containsPoint(new Point(0, 0)));
-		Assert.isTrue(rect.containsPoint(new Point(99, 99)));
-		Assert.isFalse(rect.containsPoint(new Point(100, 100)));
-
-		rect = new Rectangle(-100, -100, 100, 100);
-
-		Assert.isTrue(rect.containsPoint(new Point(-1, -1)));
-		Assert.isTrue(rect.containsPoint(new Point(-100, -100)));
-		Assert.isFalse(rect.containsPoint(new Point(-101, -101)));
+		var r = new Rectangle(0, 0, 10, 20);
+		Assert.isTrue(r.containsPoint(new Point(5, 10)));
 	}
 
 	public function test_containsRect()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
+		var r = new Rectangle(0, 0, 10, 10);
+		Assert.isTrue(r.containsRect(new Rectangle(2, 2, 5, 5)));
+		Assert.isFalse(r.containsRect(new Rectangle(-1, 2, 5, 5)));
+	}
 
-		Assert.isTrue(rect.containsRect(new Rectangle(0, 0, 100, 100)));
-		Assert.isTrue(rect.containsRect(new Rectangle()));
-		Assert.isTrue(rect.containsRect(new Rectangle(0, 0, 1, 0)));
-		Assert.isTrue(rect.containsRect(new Rectangle(0, 0, 1, 1)));
-		Assert.isTrue(rect.containsRect(new Rectangle(1, 1)));
-		Assert.isFalse(rect.containsRect(new Rectangle(-1, 0, 100, 100)));
-		Assert.isFalse(rect.containsRect(new Rectangle(0, 0, 100, 101)));
+	public function test_containsRect_flipped_exact()
+	{
+		var r = new Rectangle(0, 0, 10, 10);
+		var r2 = new Rectangle(10, 10, -10, -10);
+		Assert.isFalse(r.containsRect(r2));
+	}
 
-		rect = new Rectangle(-100, -100, 200, 200);
-
-		Assert.isTrue(rect.containsRect(new Rectangle(-100, -100, 200, 200)));
-		Assert.isTrue(rect.containsRect(new Rectangle()));
-		Assert.isTrue(rect.containsRect(new Rectangle(-100, -100)));
-		Assert.isTrue(rect.containsRect(new Rectangle(100, 100)));
-		Assert.isTrue(rect.containsRect(new Rectangle(99, 99)));
-		Assert.isFalse(rect.containsRect(new Rectangle(-101, -100, 200, 200)));
-		Assert.isFalse(rect.containsRect(new Rectangle(-100, -100, 201, 201)));
+	public function test_containsRect_zeroSize_corner()
+	{
+		var r = new Rectangle(0, 0, 10, 10);
+		var r2 = new Rectangle(0, 0, 0, 0);
+		Assert.isFalse(r.containsRect(r2));
 	}
 
 	public function test_copyFrom()
 	{
-		var source = new Rectangle(5.0, 6.0, 70.0, 90.0);
-		var dest = new Rectangle(1.0, 2.0, 100.0, 101.0);
-
-		source.copyFrom(dest);
-
-		Assert.equals(1.0, source.x);
-		Assert.equals(2.0, source.y);
-		Assert.equals(100.0, source.width);
-		Assert.equals(101.0, source.height);
-
-		// to check if dest reference is not modified
-		Assert.equals(1.00, dest.x);
-		Assert.equals(2.0, dest.y);
-		Assert.equals(100.00, dest.width);
-		Assert.equals(101.0, dest.height);
+		var src = new Rectangle(2, 3, 4, 5);
+		var dst = new Rectangle(0, 0, 10, 10);
+		dst.copyFrom(src);
+		Assert.isTrue(dst.equals(src));
 	}
 
 	public function test_equals()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.isTrue(rect.equals(new Rectangle(0, 0, 100, 100)));
-		Assert.isTrue(rect.equals(rect.clone()));
-		Assert.isFalse(rect.equals(new Rectangle(1, 0, 100, 100)));
-		Assert.isFalse(rect.equals(new Rectangle(0, 0, 100, 101)));
-	}
-
-	public function test_inflate()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-		rect.inflate(1, 0);
-
-		Assert.equals(102, rect.width);
-		Assert.equals(100, rect.height);
-		Assert.equals(-1, rect.x);
-		Assert.equals(0, rect.y);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-		rect.inflate(2, 2);
-
-		Assert.equals(104, rect.width);
-		Assert.equals(2, rect.right);
-		Assert.equals(-102, rect.x);
-		Assert.equals(-102, rect.y);
-
-		rect.inflate(-2, -2);
-
-		Assert.equals(100, rect.width);
-		Assert.equals(-100, rect.x);
-	}
-
-	public function test_inflatePoint()
-	{
-		var rect = new Rectangle(0, 0, 100, 100);
-		rect.inflatePoint(new Point(1, 0));
-
-		Assert.equals(102, rect.width);
-		Assert.equals(100, rect.height);
-		Assert.equals(-1, rect.x);
-		Assert.equals(0, rect.y);
-
-		rect = new Rectangle(-100, -100, 100, 100);
-		rect.inflatePoint(new Point(2, 2));
-
-		Assert.equals(104, rect.width);
-		Assert.equals(2, rect.right);
-		Assert.equals(-102, rect.x);
-		Assert.equals(-102, rect.y);
-
-		rect.inflatePoint(new Point(-2, -2));
-
-		Assert.equals(100, rect.width);
-		Assert.equals(-100, rect.x);
+		var r = new Rectangle(0, 0, 10, 10);
+		Assert.isTrue(r.equals(r.clone()));
+		Assert.isFalse(r.equals(new Rectangle(1, 0, 10, 10)));
 	}
 
 	public function test_intersection()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
+		var r1 = new Rectangle(0, 0, 10, 20);
+		var r2 = new Rectangle(5, 10, 10, 10);
+		var i = r1.intersection(r2);
+		Assert.equals(5, i.x);
+		Assert.equals(10, i.y);
+		Assert.equals(5, i.width);
+		Assert.equals(10, i.height);
+	}
 
-		Assert.isTrue(rect.intersection(new Rectangle()).equals(new Rectangle()));
-		Assert.isTrue(rect.intersection(new Rectangle(50, 50, 100, 100)).equals(new Rectangle(50, 50, 50, 50)));
-		Assert.isTrue(rect.intersection(new Rectangle(-50, -50, 100, 100)).equals(new Rectangle(0, 0, 50, 50)));
-		Assert.isTrue(rect.intersection(new Rectangle(-100, -100, 100, 100)).equals(new Rectangle()));
+	public function test_intersection_empty()
+	{
+		var r1 = new Rectangle(0, 0, 10, 10);
+		var r2 = new Rectangle(20, 20, 5, 5);
+		Assert.isTrue(r1.intersection(r2).isEmpty());
 	}
 
 	public function test_intersects()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
-
-		Assert.isFalse(rect.intersects(new Rectangle()));
-		Assert.isTrue(rect.intersects(new Rectangle(50, 50, 100, 100)));
-		Assert.isTrue(rect.intersects(new Rectangle(-50, -50, 100, 100)));
-		Assert.isFalse(rect.intersects(new Rectangle(-100, -100, 100, 100)));
+		var r = new Rectangle(0, 0, 10, 20);
+		Assert.isTrue(r.intersects(new Rectangle(5, 10, 10, 10)));
+		Assert.isFalse(r.intersects(new Rectangle(20, 20, 5, 5)));
 	}
 
 	public function test_isEmpty()
 	{
 		Assert.isTrue(new Rectangle().isEmpty());
-		Assert.isFalse(new Rectangle(100, 100, -1, -1).isEmpty());
-		Assert.isFalse(new Rectangle(0, 0, -1, -1).isEmpty());
-		Assert.isTrue(new Rectangle(0, 0, 1, 0).isEmpty());
+		Assert.isTrue(new Rectangle(0, 0, -5, -5).isEmpty());
+		Assert.isTrue(new Rectangle(0, 0, 0, 10).isEmpty());
 		Assert.isFalse(new Rectangle(0, 0, 1, 1).isEmpty());
 	}
 
 	public function test_offset()
 	{
-		var rect = new Rectangle();
-		rect.offset(-1, -1);
-
-		Assert.isTrue(rect.equals(new Rectangle(-1, -1, 0, 0)));
-
-		rect.offset(1, 1);
-
-		Assert.isTrue(rect.equals(new Rectangle()));
-
-		rect = new Rectangle(0, 0, 100, 100);
-		rect.offset(20, 0);
-
-		Assert.isTrue(rect.equals(new Rectangle(20, 0, 100, 100)));
+		var r = new Rectangle(0, 0, 10, 10);
+		r.offset(5, 10);
+		Assert.equals(5, r.x);
+		Assert.equals(10, r.y);
 	}
 
 	public function test_offsetPoint()
 	{
-		var rect = new Rectangle();
-		rect.offsetPoint(new Point(-1, -1));
+		var r = new Rectangle(0, 0, 10, 10);
+		r.offsetPoint(new Point(3, 4));
+		Assert.equals(3, r.x);
+		Assert.equals(4, r.y);
+	}
 
-		Assert.isTrue(rect.equals(new Rectangle(-1, -1, 0, 0)));
+	public function test_inflate()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.inflate(2, 3);
+		Assert.equals(-2, r.x);
+		Assert.equals(-3, r.y);
+		Assert.equals(14, r.width);
+		Assert.equals(26, r.height);
+	}
 
-		rect = new Rectangle(0, 0, 100, 100);
-		rect.offsetPoint(new Point(20, 0));
-
-		Assert.isTrue(rect.equals(new Rectangle(20, 0, 100, 100)));
+	public function test_inflatePoint()
+	{
+		var r = new Rectangle(0, 0, 10, 20);
+		r.inflatePoint(new Point(1, 2));
+		Assert.equals(-1, r.x);
+		Assert.equals(-2, r.y);
+		Assert.equals(12, r.width);
+		Assert.equals(24, r.height);
 	}
 
 	public function test_setEmpty()
 	{
-		var rect = new Rectangle(0, 0, 100, 100);
-		rect.setEmpty();
-
-		Assert.isTrue(rect.isEmpty());
-
-		rect = new Rectangle(0, 0, 100, 100);
-		rect.setEmpty();
-
-		Assert.isTrue(rect.equals(new Rectangle()));
+		var r = new Rectangle(1, 2, 3, 4);
+		r.setEmpty();
+		Assert.isTrue(r.isEmpty());
 	}
 
 	public function test_setTo()
 	{
-		var rect = new Rectangle(0.0, 0.0, 100.0, 100.0);
-		rect.setTo(5.0, 6.0, 7.0, 8.0);
+		var r = new Rectangle();
+		r.setTo(1, 2, 3, 4);
+		Assert.equals(1, r.x);
+		Assert.equals(2, r.y);
+		Assert.equals(3, r.width);
+		Assert.equals(4, r.height);
+	}
 
-		Assert.equals(5.0, rect.x);
-		Assert.equals(6.0, rect.y);
-		Assert.equals(7.0, rect.width);
-		Assert.equals(8.0, rect.height);
+	public function test_toString()
+	{
+		var r = new Rectangle(1, 2, 3, 4);
+		Assert.equals("(x=1, y=2, w=3, h=4)", r.toString());
 	}
 
 	public function test_union()
 	{
-		Assert.isTrue(new Rectangle().union(new Rectangle()).isEmpty());
-		Assert.isTrue(new Rectangle().union(new Rectangle(0, 0, 100, 100)).equals(new Rectangle(0, 0, 100, 100)));
-		Assert.isTrue(new Rectangle(-100, -100, 100, 100).union(new Rectangle(-20, -20, 100, 100)).equals(new Rectangle(-100, -100, 180, 180)));
-		Assert.isTrue(new Rectangle(-100, -100, 10, 10).union(new Rectangle(100, 100, 10, 10)).equals(new Rectangle(-100, -100, 210, 210)));
+		var r1 = new Rectangle(0, 0, 10, 20);
+		var r2 = new Rectangle(5, 15, 10, 10);
+		var u = r1.union(r2);
+		Assert.equals(15, u.width);
+		Assert.equals(25, u.height);
+	}
+
+	public function test_union_flipped()
+	{
+		var r1 = new Rectangle(0, 0, 10, 20);
+		var r2 = new Rectangle(15, 20, -10, -10);
+		var u = r1.union(r2);
+		Assert.equals(10, u.width);
+		Assert.equals(20, u.height);
+	}
+
+	public function test_setter_ordering()
+	{
+		var r = new Rectangle(0, 0, 10, 10);
+		r.right = 5;
+		r.left = 2;
+		Assert.equals(2, r.x);
+		Assert.equals(3, r.width);
+
+		r = new Rectangle(0, 0, 10, 10);
+		r.left = 2;
+		r.right = 5;
+		Assert.equals(2, r.x);
+		Assert.equals(3, r.width);
 	}
 }


### PR DESCRIPTION
Rectangles can have a negative width and height. Previously, these were treated as if they were empty. I believe these are originally supported as being mirrored, so they extend to the left or above the origin point, instead of to the right and below.

Included are updates to `contains`, `containsRect`, `isEmpty`, and `union` according to my other tests.

I'm submitting as a pull request here for consideration and feedback.

Have a great day!