### PR TITLE
Fix `-D lime-modular` mode.

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -101,6 +101,8 @@
 
 			<module name="openfl" if="html5 lime-modular">
 
+				<haxedef name="lime" />
+
 				<source path="src" package="openfl" exclude="openfl._internal.renderer.console.*|*.Context3DGraphics|*.SWFLibrary" />
 
 				<!-- @:expose on enums do not work in Haxe 3.4.2 -->


### PR DESCRIPTION
In this mode, Lime's classes are available, but for whatever reason `lime` isn't defined. This makes OpenFL [avoid referencing most Lime classes](https://github.com/openfl/openfl/pull/2843), which breaks a lot of functionality for no reason.

Note: this won't work without https://github.com/openfl/lime/pull/2035.