### PR TITLE
Release pooled cache bounds on zero-sized filter cache early return

### DIFF
--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -445,6 +445,8 @@ class DisplayObjectRenderer extends EventDispatcher
 				else
 				{
 					ColorTransform.__pool.release(colorTransform);
+					if (rect != null) Rectangle.__pool.release(rect);
+					if (desiredCacheBounds != null) Rectangle.__pool.release(desiredCacheBounds);
 
 					displayObject.__cacheBitmap = null;
 					displayObject.__cacheBitmapData = null;


### PR DESCRIPTION
## Summary

This fixes a cache bitmap early-return path in `DisplayObjectRenderer.__updateCacheBitmap`.

When a filtered display object ends up with a zero-sized cache target (`filterWidth < 0.5 || filterHeight < 0.5`), the function returned early without releasing pooled `Rectangle` instances allocated for cache/filter bounds computation.

This could cause unbounded memory growth on native targets when the path was hit repeatedly.

## Repro

[OpenFLZeroBoundsFilterCacheLeakRepro.zip](https://github.com/user-attachments/files/26648219/OpenFLZeroBoundsFilterCacheLeakRepro.zip)

It creates many empty `Sprite` instances with:

- `cacheAsBitmap = true`
- `filters = [new ColorMatrixFilter()]`

Because the sprites are empty and `ColorMatrixFilter` has zero filter extension, this repeatedly hits the zero-sized cache early-return path.

## Before

On an unfixed build, the repro quickly grows to multiple GB of RAM and eventually freezes with:

`Memory exhausted. try HXCPP_GC_BIG_BLOCKS`

`heaptrack` also reports the targeted allocation path, including:

- `lime::utils::ObjectPool_obj::get`
- `openfl::display::DisplayObject_obj::__getFilterBounds`
- `openfl::display::DisplayObjectRenderer_obj::__updateCacheBitmap`

## After

With this change applied:

- memory stays stable (well under 100 MB in my repro)
- the app runs indefinitely
- the `ObjectPool -> __getFilterBounds -> __updateCacheBitmap` hotspot disappears from `heaptrack`

## Change

Release pooled `rect` / `desiredCacheBounds` before the zero-sized cache early return, matching the normal cleanup path used later in the function.

## Note

The fix relies on https://github.com/openfl/openfl/pull/2854, but the problem is also present in the develop branch.