### PR TITLE
Fix dropTarget when dragging over a child of the dragged sprite

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -3252,7 +3252,7 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 			var dropTarget:DisplayObject = null;
 
-			if (__mouseOverTarget == __dragObject)
+			if (__isDraggingMouseOverTarget())
 			{
 				var cacheMouseEnabled = __dragObject.mouseEnabled;
 				var cacheMouseChildren = __dragObject.mouseChildren;
@@ -3280,6 +3280,23 @@ class Stage extends DisplayObjectContainer #if lime implements IModule #end
 
 		Point.__pool.release(targetPoint);
 		Point.__pool.release(localPoint);
+	}
+
+	@:noCompletion private function __isDraggingMouseOverTarget():Bool
+	{
+		var target = __mouseOverTarget;
+
+		while (target != null)
+		{
+			if (target == __dragObject)
+			{
+				return true;
+			}
+
+			target = target.parent;
+		}
+
+		return false;
 	}
 
 	#if lime


### PR DESCRIPTION
## Summary

Fixes `Sprite.dropTarget` while dragging when the current mouse target is a descendant of the dragged sprite.

Previously, OpenFL ignored the dragged sprite itself when resolving `dropTarget`, but only when `__mouseOverTarget == __dragObject`. If the pointer was over an interactive child of the dragged sprite, `dropTarget` could resolve to that child instead of the object underneath.

This updates the check to treat descendants of `__dragObject` the same as `__dragObject`.

## Repro
[OpenFLDropTargetDraggedChildRepro.zip](https://github.com/user-attachments/files/27571113/OpenFLDropTargetDraggedChildRepro.zip)