### PR TITLE
Avoid bounds-sized BitmapData allocations in CairoGraphics.hitTest

### DIFF
--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -51,6 +51,8 @@ class CairoGraphics
 	private static var graphics:Graphics;
 	private static var hasFill:Bool;
 	private static var hasStroke:Bool;
+	private static var hitTestBitmap:BitmapData;
+	private static var hitTestCairo:Cairo;
 	private static var hitTesting:Bool;
 	private static var inversePendingMatrix:Matrix;
 	private static var pendingMatrix:Matrix;
@@ -468,15 +470,14 @@ class CairoGraphics
 			x -= bounds.x;
 			y -= bounds.y;
 
-			if (graphics.__cairo == null)
+			if (hitTestCairo == null)
 			{
-				var bitmap = new BitmapData(Math.floor(Math.max(1, bounds.width)), Math.floor(Math.max(1, bounds.height)), true, 0);
-				var surface = bitmap.getSurface();
-				graphics.__cairo = new Cairo(surface);
-				// graphics.__bitmap = bitmap;
+				hitTestBitmap = new BitmapData(1, 1, true, 0);
+				hitTestCairo = new Cairo(hitTestBitmap.getSurface());
 			}
 
-			cairo = graphics.__cairo;
+			cairo = hitTestCairo;
+			cairo.identityMatrix();
 
 			fillCommands.clear();
 			strokeCommands.clear();


### PR DESCRIPTION
## Summary

This changes `CairoGraphics.hitTest()` to reuse a tiny shared Cairo surface instead of creating a `BitmapData` sized to the full graphics bounds.

The rendering path is unchanged. This only affects the native Cairo hit-test path used for `cairo.inFill()` / `cairo.inStroke()`.

## Problem

Before this change, `CairoGraphics.hitTest()` allocated a full-size `BitmapData(bounds.width, bounds.height)` for hit-testing.

In native targets, this could cause very large transient allocations when hovering interactive vector `Graphics` with large local bounds, even if the object was visually small on screen because it was scaled down.

Heaptrack showed the hotspot in:

`Stage.__onMouse -> Graphics.__hitTest -> CairoGraphics.hitTest -> BitmapData.__construct`

## Fix

- add a shared 1x1 Cairo surface for hit-testing
- reuse that surface in `CairoGraphics.hitTest()`
- keep the existing path construction and `inFill` / `inStroke` logic unchanged

## Reproduction

This minimal repro [repro-cairo-hit-test.zip](https://github.com/user-attachments/files/26334926/repro-cairo-hit-test.zip) demonstrates the initial native memory spike on first hover.

In a larger real-world project, this transient over-allocation was also causing heavy GC pressure, which led to severe long-term performance degradation and recurring frame drops during gameplay.