### PR TITLE
Added index buffer support for indexed rendering in Graphics.drawTriangles

### DIFF
--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -960,6 +960,17 @@ class Shader
 
 		return __glVertexSource = value;
 	}
+
+	@:noCompletion private var __useDrawElements:Bool = false;
+
+	/**
+	 * When set to true, triangles are rendered using gl.drawElements; otherwise, gl.drawArrays is used. This setting only affects the Graphics.drawTriangles interface.
+	 * @param value Whether to use draw elements.
+	 */
+	public function useDrawElements(value:Bool = true):Void
+	{
+		__useDrawElements = value;
+	}
 }
 #else
 typedef Shader = flash.display.Shader;

--- a/src/openfl/display/Shader.hx
+++ b/src/openfl/display/Shader.hx
@@ -960,17 +960,6 @@ class Shader
 
 		return __glVertexSource = value;
 	}
-
-	@:noCompletion private var __useDrawElements:Bool = false;
-
-	/**
-	 * When set to true, triangles are rendered using gl.drawElements; otherwise, gl.drawArrays is used. This setting only affects the Graphics.drawTriangles interface.
-	 * @param value Whether to use draw elements.
-	 */
-	public function useDrawElements(value:Bool = true):Void
-	{
-		__useDrawElements = value;
-	}
 }
 #else
 typedef Shader = flash.display.Shader;

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -122,7 +122,7 @@ class Context3DGraphics
 			var vertexOffset = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
 
 			// Use index buffer for indexed render
