### PR TITLE
Fix references to Lime classes when `lime` isn't defined.

### DIFF
--- a/src/openfl/display/Application.hx
+++ b/src/openfl/display/Application.hx
@@ -35,6 +35,7 @@ class Application #if lime extends LimeApplication #end
 	#if !lime
 	public static var current:Application;
 
+	public var meta:Map<String, String>;
 	public var window:Window;
 	#end
 
@@ -42,6 +43,8 @@ class Application #if lime extends LimeApplication #end
 	{
 		#if lime
 		super();
+		#else
+		meta = new Map();
 		#end
 
 		if (Lib.application == null)

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -744,7 +744,7 @@ class BitmapData implements IBitmapDrawable
 	**/
 	public function dispose():Void
 	{
-		#if (js && html5)
+		#if (js && html5 && lime)
 		// if this BitmapData was created with Assets.getBitmapData(), then
 		// don't destroy the underlying image buffer.
 		// on html5, images are loaded asynchronously, and cloning is too
@@ -1014,7 +1014,9 @@ class BitmapData implements IBitmapDrawable
 			}
 
 			#if (js && html5)
+			#if lime
 			ImageCanvasUtil.convertToCanvas(image);
+			#end
 			var renderer = new CanvasRenderer(image.buffer.__srcContext);
 			#else
 			var renderer = new CairoRenderer(new Cairo(getSurface()));
@@ -1315,12 +1317,16 @@ class BitmapData implements IBitmapDrawable
 	**/
 	public static function fromCanvas(canvas:CanvasElement, transparent:Bool = true):BitmapData
 	{
+		#if lime
 		if (canvas == null) return null;
 
 		var bitmapData = new BitmapData(0, 0, transparent, 0);
 		bitmapData.__fromImage(Image.fromCanvas(canvas));
 		bitmapData.image.transparent = transparent;
 		return bitmapData;
+		#else
+		return null;
+		#end
 	}
 	#end
 
@@ -3116,7 +3122,7 @@ class BitmapData implements IBitmapDrawable
 
 	@:noCompletion private function __applyAlpha(alpha:ByteArray):Void
 	{
-		#if (js && html5)
+		#if (js && html5 && lime)
 		ImageCanvasUtil.convertToCanvas(image);
 		ImageCanvasUtil.createImageData(image);
 		#end
@@ -3445,7 +3451,7 @@ class BitmapData implements IBitmapDrawable
 
 	@:noCompletion private function __sync():Void
 	{
-		#if (js && html5)
+		#if (js && html5 && lime)
 		ImageCanvasUtil.sync(image, false);
 		#end
 	}

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -2778,6 +2778,8 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 			__dispatchEvent(new FullScreenEvent(FullScreenEvent.FULL_SCREEN, false, false, false, true));
 		}
 	}
+	#else // lime
+	@:noCompletion private function __renderAfterEvent():Void {}
 	#end
 
 	@:noCompletion private function __onMouse(type:String, x:Float, y:Float, button:Int):Void

--- a/src/openfl/display/Stage3D.hx
+++ b/src/openfl/display/Stage3D.hx
@@ -115,7 +115,9 @@ class Stage3D extends EventDispatcher
 	@:noCompletion private var __y:Float;
 	#if (js && html5)
 	@:noCompletion private var __canvas:CanvasElement;
+	#if lime
 	@:noCompletion private var __renderContext:RenderContext;
+	#end
 	@:noCompletion private var __style:CSSStyleDeclaration;
 	@:noCompletion private var __webgl:RenderingContext;
 	#end

--- a/src/openfl/display/Window.hx
+++ b/src/openfl/display/Window.hx
@@ -25,6 +25,9 @@ class Window #if lime extends LimeWindow #end
 	@SuppressWarnings("checkstyle:Dynamic") public var context:Dynamic;
 	@SuppressWarnings("checkstyle:Dynamic") public var cursor:Dynamic;
 	@SuppressWarnings("checkstyle:Dynamic") public var display:Dynamic;
+	#if (js && html5)
+	public var element(default, null):js.html.Element;
+	#end
 	public var frameRate:Float;
 	public var fullscreen:Bool;
 	public var height:Int;
