### PR TITLE
Fix Cairo scale9 hit test and raster bounds

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -1973,6 +1973,12 @@ import js.html.CanvasRenderingContext2D;
 			}
 		}
 
+		if (__owner.__worldScale9Grid != null)
+		{
+			scaleX = Math.abs(__bitmapScaleX) * pixelRatio;
+			scaleY = Math.abs(__bitmapScaleY) * pixelRatio;
+		}
+
 		#if openfl_disable_graphics_upscaling
 		if (__owner.__worldScale9Grid == null)
 		{

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -1975,8 +1975,8 @@ import js.html.CanvasRenderingContext2D;
 
 		if (__owner.__worldScale9Grid != null)
 		{
-			scaleX = Math.abs(__bitmapScaleX) * pixelRatio;
-			scaleY = Math.abs(__bitmapScaleY) * pixelRatio;
+			scaleX = Math.abs(__owner.scaleX) * pixelRatio;
+			scaleY = Math.abs(__owner.scaleY) * pixelRatio;
 		}
 
 		#if openfl_disable_graphics_upscaling

--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -465,6 +465,20 @@ class CairoGraphics
 		{
 			hitTesting = true;
 
+			var scale9Grid:Rectangle = graphics.__owner.__scale9Grid;
+			#if (openfl_legacy_scale9grid && !cairo)
+			var hasScale9Grid:Bool = false;
+			#else
+			// no scale9Grid for masks
+			// no scale9Grid for rotation 0.02 degrees or higher (less than 0.02 is allowed in flash)
+			var hasScale9Grid = scale9Grid != null && !graphics.__owner.__isMask && Math.abs(graphics.__owner.__rotation) < 0.02;
+			#end
+			if (hasScale9Grid)
+			{
+				x = toScale9Position(x, scale9Grid.x, scale9Grid.width, bounds.width, graphics.__owner.scaleX);
+				y = toScale9Position(y, scale9Grid.y, scale9Grid.height, bounds.height, graphics.__owner.scaleY);
+			}
+
 			x -= bounds.x;
 			y -= bounds.y;
 


### PR DESCRIPTION
Fixes two Cairo `scale9Grid` issues:

- maps Cairo graphics hit testing through `scale9Grid`, so hit areas match scaled graphics
- allocates Cairo software graphics for scale9 content using the local scale used by scale9 drawing, avoiding raster clipping under scaled parents

[openfl-scale9-hit-test.zip](https://github.com/user-attachments/files/27562207/openfl-scale9-hit-test.zip)
[openfl-scale9-raster-clipping.zip](https://github.com/user-attachments/files/27562209/openfl-scale9-raster-clipping.zip)
