### PR TITLE
Fix Linux window icon handling

### DIFF
--- a/assets/templates/haxe/ApplicationMain.hx
+++ b/assets/templates/haxe/ApplicationMain.hx
@@ -103,6 +103,17 @@ class ApplicationMain
 		}
 
 		app.createWindow(attributes);
+		#if (linux && sys)
+		var iconPath = lime.system.System.applicationDirectory + "/icon.png";
+		if (sys.FileSystem.exists(iconPath))
+		{
+			var icon = lime.graphics.Image.fromFile(iconPath);
+			if (icon != null && app.window != null)
+			{
+				app.window.setIcon(icon);
+			}
+		}
+		#end
 		::end::
 		#elseif air
 		app.window.title = "::meta.title::";


### PR DESCRIPTION
This updates OpenFL’s generated `ApplicationMain` template to apply the generated Linux icon at startup.

On Linux, the window icon needs to be set at runtime using Lime’s window icon API. The template now checks for `icon.png` in the application directory and calls `window.setIcon(...)` when it exists.

This complements https://github.com/openfl/lime/pull/2057.