@@ -77,13 +80,15 @@ class Window #if lime extends LimeWindow #end
 		#end
 	}
 
-	override public function close():Void
+	#if lime override #end public function close():Void
 	{
+		#if lime
 		super.close();
 		if (onClose.canceled)
 		{
 			return;
 		}
+		#end
 		if (stage == null)
 		{
 			// already closed

--- a/src/openfl/display/_internal/CanvasBitmap.hx
+++ b/src/openfl/display/_internal/CanvasBitmap.hx
@@ -14,7 +14,7 @@ class CanvasBitmap
 {
 	public static inline function render(bitmap:Bitmap, renderer:CanvasRenderer):Void
 	{
-		#if (js && html5)
+		#if (js && html5 && lime)
 		if (!bitmap.__renderable) return;
 
 		var alpha = renderer.__getAlpha(bitmap.__worldAlpha);

--- a/src/openfl/display/_internal/CanvasBitmapData.hx
+++ b/src/openfl/display/_internal/CanvasBitmapData.hx
@@ -15,10 +15,12 @@ class CanvasBitmapData
 
 		var image = bitmapData.image;
 
+		#if lime
 		if (image.type == DATA)
 		{
 			ImageCanvasUtil.convertToCanvas(image);
 		}
+		#end
 
 		var context = renderer.context;
 		context.globalAlpha = 1;

--- a/src/openfl/display/_internal/CanvasDisplayObject.hx
+++ b/src/openfl/display/_internal/CanvasDisplayObject.hx
@@ -33,9 +33,11 @@ class CanvasDisplayObject
 
 			renderer.setTransform(displayObject.__renderTransform, context);
 
+			#if lime
 			var color:ARGB = (displayObject.opaqueBackground : ARGB);
 			context.fillStyle = 'rgb(${color.r},${color.g},${color.b})';
 			context.fillRect(0, 0, displayObject.width, displayObject.height);
+			#end
 
 			renderer.__popMaskObject(displayObject);
 		}

--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -136,7 +136,7 @@ class CanvasGraphics
 	@SuppressWarnings("checkstyle:Dynamic")
 	private static function createBitmapFill(bitmap:BitmapData, bitmapRepeat:Bool, smooth:Bool):#if (js && html5) CanvasPattern #else Dynamic #end
 	{
-		#if (js && html5)
+		#if (js && html5 && lime)
 		ImageCanvasUtil.convertToCanvas(bitmap.image);
 		setSmoothing(smooth);
 		// flash extends the pixels on the edges to fill any remaining space,

--- a/src/openfl/display/_internal/CanvasTilemap.hx
+++ b/src/openfl/display/_internal/CanvasTilemap.hx
@@ -143,10 +143,12 @@ class CanvasTilemap
 
 				if (bitmapData != cacheBitmapData)
 				{
+					#if lime
 					if (bitmapData.image.buffer.__srcImage == null)
 					{
 						ImageCanvasUtil.convertToCanvas(bitmapData.image);
 					}
+					#end
 
 					source = bitmapData.image.src;
 					cacheBitmapData = bitmapData;

--- a/src/openfl/display/_internal/DOMBitmap.hx
+++ b/src/openfl/display/_internal/DOMBitmap.hx
@@ -97,7 +97,9 @@ class DOMBitmap
 
 		if (bitmap.__imageVersion != bitmap.__bitmapData.image.version)
 		{
+			#if lime
 			ImageCanvasUtil.convertToCanvas(bitmap.__bitmapData.image);
+			#end
 
 			// Next line is workaround, to fix rendering bug in Chrome 59 (https://vimeo.com/222938554)
 			bitmap.__canvas.width = bitmap.__bitmapData.width + 1;

--- a/src/openfl/net/FileReference.hx
+++ b/src/openfl/net/FileReference.hx
@@ -956,7 +956,7 @@ class FileReference extends EventDispatcher
 			data = Bytes.fromFile(__path);
 			openFileDialog_onComplete();
 		}
-		#elseif (js && html5)
+		#elseif (js && html5 && lime)
 		var file = __inputControl.files[0];
 		var reader = new FileReader();
 		reader.onload = function(evt)
@@ -1358,7 +1358,7 @@ class FileReference extends EventDispatcher
 			return;
 		}
 		__uploadFileBytes(request, uploadDataFieldName, fileBytes);
-		#elseif (js && html5)
+		#elseif (js && html5 && lime)
 		var file = __inputControl.files[0];
 		var reader = new FileReader();
 		reader.onload = function(evt)

--- a/src/openfl/printing/PrintJob.hx
+++ b/src/openfl/printing/PrintJob.hx
@@ -345,7 +345,9 @@ class PrintJob
 			for (i in 0...__bitmapData.length)
 			{
 				bitmapData = __bitmapData[i];
+				#if lime
 				ImageCanvasUtil.sync(bitmapData.image, false);
+				#end
 
 				if (bitmapData.image.buffer.__srcCanvas != null)
 				{

--- a/src/openfl/utils/ByteArray.hx
+++ b/src/openfl/utils/ByteArray.hx
@@ -1281,7 +1281,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 		compress(CompressionAlgorithm.DEFLATE);
 	}
 
-	#if openfljs
+	#if (openfljs && lime)
 	public static function fromArrayBuffer(buffer:ArrayBuffer):ByteArrayData
 	{
 		return ByteArray.fromArrayBuffer(buffer);
@@ -1441,7 +1441,7 @@ abstract ByteArray(ByteArrayData) from ByteArrayData to ByteArrayData
 
 	public function readMultiByte(length:Int, charSet:String):String
 	{
-		#if js
+		#if (js && lime)
 		if (position + length > __length)
 		{
 			throw new EOFError();

--- a/src/openfl/utils/Future.hx
+++ b/src/openfl/utils/Future.hx
@@ -1,7 +1,7 @@
 package openfl.utils;
 
 #if !lime
-@SuppressWarnings("checkstyle:FieldDocComment")
+@SuppressWarnings("checkstyle:FieldDocComment") @:allow(openfl.utils.Promise)
 class Future<T>
 {
 	public var error(default, null):Dynamic;

--- a/src/openfl/utils/Promise.hx
+++ b/src/openfl/utils/Promise.hx
@@ -100,16 +100,6 @@ class Promise<T>
 		{
 			future.isComplete = true;
 			future.value = data;
-
-			if (future.__completeListeners != null)
-			{
-				for (listener in future.__completeListeners)
-				{
-					listener(data);
-				}
-
-				future.__completeListeners = null;
-			}
 		}
 
 		return this;
@@ -141,16 +131,6 @@ class Promise<T>
 		{
 			future.isError = true;
 			future.error = msg;
-
-			if (future.__errorListeners != null)
-			{
-				for (listener in future.__errorListeners)
-				{
-					listener(msg);
-				}
-
-				future.__errorListeners = null;
-			}
 		}
 
 		return this;
@@ -166,13 +146,6 @@ class Promise<T>
 	{
 		if (!future.isError && !future.isComplete)
 		{
-			if (future.__progressListeners != null)
-			{
-				for (listener in future.__progressListeners)
-				{
-					listener(progress, total);
-				}
-			}
 		}
 
 		return this;

--- a/src/openfl/utils/Timer.hx
+++ b/src/openfl/utils/Timer.hx
@@ -220,11 +220,13 @@ class Timer extends EventDispatcher
 
 	@:noCompletion private function __handleUpdateAfterEvent():Void
 	{
+		#if lime
 		if (Lib.current == null || Lib.current.stage == null)
 		{
 			return;
 		}
 		Lib.current.stage.__renderAfterEvent();
+		#end
 	}
 
 	// Event Handlers


### PR DESCRIPTION
Several places import a Lime class inside an `#if lime` check, then reference that class without such a check. Or they extend a Lime class if `lime` is defined, then reference an inherited property without checking. This PR fixes most of those, other than in _ApplicationMain.hx_.

But I think the real question should be, do we check `#if lime` at all? Clearly, large portions of OpenFL only work with Lime, and this hasn't been caught in years, so I think it's safe to assume Lime is always available. Unless I'm missing something?