-			var useDrawElements = shaderBuffer != null && shaderBuffer.shader.__useDrawElements;
+			var useDrawElements = shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength;
 			if (useDrawElements)
 			{
 				resizeIndexBuffer(graphics, false, triangleIndexBufferPosition + length);
@@ -761,9 +761,10 @@ class Context3DGraphics
 
 					if (bitmap != null || shaderBuffer != null || (uvDataLength == 0 && fill != null))
 					{
-						var useDrawElements = shaderBuffer != null && shaderBuffer.shader.__useDrawElements;
 						var numVertices = Math.floor(verticesLength / 2);
 						var length = indicesLength > 0 ? indicesLength : numVertices;
+						var useDrawElements = shaderBuffer != null
+							&& shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength;
 
 						var hasUVTData = uvDataLength >= (numVertices * 3);
 						var vertLength = hasUVTData ? 4 : 2;

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -123,9 +123,13 @@ class Context3DGraphics
 
 			// TODO: Implement drawElements optimization when uvtData.length == 3 (x, y, t) if the t component is identical for each shared index.
 			// TODO: Support drawElements by moving the t division logic from the CPU buffer to the shader when uvtData.length == 3 (x, y, t).
+			#if openfl_enable_experimental_graphics_draw_elements
 			var useDrawElements = !hasUVTData
 				&& (shaderBuffer == null
 					|| (shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength));
+			#else
+			var useDrawElements = false;
+			#end
 			if (useDrawElements)
 			{
 				resizeIndexBuffer(graphics, false, triangleIndexBufferPosition + length);
@@ -777,10 +781,13 @@ class Context3DGraphics
 
 						// TODO: Implement drawElements optimization when uvtData.length == 3 (x, y, t) if the t component is identical for each shared index.
 						// TODO: Support drawElements by moving the t division logic from the CPU buffer to the shader when uvtData.length == 3 (x, y, t).
+						#if openfl_enable_experimental_graphics_draw_elements
 						var useDrawElements = !hasUVTData
 							&& (shaderBuffer == null
 								|| (shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength));
-
+						#else
+						var useDrawElements = false;
+						#end
 						var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
 						var shader:Shader;
 

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -122,7 +122,9 @@ class Context3DGraphics
 			var vertexOffset = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
 
 			// Use index buffer for indexed render
-			var useDrawElements = shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength;
+			var useDrawElements = !hasUVTData
+				&& (shaderBuffer == null
+					|| (shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength));
 			if (useDrawElements)
 			{
 				resizeIndexBuffer(graphics, false, triangleIndexBufferPosition + length);
@@ -763,8 +765,6 @@ class Context3DGraphics
 					{
 						var numVertices = Math.floor(verticesLength / 2);
 						var length = indicesLength > 0 ? indicesLength : numVertices;
-						var useDrawElements = shaderBuffer != null
-							&& shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength;
 
 						var hasUVTData = uvDataLength >= (numVertices * 3);
 						var vertLength = hasUVTData ? 4 : 2;
@@ -773,6 +773,10 @@ class Context3DGraphics
 						var dataPerVertex = vertLength + 2;
 						var vertexBuffer = hasUVTData ? graphics.__vertexBufferUVT : graphics.__vertexBuffer;
 						var bufferPosition = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
+
+						var useDrawElements = !hasUVTData
+							&& (shaderBuffer == null
+								|| (shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength));
 
 						var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
 						var shader:Shader;

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -121,7 +121,8 @@ class Context3DGraphics
 			var dataPerVertex = vertLength + 2;
 			var vertexOffset = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
 
-			// Use index buffer for indexed render
+			// TODO: Implement drawElements optimization when uvtData.length == 3 (x, y, t) if the t component is identical for each shared index.
+			// TODO: Support drawElements by moving the t division logic from the CPU buffer to the shader when uvtData.length == 3 (x, y, t).
 			var useDrawElements = !hasUVTData
 				&& (shaderBuffer == null
 					|| (shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength));
@@ -774,6 +775,8 @@ class Context3DGraphics
 						var vertexBuffer = hasUVTData ? graphics.__vertexBufferUVT : graphics.__vertexBuffer;
 						var bufferPosition = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
 
+						// TODO: Implement drawElements optimization when uvtData.length == 3 (x, y, t) if the t component is identical for each shared index.
+						// TODO: Support drawElements by moving the t division logic from the CPU buffer to the shader when uvtData.length == 3 (x, y, t).
 						var useDrawElements = !hasUVTData
 							&& (shaderBuffer == null
 								|| (shaderBuffer != null && shaderBuffer.paramDataLength < length * shaderBuffer.paramIndicesDataLength));

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -59,6 +59,7 @@ class Context3DGraphics
 
 		var bitmap:BitmapData = null;
 		var bitmapMatrix:Matrix = null;
+		var shaderBuffer:ShaderBuffer = null;
 
 		var scale9Grid:Rectangle = graphics.__owner.__scale9Grid;
 		// no scale9Grid for masks
@@ -120,10 +121,15 @@ class Context3DGraphics
 			var dataPerVertex = vertLength + 2;
 			var vertexOffset = hasUVTData ? vertexBufferPositionUVT : vertexBufferPosition;
 
-			// TODO: Use index buffer for indexed render
-
-			// if (hasIndices) resizeIndexBuffer (graphics, false, triangleIndexBufferPosition + length);
-			resizeVertexBuffer(graphics, hasUVTData, vertexOffset + (length * dataPerVertex));
+			// Use index buffer for indexed render
+			var useDrawElements = shaderBuffer != null && shaderBuffer.shader.__useDrawElements;
+			if (useDrawElements)
+			{
+				resizeIndexBuffer(graphics, false, triangleIndexBufferPosition + length);
+				resizeVertexBuffer(graphics, hasUVTData, vertexOffset + (numVertices * dataPerVertex));
+			}
+			else
+				resizeVertexBuffer(graphics, hasUVTData, vertexOffset + (length * dataPerVertex));
 
 			// var indexBufferData = graphics.__triangleIndexBufferData;
 			var vertexBufferData = hasUVTData ? graphics.__vertexBufferDataUVT : graphics.__vertexBufferData;
@@ -132,31 +138,65 @@ class Context3DGraphics
 			var uvOffset:Int;
 			var t:Float;
 
-			for (i in 0...length)
+			if (!useDrawElements)
 			{
-				offset = vertexOffset + (i * dataPerVertex);
-				vertOffset = hasIndices ? indices[i] * 2 : i * 2;
-				uvOffset = hasIndices ? indices[i] * uvStride : i * uvStride;
-
-				// if (hasIndices) indexBufferData[triangleIndexBufferPosition + i] = indices[i];
-
-				if (hasUVTData)
+				for (i in 0...length)
 				{
-					t = uvtData[uvOffset + 2];
+					offset = vertexOffset + (i * dataPerVertex);
+					vertOffset = hasIndices ? indices[i] * 2 : i * 2;
+					uvOffset = hasIndices ? indices[i] * uvStride : i * uvStride;
 
-					vertexBufferData[offset + 0] = vertices[vertOffset] / t;
-					vertexBufferData[offset + 1] = vertices[vertOffset + 1] / t;
-					vertexBufferData[offset + 2] = 0;
-					vertexBufferData[offset + 3] = 1 / t;
+					if (hasUVTData)
+					{
+						t = uvtData[uvOffset + 2];
+
+						vertexBufferData[offset + 0] = vertices[vertOffset] / t;
+						vertexBufferData[offset + 1] = vertices[vertOffset + 1] / t;
+						vertexBufferData[offset + 2] = 0;
+						vertexBufferData[offset + 3] = 1 / t;
+					}
+					else
+					{
+						vertexBufferData[offset + 0] = vertices[vertOffset];
+						vertexBufferData[offset + 1] = vertices[vertOffset + 1];
+					}
+
+					vertexBufferData[offset + vertLength] = hasUVData ? uvtData[uvOffset] : 0;
+					vertexBufferData[offset + vertLength + 1] = hasUVData ? uvtData[uvOffset + 1] : 0;
 				}
-				else
+			}
+			else
+			{
+				var indexBufferData = graphics.__triangleIndexBufferData;
+				for (i in 0...length)
 				{
-					vertexBufferData[offset + 0] = vertices[vertOffset];
-					vertexBufferData[offset + 1] = vertices[vertOffset + 1];
+					indexBufferData[triangleIndexBufferPosition + i] = indices[i];
 				}
+				for (i in 0...numVertices)
+				{
+					offset = vertexOffset + (i * dataPerVertex);
+					vertOffset = i * 2;
+					uvOffset = i * uvStride;
 
-				vertexBufferData[offset + vertLength] = hasUVData ? uvtData[uvOffset] : 0;
-				vertexBufferData[offset + vertLength + 1] = hasUVData ? uvtData[uvOffset + 1] : 0;
+					if (hasUVTData)
+					{
+						t = uvtData[uvOffset + 2];
+
+						vertexBufferData[offset + 0] = vertices[vertOffset] / t;
+						vertexBufferData[offset + 1] = vertices[vertOffset + 1] / t;
+						vertexBufferData[offset + 2] = 0;
+						vertexBufferData[offset + 3] = 1 / t;
+					}
+					else
+					{
+						vertexBufferData[offset + 0] = vertices[vertOffset];
+						vertexBufferData[offset + 1] = vertices[vertOffset + 1];
+					}
+
+					vertexBufferData[offset + vertLength] = hasUVData ? uvtData[uvOffset] : 0;
+					vertexBufferData[offset + vertLength + 1] = hasUVData ? uvtData[uvOffset + 1] : 0;
+				}
+				triangleIndexBufferPosition += length;
 			}
 
 			// if (hasIndices) triangleIndexBufferPosition += length;
@@ -191,7 +231,7 @@ class Context3DGraphics
 
 				case BEGIN_SHADER_FILL:
 					var c = data.readBeginShaderFill();
-					var shaderBuffer = c.shaderBuffer;
+					shaderBuffer = c.shaderBuffer;
 
 					bitmap = null;
 					bitmapMatrix = null;
@@ -721,6 +761,7 @@ class Context3DGraphics
 
 					if (bitmap != null || shaderBuffer != null || (uvDataLength == 0 && fill != null))
 					{
+						var useDrawElements = shaderBuffer != null && shaderBuffer.shader.__useDrawElements;
 						var numVertices = Math.floor(verticesLength / 2);
 						var length = indicesLength > 0 ? indicesLength : numVertices;
 
@@ -796,7 +837,15 @@ class Context3DGraphics
 							default:
 						}
 
-						context.__drawTriangles(0, length);
+						if (useDrawElements)
+						{
+							context.drawTriangles(graphics.__triangleIndexBuffer, triangleIndexBufferPosition, Math.floor(length / 3));
+							triangleIndexBufferPosition += length;
+						}
+						else
+						{
+							context.__drawTriangles(0, length);
+						}
 
 						shaderBufferOffset += length;
 						if (hasUVTData)

--- a/src/openfl/display/_internal/ShaderBuffer.hx
+++ b/src/openfl/display/_internal/ShaderBuffer.hx
@@ -16,6 +16,7 @@ import openfl.display.ShaderParameter;
 @:noDebug
 #end
 @:access(openfl.display.Shader)
+@:access(openfl.display.ShaderParameter)
 @SuppressWarnings("checkstyle:FieldDocComment")
 class ShaderBuffer
 {
@@ -50,6 +51,7 @@ class ShaderBuffer
 	public var paramRefs_Float:Array<ShaderParameter<Float>>;
 	public var paramRefs_Int:Array<ShaderParameter<Int>>;
 	public var paramTypes:Array<Int>;
+	public var paramIndicesDataLength:Int;
 	public var shader:GraphicsShader;
 
 	public function new()
@@ -117,6 +119,7 @@ class ShaderBuffer
 		paramDataLength = 0;
 		paramFloatCount = 0;
 		paramIntCount = 0;
+		paramIndicesDataLength = 0;
 		this.shader = null;
 
 		if (shader == null) return;
@@ -156,6 +159,7 @@ class ShaderBuffer
 			paramLengths[p] = length;
 			paramDataLength += length;
 			paramTypes[p] = 0;
+			if (param.value != null && !param.__isUniform) paramIndicesDataLength += param.__length;
 
 			paramRefs_Bool[i] = param;
 			p++;
@@ -172,6 +176,7 @@ class ShaderBuffer
 			paramLengths[p] = length;
 			paramDataLength += length;
 			paramTypes[p] = 1;
+			if (param.value != null && !param.__isUniform) paramIndicesDataLength += param.__length;
 
 			paramRefs_Float[i] = param;
 			p++;
@@ -188,6 +193,7 @@ class ShaderBuffer
 			paramLengths[p] = length;
 			paramDataLength += length;
 			paramTypes[p] = 2;
+			if (param.value != null && !param.__isUniform) paramIndicesDataLength += param.__length;
 
 			paramRefs_Int[i] = param;
 			p++;


### PR DESCRIPTION
1. Introduced the useDrawElements API, enabling Shaders to indicate when vertex data is structured for indexed rendering via gl.drawElements.
2. Enhanced the internal rendering implementation of Context3DGraphics for better performance.