### PR TITLE
Reduce cacheAsBitmap filter buffer churn for filtered OpenGL caches

### DIFF
--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -467,11 +467,24 @@ class DisplayObjectRenderer extends EventDispatcher
 			}
 			else
 			{
-				// Should we retain these longer?
+				var currentCacheBitmapData = displayObject.__cacheBitmap.bitmapData;
 
-				displayObject.__cacheBitmapData = displayObject.__cacheBitmap.bitmapData;
-				displayObject.__cacheBitmapData2 = null;
-				displayObject.__cacheBitmapData3 = null;
+				if (currentCacheBitmapData == displayObject.__cacheBitmapData2)
+				{
+					var previousMainBitmapData = displayObject.__cacheBitmapData;
+					displayObject.__cacheBitmapData = currentCacheBitmapData;
+					displayObject.__cacheBitmapData2 = previousMainBitmapData;
+				}
+				else if (currentCacheBitmapData == displayObject.__cacheBitmapData3)
+				{
+					var previousMainBitmapData = displayObject.__cacheBitmapData;
+					displayObject.__cacheBitmapData = currentCacheBitmapData;
+					displayObject.__cacheBitmapData3 = previousMainBitmapData;
+				}
+				else
+				{
+					displayObject.__cacheBitmapData = currentCacheBitmapData;
+				}
 			}
 
 			if (updateTransform || needRender)

--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -699,7 +699,14 @@ class DisplayObjectRenderer extends EventDispatcher
 							filter.__renderDirty = false;
 						}
 
-						displayObject.__cacheBitmap.__bitmapData = bitmap;
+						if (displayObject.__cacheBitmapData != bitmap)
+						{
+							cacheBitmap = displayObject.__cacheBitmapData;
+							displayObject.__cacheBitmapData = bitmap;
+							displayObject.__cacheBitmapData2 = cacheBitmap;
+						}
+
+						displayObject.__cacheBitmap.__bitmapData = displayObject.__cacheBitmapData;
 					}
 
 					parentRenderer.__blendMode = NORMAL;


### PR DESCRIPTION
## Summary

This PR reduces `cacheAsBitmap` buffer churn in `DisplayObjectRenderer` for filtered objects rendered through the OpenGL cache path.

The main change keeps auxiliary bitmap buffers alive across cache reuse instead of discarding them immediately. In a real-world SWF-heavy native C++ project, this consistently reduced peak process memory before GC.

The PR also includes a small follow-up change that keeps the primary cache bitmap reference aligned with the last filter output buffer. This second change did not show a measurable memory difference in the tested scenario, but it appears to be a safer state transition when filter passes swap buffers.

## Changes

1. Retain auxiliary filter cache buffers between cache updates.
2. Keep the primary cache bitmap reference aligned with the latest filter output.

## Testing

Tested on a native C++ OpenFL build with a SWF-heavy UI scene using filtered cached display objects.

Observed in repeated runs:

- short run: about 2050 MB -> 1900 MB before the first major GC
- 10-minute run: about 4450 MB -> 4250 MB peak before GC

The second change did not show a measurable memory difference in these tests.

## Notes

This does not eliminate the broader native memory gap in the tested project, but it consistently reduces allocation churn and peak process memory in this filtered cache path.

If preferred, the second commit can be dropped to keep the PR limited to the measured memory-related change only.