### PR TITLE
Support deferred cleanup for removed display children

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -996,6 +996,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 	@:noCompletion private var __renderTransform:Matrix;
 	@:noCompletion private var __renderTransformCache:Matrix;
 	@:noCompletion private var __renderTransformChanged:Bool;
+	@:noCompletion private var __removedChildCleanupDelay:Float;
 	@:noCompletion private var __rotation:Float;
 	@:noCompletion private var __rotationCosine:Float;
 	@:noCompletion private var __rotationSine:Float;
@@ -1134,6 +1135,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 		__cacheAsBitmap = false;
 		__transform = new Matrix();
 		__visible = true;
+		__removedChildCleanupDelay = 0.0;
 
 		__rotation = 0;
 		__rotationSine = 0;

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -1,6 +1,7 @@
 package openfl.display;
 
 #if !flash
+import haxe.Timer;
 import openfl.errors.ArgumentError;
 import openfl.errors.RangeError;
 import openfl.errors.TypeError;
@@ -99,6 +100,7 @@ class DisplayObjectContainer extends InteractiveObject
 
 	// @:noCompletion @:dox(hide) public var textSnapshot (default, never):openfl.text.TextSnapshot;
 	@:noCompletion private var __removedChildren:Vector<DisplayObject>;
+	@:noCompletion private var __removedChildrenCleanupAt:Vector<Float>;
 	@:noCompletion private var __tabChildren:Bool;
 
 	#if openfljs
@@ -129,6 +131,7 @@ class DisplayObjectContainer extends InteractiveObject
 
 		__children = new Array<DisplayObject>();
 		__removedChildren = new Vector<DisplayObject>();
+		__removedChildrenCleanupAt = new Vector<Float>();
 	}
 
 	/**
@@ -486,6 +489,7 @@ class DisplayObjectContainer extends InteractiveObject
 			child.parent = null;
 			__children.remove(child);
 			__removedChildren.push(child);
+			__removedChildrenCleanupAt.push(Timer.stamp() + child.__removedChildCleanupDelay);
 			child.__setTransformDirty();
 		}
 
@@ -689,20 +693,43 @@ class DisplayObjectContainer extends InteractiveObject
 			child.__cleanup();
 		}
 
-		__cleanupRemovedChildren();
+		__cleanupRemovedChildren(true);
 	}
 
-	@:noCompletion private inline function __cleanupRemovedChildren():Void
+	@:noCompletion private inline function __cleanupRemovedChildren(force:Bool = false):Void
 	{
-		for (orphan in __removedChildren)
+		if (__removedChildren.length == 0) return;
+
+		var now = Timer.stamp();
+		var writeIndex = 0;
+
+		for (i in 0...__removedChildren.length)
 		{
-			if (orphan.stage == null)
+			var orphan = __removedChildren[i];
+
+			if (orphan == null)
+			{
+				continue;
+			}
+
+			if (force || (orphan.stage == null && orphan.parent == null && now >= __removedChildrenCleanupAt[i]))
 			{
 				orphan.__cleanup();
+				continue;
 			}
+
+			if (orphan.stage != null || orphan.parent != null)
+			{
+				continue;
+			}
+
+			__removedChildren[writeIndex] = orphan;
+			__removedChildrenCleanupAt[writeIndex] = __removedChildrenCleanupAt[i];
+			writeIndex++;
 		}
 
-		__removedChildren.length = 0;
+		__removedChildren.length = writeIndex;
+		__removedChildrenCleanupAt.length = writeIndex;
 	}
 
 	@:noCompletion private override function __dispatchChildren(event:Event):Void


### PR DESCRIPTION
## Summary

This adds support for delayed cleanup of removed display children.

OpenFL currently schedules removed-child cleanup immediately. That is fine for normal display objects, but some downstream runtimes create display objects that are intended to be removed and later reused. Immediate cleanup can dispose cached bitmap data and other internal state too early.

This patch adds a per-display-object cleanup delay and stores the cleanup timestamp when a child is removed. Removed children are only cleaned up once their delay has elapsed, while full container cleanup still forces immediate cleanup.

## Intended downstream use

This change is needed by a companion `swf` change that marks timeline-created instances as reusable and opts them out of immediate removed-child cleanup: [openfl/swf#43](https://github.com/openfl/swf/pull/43).

## Notes on observed impact

The visible memory impact is platform- and project-dependent because it involves native resources and runtime behavior, so I would not expect an identical result on every machine.

However, the cleanup/reuse mismatch itself is deterministic, and this change provides a targeted hook for runtimes that need it.

## Suggested validation

If you want to validate the practical effect, the most representative test would probably be a medium/large project that uses many SWF timeline instances and already has a significant native memory footprint.