### PR TITLE
Fix stale cacheAsBitmap render when a filtered container loses its last child

### DIFF
--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -258,7 +258,8 @@ class DisplayObjectRenderer extends EventDispatcher
 			var rect:Rectangle = null;
 
 			var needRender = (displayObject.__cacheBitmap == null
-				|| (displayObject.__renderDirty && (force || (displayObject.__children != null && displayObject.__children.length > 0)))
+				|| (displayObject.__renderDirty
+					&& (displayObject.__cacheBitmap != null || force || (displayObject.__children != null && displayObject.__children.length > 0)))
 				|| displayObject.opaqueBackground != displayObject.__cacheBitmapBackground);
 			var softwareDirty = needRender
 				|| (displayObject.__graphics != null && displayObject.__graphics.__softwareDirty)


### PR DESCRIPTION
This fixes a stale cacheAsBitmap case for cached display objects.

When a display object has filters, OpenFL enables cacheAsBitmap. If that cached container loses its last child, it may still be marked renderDirty while no longer having children. In that case, __updateCacheBitmap could skip rerendering the cached bitmap, leaving the previous cached image visible.

This patch allows rerendering to proceed when a cached bitmap already exists and the display object is renderDirty, even if it no longer has children.

In practice, this fixes stale/ghost rendering on native targets for filtered containers whose contents are removed or swapped.

I did not prepare a minimal reproduction project because the patch is very small and the issue seemed clear from the code path and observed runtime behavior. If needed, I can provide one.