### PR TITLE
Event: Use rest arguments in formatToString for Haxe 4.2+

### DIFF
--- a/lib/flash-externs/src/flash/events/Event.hx
+++ b/lib/flash-externs/src/flash/events/Event.hx
@@ -99,7 +99,11 @@ extern class Event
 
 	public function new(type:String, bubbles:Bool = false, cancelable:Bool = false);
 	public function clone():Event;
+	#if (haxe_ver >= 4.2)
+	public function formatToString(className:String, args:haxe.Rest<String>):String;
+	#else
 	public function formatToString(className:String, ?p1:Dynamic, ?p2:Dynamic, ?p3:Dynamic, ?p4:Dynamic, ?p5:Dynamic):String;
+	#end
 	public function isDefaultPrevented():Bool;
 	public function preventDefault():Void;
 	public function stopImmediatePropagation():Void;

--- a/src/openfl/events/Event.hx
+++ b/src/openfl/events/Event.hx
@@ -829,6 +829,12 @@ class Event
 		@return The name of your custom Event class and the String value of
 				your `...arguments` parameter.
 	**/
+	#if (haxe_ver >= 4.2)
+	public function formatToString(className:String, args:haxe.Rest<String>):String
+	{
+		return __formatToString(className, args);
+	}
+	#else
 	public function formatToString(className:String, p1:String = null, p2:String = null, p3:String = null, p4:String = null, p5:String = null):String
 	{
 		var parameters:Array<String> = [];
@@ -840,6 +846,7 @@ class Event
 
 		return Reflect.callMethod(this, __formatToString, [className, parameters]);
 	}
+	#end
 
 	/**
 		Checks whether the `preventDefault()` method has been called on


### PR DESCRIPTION
This matches Flash and allows you to pass more than 5 field names.