### PR TITLE
Clamp Cairo graphics upscale surfaces to max texture size

### DIFF
--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -1896,7 +1896,20 @@ class CairoGraphics
 
 			if (graphics.__cairo == null || graphics.__bitmap == null)
 			{
-				var bitmap = needsUpscaling ? new BitmapData(Std.int(width * 1.25), Std.int(height * 1.25), true, 0) : new BitmapData(width, height, true, 0);
+				var bitmapWidth = needsUpscaling ? Std.int(width * 1.25) : width;
+				var bitmapHeight = needsUpscaling ? Std.int(height * 1.25) : height;
+
+				if (Graphics.maxTextureWidth != null && bitmapWidth > Graphics.maxTextureWidth)
+				{
+					bitmapWidth = Graphics.maxTextureWidth;
+				}
+
+				if (Graphics.maxTextureHeight != null && bitmapHeight > Graphics.maxTextureHeight)
+				{
+					bitmapHeight = Graphics.maxTextureHeight;
+				}
+
+				var bitmap = new BitmapData(bitmapWidth, bitmapHeight, true, 0);
 				var surface = bitmap.getSurface();
 				graphics.__cairo = new Cairo(surface);
 				graphics.__bitmap = bitmap;


### PR DESCRIPTION
## Summary

Clamp the temporary Cairo `Graphics` bitmap size to `Graphics.maxTextureWidth` / `Graphics.maxTextureHeight` when OpenFL reallocates a larger software surface.

## Problem

On native/OpenGL targets with HiDPI displays, some large `Graphics` objects may be reallocated at `1.25x` size in the Cairo path. In some cases this pushes the internal bitmap above `GL_MAX_TEXTURE_SIZE` (in my case: `17335 > 16384`), which can cause the graphic to disappear entirely.

This was reproducible with a very large world map background that rendered correctly on lower-DPI displays, but turned black on higher-DPI displays.

## Fix

When Cairo reallocates a larger backing `BitmapData`, clamp the new width and height to the current `Graphics.maxTextureWidth` / `Graphics.maxTextureHeight` before creating the surface.

This keeps the HiDPI behavior for normal cases, while preventing oversized intermediate textures from exceeding the GPU limit.

## Notes

This avoids the need for the global `openfl_disable_hdpi_graphics` workaround, which fixes the issue but also reduces visual quality for other graphics-based content.