### PR TITLE
Fix fast scaleX/scaleY transform update path

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -2321,7 +2321,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		{
 			__scaleX = value;
 
-			if (__transform.b == 0)
+			if (__rotation == 0)
 			{
 				if (value != __transform.a) __setTransformDirty();
 				__transform.a = value;
@@ -2355,7 +2355,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		{
 			__scaleY = value;
 
-			if (__transform.c == 0)
+			if (__rotation == 0)
 			{
 				if (value != __transform.d) __setTransformDirty();
 				__transform.d = value;


### PR DESCRIPTION
The original code checks for `__transform.b == 0` or `__transform.c == 0` as a sign that the local transform has not been rotated.

However it is my understanding that if `rotation = 180` or `rotation = -180`, these will return true except we must use a _negative_ scale value in order to have the proper local transform. As a result, in this specific case of 180 degree rotation, scale values will be wrong.

This could be written to defer the local transform calculation, or to handle other cardinal values, however at a minimum, this should probably resolve a bug.