### PR TITLE
Fix StageScaleMode and StageAlign behaviors

### DIFF
--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -390,7 +390,17 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	**/
 	public function setViewport():Void
 	{
-		__gl.viewport(__offsetX, __offsetY, __displayWidth, __displayHeight);
+		if (__defaultRenderTarget == null && __context3D != null && __context3D.__stage3D == null && __stage != null && __stage.window != null)
+		{
+			var contextHeight = Std.int(__stage.window.height * __stage.window.scale);
+			var viewportY = contextHeight - __displayHeight - __offsetY;
+			if (viewportY < 0) viewportY = 0;
+			__gl.viewport(__offsetX, viewportY, __displayWidth, __displayHeight);
+		}
+		else
+		{
+			__gl.viewport(__offsetX, __offsetY, __displayWidth, __displayHeight);
+		}
 	}
 
 	/**
@@ -402,6 +412,10 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	{
 		if (__currentShader != null)
 		{
+			if (__defaultRenderTarget == null && __context3D.__state.renderToTexture == null)
+			{
+				setViewport();
+			}
 			if (__currentShader.__position != null) __currentShader.__position.__useArray = true;
 			if (__currentShader.__textureCoord != null) __currentShader.__textureCoord.__useArray = true;
 			__context3D.setProgram(__currentShader.program);
@@ -777,6 +791,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 			}
 			#end
 			__context3D.setScissorRectangle(__scissorRectangle);
+			setViewport();
 
 			__upscaled = (__worldTransform.a != 1 || __worldTransform.d != 1);
 
@@ -848,7 +863,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 			}
 			#end
 			__context3D.setScissorRectangle(__scissorRectangle);
-			// __gl.viewport (__offsetX, __offsetY, __displayWidth, __displayHeight);
+			setViewport();
 
 			// __upscaled = (__worldTransform.a != 1 || __worldTransform.d != 1);
 
@@ -978,6 +993,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 
 		__projection.createOrtho(0, __displayWidth + __offsetX * 2, 0, __displayHeight + __offsetY * 2, -1000, 1000);
 		__projectionFlipped.createOrtho(0, __displayWidth + __offsetX * 2, __displayHeight + __offsetY * 2, 0, -1000, 1000);
+		setViewport();
 	}
 
 	@:noCompletion private function __resumeClipAndMask(childRenderer:OpenGLRenderer):Void

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -986,10 +986,22 @@ class OpenGLRenderer extends DisplayObjectRenderer
 		var w = (__defaultRenderTarget == null) ? __stage.stageWidth : __defaultRenderTarget.width;
 		var h = (__defaultRenderTarget == null) ? __stage.stageHeight : __defaultRenderTarget.height;
 
-		__offsetX = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformX(0, 0)) : 0;
-		__offsetY = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformY(0, 0)) : 0;
-		__displayWidth = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformX(w, 0) - __offsetX) : w;
-		__displayHeight = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformY(0, h) - __offsetY) : h;
+		if (__defaultRenderTarget == null && __context3D != null && __context3D.__stage3D == null)
+		{
+			// Stage2D path: Stage.__displayMatrix already contains scale + align translation.
+			// Use a full-window viewport to avoid applying alignment offset twice.
+			__offsetX = 0;
+			__offsetY = 0;
+			__displayWidth = width;
+			__displayHeight = height;
+		}
+		else
+		{
+			__offsetX = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformX(0, 0)) : 0;
+			__offsetY = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformY(0, 0)) : 0;
+			__displayWidth = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformX(w, 0) - __offsetX) : w;
+			__displayHeight = __defaultRenderTarget == null ? Math.round(__worldTransform.__transformY(0, h) - __offsetY) : h;
+		}
 
 		__projection.createOrtho(0, __displayWidth + __offsetX * 2, 0, __displayHeight + __offsetY * 2, -1000, 1000);
 		__projectionFlipped.createOrtho(0, __displayWidth + __offsetX * 2, __displayHeight + __offsetY * 2, 0, -1000, 1000);

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -2352,6 +2352,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 					__renderer.__clear();
 				}
 
+				__renderer.__worldTransform = __displayMatrix;
 				__renderer.__render(this);
 			}
 			else if (context3D == null)
@@ -3654,7 +3655,9 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 		if (context3D != null)
 		{
-			#if openfl_dpi_aware
+			#if cpp
+			context3D.configureBackBuffer(windowWidth, windowHeight, 0, true, true, true);
+			#elseif openfl_dpi_aware
 			context3D.configureBackBuffer(windowWidth, windowHeight, 0, true, true, true);
 			#else
 			context3D.configureBackBuffer(stageWidth, stageHeight, 0, true, true, true);
@@ -3668,6 +3671,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 		if (__renderer != null)
 		{
+			__renderer.__worldTransform = __displayMatrix;
 			__renderer.__resize(windowWidth, windowHeight);
 		}
 

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -3551,6 +3551,10 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 		var visibleY = 0.0;
 		switch (align)
 		{
+			case null:
+				// AIR/Flash behavior for stage.align = "" (no edge anchor): center both axes
+				visibleX = Math.round((__logicalWidth - visibleWidth) / 2);
+				visibleY = Math.round((__logicalHeight - visibleHeight) / 2);
 			case BOTTOM_RIGHT:
 				visibleX = Math.round(__logicalWidth - visibleWidth);
 				visibleY = Math.round(__logicalHeight - visibleHeight);

--- a/src/openfl/display/StageAlign.hx
+++ b/src/openfl/display/StageAlign.hx
@@ -52,14 +52,14 @@ package openfl.display;
 	{
 		return switch (value)
 		{
-			case "bottom": BOTTOM;
-			case "bottomLeft": BOTTOM_LEFT;
-			case "bottomRight": BOTTOM_RIGHT;
-			case "left": LEFT;
-			case "right": RIGHT;
-			case "top": TOP;
-			case "topLeft": TOP_LEFT;
-			case "topRight": TOP_RIGHT;
+			case "bottom", "B", "b": BOTTOM;
+			case "bottomLeft", "BL", "bl": BOTTOM_LEFT;
+			case "bottomRight", "BR", "br": BOTTOM_RIGHT;
+			case "left", "L", "l": LEFT;
+			case "right", "R", "r": RIGHT;
+			case "top", "T", "t": TOP;
+			case "topLeft", "TL", "tl": TOP_LEFT;
+			case "topRight", "TR", "tr": TOP_RIGHT;
 			default: null;
 		}
 	}

--- a/src/openfl/display3D/Context3D.hx
+++ b/src/openfl/display3D/Context3D.hx
@@ -12,6 +12,7 @@ import openfl.display3D.textures.TextureBase;
 import openfl.display3D.textures.Texture;
 import openfl.display3D.textures.VideoTexture;
 import openfl.display.BitmapData;
+import openfl.display.OpenGLRenderer;
 import openfl.display.Stage;
 import openfl.display.Stage3D;
 import openfl.errors.Error;
@@ -140,6 +141,7 @@ import lime.math.Vector2;
 @:access(openfl.display.BitmapData)
 @:access(openfl.display.Bitmap)
 @:access(openfl.display.DisplayObjectRenderer)
+@:access(openfl.display.OpenGLRenderer)
 @:access(openfl.display.Shader)
 @:access(openfl.display.Stage)
 @:access(openfl.display.Stage3D)
@@ -2461,9 +2463,21 @@ import lime.math.Vector2;
 					scaledBackBufferHeight = Std.int(backBufferHeight * __stage.window.scale);
 				}
 				#end
-				var x = __stage3D == null ? 0 : Std.int(__stage3D.x);
-				var y = Std.int((__stage.window.height * __stage.window.scale) - scaledBackBufferHeight - (__stage3D == null ? 0 : __stage3D.y));
-				gl.viewport(x, y, scaledBackBufferWidth, scaledBackBufferHeight);
+				if (__stage3D == null && __stage.__renderer != null && Std.isOfType(__stage.__renderer, OpenGLRenderer))
+				{
+					var renderer:OpenGLRenderer = cast __stage.__renderer;
+					var contextHeight = Std.int(__stage.window.height * __stage.window.scale);
+					var viewportX = renderer.__offsetX;
+					var viewportY = contextHeight - renderer.__displayHeight - renderer.__offsetY;
+					if (viewportY < 0) viewportY = 0;
+					gl.viewport(viewportX, viewportY, renderer.__displayWidth, renderer.__displayHeight);
+				}
+				else
+				{
+					var x = __stage3D == null ? 0 : Std.int(__stage3D.x);
+					var y = Std.int((__stage.window.height * __stage.window.scale) - scaledBackBufferHeight - (__stage3D == null ? 0 : __stage3D.y));
+					gl.viewport(x, y, scaledBackBufferWidth, scaledBackBufferHeight);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Hi, on latest OpenFL version (9.5.1), StageScaleMode.SHOW_ALL/EXACT_FIT/NO_BORDER behaves mostly the same as NO_SCALE, except things get blurry when the windows is resized down, and it adds a mouse offset. I tried oldest OpenFL versions and it gave different but still not right results.
Now, SHOW_ALL/EXACT_FIT/NO_BORDER behaves exactly like on Flash.
As for StageAlign, the alignment was previously applied two times for some reason, which was causing it to be incorrect. I also added the "" value which centers horizontally and vertically, like on Flash.
Note: StageAlign still doesn't seem to do anything when used with StageScaleMode.NO_SCALE, which I think isn't correct.

Validated on Windows/C++ target with a minimal repro and game project.
I believe this should fix https://github.com/openfl/openfl/issues/2768