### PR TITLE
CairoGraphics: match surface size exactly, drop 1.25x upscale margin

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -98,6 +98,11 @@ class Bitmap extends DisplayObject
 	#end
 	@:noCompletion private var __bitmapData:BitmapData;
 	@:noCompletion private var __imageVersion:Int;
+	// Painted sub-region (-1 = use full bitmapData dims). Set when this Bitmap
+	// instance is `DisplayObject.__cacheBitmap` and the backing data is sized
+	// larger than the current cache footprint (high-water-mark strategy).
+	@:noCompletion private var __paintedWidth:Int = -1;
+	@:noCompletion private var __paintedHeight:Int = -1;
 
 	#if openfljs
 	@:noCompletion private static function __init__()

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -227,6 +227,8 @@ class BitmapData implements IBitmapDrawable
 	@:noCompletion private var __vertexBufferScaleX:Float;
 	@:noCompletion private var __vertexBufferScaleY:Float;
 	@:noCompletion private var __vertexBufferWidth:Float;
+	@:noCompletion private var __vertexBufferPaintedWidth:Int = -1;
+	@:noCompletion private var __vertexBufferPaintedHeight:Int = -1;
 	@:noCompletion private var __worldAlpha:Float;
 	@:noCompletion private var __worldColorTransform:ColorTransform;
 	@:noCompletion private var __worldTransform:Matrix;
@@ -1656,7 +1658,8 @@ class BitmapData implements IBitmapDrawable
 		@param	context	A Stage3D context
 		@returns	A VertexBuffer3D object for use with rendering
 	**/
-	@:dox(hide) public function getVertexBuffer(context:Context3D, scale9Grid:Rectangle = null, targetObject:DisplayObject = null):VertexBuffer3D
+	@:dox(hide) public function getVertexBuffer(context:Context3D, scale9Grid:Rectangle = null, targetObject:DisplayObject = null,
+			paintedWidth:Int = -1, paintedHeight:Int = -1):VertexBuffer3D
 	{
 		var gl = context.gl;
 
@@ -1667,6 +1670,8 @@ class BitmapData implements IBitmapDrawable
 			|| __vertexBufferContext != context.__context
 			|| (scale9Grid != null && __vertexBufferGrid == null)
 			|| (__vertexBufferGrid != null && !__vertexBufferGrid.equals(scale9Grid))
+			|| __vertexBufferPaintedWidth != paintedWidth
+			|| __vertexBufferPaintedHeight != paintedHeight
 			|| (targetObject != null
 				&& (__vertexBufferWidth != targetObject.width
 					|| __vertexBufferHeight != targetObject.height
@@ -1961,19 +1966,33 @@ class BitmapData implements IBitmapDrawable
 
 			if (__vertexBuffer == null)
 			{
+				// Painted region support: when the caller passes paintedWidth/Height
+				// (the sub-region of the bitmap that actually contains rendered
+				// content), build the quad for that sub-region and scale UV so we
+				// sample only that part of the texture. Used by Context3DShape /
+				// Context3DBitmap to composite a high-water cached surface without
+				// dragging its transparent padding into world space.
+				var quadW:Float = (paintedWidth > 0) ? paintedWidth : width;
+				var quadH:Float = (paintedHeight > 0) ? paintedHeight : height;
+				var quadUvW:Float = (paintedWidth > 0) ? uvWidth * (paintedWidth / width) : uvWidth;
+				var quadUvH:Float = (paintedHeight > 0) ? uvHeight * (paintedHeight / height) : uvHeight;
+
 				__vertexBufferData = new Float32Array(VERTEX_BUFFER_STRIDE * 4);
 
-				__vertexBufferData[0] = width;
-				__vertexBufferData[1] = height;
-				__vertexBufferData[3] = uvWidth;
-				__vertexBufferData[4] = uvHeight;
-				__vertexBufferData[VERTEX_BUFFER_STRIDE + 1] = height;
-				__vertexBufferData[VERTEX_BUFFER_STRIDE + 4] = uvHeight;
-				__vertexBufferData[VERTEX_BUFFER_STRIDE * 2] = width;
-				__vertexBufferData[VERTEX_BUFFER_STRIDE * 2 + 3] = uvWidth;
+				__vertexBufferData[0] = quadW;
+				__vertexBufferData[1] = quadH;
+				__vertexBufferData[3] = quadUvW;
+				__vertexBufferData[4] = quadUvH;
+				__vertexBufferData[VERTEX_BUFFER_STRIDE + 1] = quadH;
+				__vertexBufferData[VERTEX_BUFFER_STRIDE + 4] = quadUvH;
+				__vertexBufferData[VERTEX_BUFFER_STRIDE * 2] = quadW;
+				__vertexBufferData[VERTEX_BUFFER_STRIDE * 2 + 3] = quadUvW;
 
 				__vertexBuffer = context.createVertexBuffer(3, VERTEX_BUFFER_STRIDE);
 			}
+
+			__vertexBufferPaintedWidth = paintedWidth;
+			__vertexBufferPaintedHeight = paintedHeight;
 
 			// for (i in 0...4) {
 

--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -43,6 +43,16 @@ import lime.graphics.RenderContextType;
 @:allow(openfl.text)
 class DisplayObjectRenderer extends EventDispatcher
 {
+	#if openfl_count_surface_allocs
+	/**
+		Diagnostic counter incremented every time a new BitmapData is allocated
+		for `DisplayObject.__cacheBitmapData` (the cacheAsBitmap/filters cache).
+		Used by `tests/cairo-surface-clip` to compare allocation churn between
+		surface-sizing strategies. No-op unless `-D openfl_count_surface_allocs`.
+	**/
+	public static var __cacheBitmapAllocs:Int = 0;
+	#end
+
 	@:noCompletion private var __allowSmoothing:Bool;
 	@:noCompletion private var __blendMode:BlendMode;
 	@:noCompletion private var __cleared:Bool;
@@ -392,10 +402,18 @@ class DisplayObjectRenderer extends EventDispatcher
 
 				if (displayObject.__cacheBitmapData != null)
 				{
-					if (filterWidth > displayObject.__cacheBitmapData.width || filterHeight > displayObject.__cacheBitmapData.height)
+					// High-water-mark cache strategy: grow on demand, keep the peak
+					// size on shrink. Safe because `Context3DBitmap` composites only
+					// the painted sub-region `filterWidth x filterHeight` (set as
+					// `__cacheBitmap.__paintedWidth/Height` below) — see the matching
+					// CairoGraphics surface strategy and openfl/openfl#2866.
+					if (filterWidth > displayObject.__cacheBitmapData.width
+						|| filterHeight > displayObject.__cacheBitmapData.height)
 					{
-						bitmapWidth = Math.ceil(Math.max(filterWidth * 1.25, displayObject.__cacheBitmapData.width));
-						bitmapHeight = Math.ceil(Math.max(filterHeight * 1.25, displayObject.__cacheBitmapData.height));
+						bitmapWidth = (displayObject.__cacheBitmapData.width > filterWidth)
+							? displayObject.__cacheBitmapData.width : filterWidth;
+						bitmapHeight = (displayObject.__cacheBitmapData.height > filterHeight)
+							? displayObject.__cacheBitmapData.height : filterHeight;
 						needRender = true;
 					}
 					else
@@ -429,6 +447,9 @@ class DisplayObjectRenderer extends EventDispatcher
 						|| bitmapHeight > displayObject.__cacheBitmapData.height)
 					{
 						displayObject.__cacheBitmapData = new BitmapData(bitmapWidth, bitmapHeight, true, bitmapColor);
+						#if openfl_count_surface_allocs
+						__cacheBitmapAllocs++;
+						#end
 
 						if (displayObject.__cacheBitmap == null) displayObject.__cacheBitmap = new Bitmap();
 						displayObject.__cacheBitmap.__bitmapData = displayObject.__cacheBitmapData;
@@ -437,6 +458,14 @@ class DisplayObjectRenderer extends EventDispatcher
 					else
 					{
 						displayObject.__cacheBitmapData.__fillRect(displayObject.__cacheBitmapData.rect, bitmapColor, allowFramebuffer);
+					}
+
+					// Tell Context3DBitmap to composite only the painted sub-region
+					// (matters when bitmapWidth > filterWidth — high-water cache).
+					if (displayObject.__cacheBitmap != null)
+					{
+						displayObject.__cacheBitmap.__paintedWidth = filterWidth;
+						displayObject.__cacheBitmap.__paintedHeight = filterHeight;
 					}
 
 					if (needsFill)

--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -1881,23 +1881,27 @@ class CairoGraphics
 		else
 		{
 			hitTesting = false;
-			var needsUpscaling = false;
 
 			if (graphics.__cairo != null)
 			{
 				var surface:CairoImageSurface = cast graphics.__cairo.target;
 
-				if (width > surface.width || height > surface.height)
+				// Surface must match width x height exactly. Context3DShape maps the
+				// full bitmap dimensions to world coords via __worldTransform — if the
+				// surface is oversized (from a previous high-scale render, or from the
+				// legacy 1.25x upscaling margin), Cairo fills only the width x height
+				// region and the empty padding visually clips content at the shape's
+				// right/bottom edges.
+				if (width != surface.width || height != surface.height)
 				{
 					graphics.__cairo = null;
-					needsUpscaling = true;
 				}
 			}
 
 			if (graphics.__cairo == null || graphics.__bitmap == null)
 			{
-				var bitmapWidth = needsUpscaling ? Std.int(width * 1.25) : width;
-				var bitmapHeight = needsUpscaling ? Std.int(height * 1.25) : height;
+				var bitmapWidth = width;
+				var bitmapHeight = height;
 
 				if (Graphics.maxTextureWidth != null && bitmapWidth > Graphics.maxTextureWidth)
 				{

--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -36,6 +36,16 @@ import lime.math.Vector2;
 @SuppressWarnings("checkstyle:FieldDocComment")
 class CairoGraphics
 {
+	#if openfl_count_surface_allocs
+	/**
+	 * Diagnostic counter incremented every time `render()` allocates a new
+	 * BitmapData for the cached Cairo surface. Used by the visual repro in
+	 * `tests/cairo-surface-clip` to compare allocation churn between
+	 * strategies. No-op unless `-D openfl_count_surface_allocs` is set.
+	 */
+	public static var __surfaceAllocs:Int = 0;
+	#end
+
 	#if lime_cairo
 	private static var SIN45:Float = 0.70710678118654752440084436210485;
 	private static var TAN22:Float = 0.4142135623730950488016887242097;
@@ -1882,27 +1892,28 @@ class CairoGraphics
 		{
 			hitTesting = false;
 
+			// High-water-mark surface strategy: grow on demand, keep the peak size
+			// on shrink. Safe because `Context3DShape` composites only the painted
+			// sub-region `graphics.__width x graphics.__height` (see openfl/openfl#2866
+			// follow-up — `BitmapData.getVertexBuffer(..., paintedWidth, paintedHeight)`).
+			// Without the painted-region clamp the oversize bitmap's transparent
+			// padding ends up in world space; with it, padding is harmless and we
+			// avoid reallocations on every oscillating-bounds frame.
+			var bitmapWidth = width;
+			var bitmapHeight = height;
 			if (graphics.__cairo != null)
 			{
 				var surface:CairoImageSurface = cast graphics.__cairo.target;
-
-				// Surface must match width x height exactly. Context3DShape maps the
-				// full bitmap dimensions to world coords via __worldTransform — if the
-				// surface is oversized (from a previous high-scale render, or from the
-				// legacy 1.25x upscaling margin), Cairo fills only the width x height
-				// region and the empty padding visually clips content at the shape's
-				// right/bottom edges.
-				if (width != surface.width || height != surface.height)
+				if (width > surface.width || height > surface.height)
 				{
+					bitmapWidth = (surface.width > width) ? surface.width : width;
+					bitmapHeight = (surface.height > height) ? surface.height : height;
 					graphics.__cairo = null;
 				}
 			}
 
 			if (graphics.__cairo == null || graphics.__bitmap == null)
 			{
-				var bitmapWidth = width;
-				var bitmapHeight = height;
-
 				if (Graphics.maxTextureWidth != null && bitmapWidth > Graphics.maxTextureWidth)
 				{
 					bitmapWidth = Graphics.maxTextureWidth;
@@ -1917,6 +1928,9 @@ class CairoGraphics
 				var surface = bitmap.getSurface();
 				graphics.__cairo = new Cairo(surface);
 				graphics.__bitmap = bitmap;
+				#if openfl_count_surface_allocs
+				__surfaceAllocs++;
+				#end
 			}
 
 			cairo = graphics.__cairo;

--- a/src/openfl/display/_internal/CairoTextField.hx
+++ b/src/openfl/display/_internal/CairoTextField.hx
@@ -111,7 +111,9 @@ class CairoTextField
 		var height = Math.round(graphics.__height * pixelRatio);
 
 		var renderable = (textEngine.border || textEngine.background || textEngine.text != null);
-		var needsUpscaling = false;
+		var needsGrow = false;
+		var grownWidth = width;
+		var grownHeight = height;
 
 		if (cairo != null)
 		{
@@ -120,10 +122,17 @@ class CairoTextField
 
 			if (graphics.__softwareDirty && (width > surface.width || height > surface.height))
 			{
-				needsUpscaling = true;
+				// High-water-mark surface strategy: take max(current, new) per axis
+				// so growth only ratchets up. Safe because Context3DShape composites
+				// only the painted `graphics.__width x graphics.__height` sub-region
+				// (see BitmapData.getVertexBuffer painted-region params, follow-up
+				// to openfl/openfl#2866). Avoids reallocation on every text reflow.
+				needsGrow = true;
+				grownWidth = (surface.width > width) ? surface.width : width;
+				grownHeight = (surface.height > height) ? surface.height : height;
 			}
 
-			if (!renderable || needsUpscaling || width <= 0 || height <= 0)
+			if (!renderable || needsGrow || width <= 0 || height <= 0)
 			{
 				graphics.__cairo = null;
 				graphics.__bitmap = null;
@@ -143,8 +152,8 @@ class CairoTextField
 
 		if (cairo == null)
 		{
-			var bitmapWidth = needsUpscaling ? Std.int(width * 1.25) : width;
-			var bitmapHeight = needsUpscaling ? Std.int(height * 1.25) : height;
+			var bitmapWidth = needsGrow ? grownWidth : width;
+			var bitmapHeight = needsGrow ? grownHeight : height;
 
 			if (Graphics.maxTextureWidth != null && bitmapWidth > Graphics.maxTextureWidth)
 			{

--- a/src/openfl/display/_internal/Context3DBitmap.hx
+++ b/src/openfl/display/_internal/Context3DBitmap.hx
@@ -42,7 +42,12 @@ class Context3DBitmap
 			renderer.applyColorTransform(bitmap.__worldColorTransform);
 			renderer.updateShader();
 
-			var vertexBuffer = bitmap.__bitmapData.getVertexBuffer(context);
+			// `__paintedWidth/Height` are set on the cacheBitmap when the backing
+			// `__bitmapData` is sized larger than the current filterWidth/Height
+			// (high-water-mark cache strategy in DisplayObjectRenderer). Without
+			// this clamp the oversize transparent padding would leak into world
+			// space — see openfl/openfl#2866 follow-up.
+			var vertexBuffer = bitmap.__bitmapData.getVertexBuffer(context, null, null, bitmap.__paintedWidth, bitmap.__paintedHeight);
 			if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, 0, FLOAT_3);
 			if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, 3, FLOAT_2);
 			var indexBuffer = bitmap.__bitmapData.getIndexBuffer(context);

--- a/src/openfl/display/_internal/Context3DShape.hx
+++ b/src/openfl/display/_internal/Context3DShape.hx
@@ -59,7 +59,13 @@ class Context3DShape
 				renderer.applyColorTransform(shape.__worldColorTransform);
 				renderer.updateShader();
 
-				var vertexBuffer = graphics.__bitmap.getVertexBuffer(context);
+				// Composite only the painted sub-region of the Cairo cache surface.
+				// `graphics.__bitmap` may be larger than the painted area when the
+				// shape uses a high-water-mark surface strategy (grows on demand,
+				// keeps the peak size to avoid reallocations on shrink/oscillation).
+				// Without this, the oversize bitmap's transparent right/bottom
+				// padding ends up in world space — see openfl/openfl#2866.
+				var vertexBuffer = graphics.__bitmap.getVertexBuffer(context, null, null, graphics.__width, graphics.__height);
 				if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, 0, FLOAT_3);
 				if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, 3, FLOAT_2);
 				var indexBuffer = graphics.__bitmap.getIndexBuffer(context);
@@ -97,7 +103,9 @@ class Context3DShape
 				renderer.applyMatrix(renderer.__getMatrix(graphics.__worldTransform, AUTO));
 				renderer.updateShader();
 
-				var vertexBuffer = graphics.__bitmap.getVertexBuffer(context);
+				// Same painted-region clamp as render() above so masks composited
+				// from a high-water cache surface don't pick up transparent padding.
+				var vertexBuffer = graphics.__bitmap.getVertexBuffer(context, null, null, graphics.__width, graphics.__height);
 				if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, 0, FLOAT_3);
 				if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, 3, FLOAT_2);
 				var indexBuffer = graphics.__bitmap.getIndexBuffer(context);

--- a/tests/cairo-surface-clip/README.md
+++ b/tests/cairo-surface-clip/README.md
@@ -1,0 +1,38 @@
+# Cairo surface clip — visual repro for openfl/openfl#2866
+
+A small OpenFL app that demonstrates two symptoms of the cached Cairo
+surface being allowed to exceed the painted region:
+
+1. **Clipping** at the right/bottom edge of a Shape after its bounds
+   shrink (Context3D composite path picks up the empty padding).
+2. **Reallocation churn** during scale-tween animations when the surface
+   is sized to exactly match every frame.
+
+Both rows of the demo animate the same `drawRoundRect` shape; the top
+row is rendered through the Cairo cache (`cacheAsBitmap = true`), the
+bottom row uses the hardware path for comparison.
+
+A live counter in the corner tracks how many times the Cairo cache
+surface was (re)allocated since startup.
+
+## Run
+
+From this directory:
+
+```sh
+lime test mac        # or windows / linux
+```
+
+Press:
+
+* `space` — toggle between **shrink/grow** cycle and **scale tween** cycle.
+* `r` — reset the allocation counter.
+* `s` — toggle `cacheAsBitmap` on the top row (forces software path).
+
+## Expected outcomes
+
+| State of the fix | Visible result |
+|------------------|----------------|
+| Upstream (`>` check + 1.25× margin) | Right/bottom edges of the top shape clip during shrink frames; allocation counter is low during the scale-tween cycle. |
+| Exact-fit (current PR head)         | No clipping; allocation counter ticks every frame during scale-tween. |
+| High-water / decoupled (proposed)   | No clipping; allocation counter stable after warm-up. |

--- a/tests/cairo-surface-clip/project.xml
+++ b/tests/cairo-surface-clip/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+	<meta title="Cairo Surface Clip" package="com.openfl.tests.cairoSurfaceClip" version="1.0.0" company="OpenFL"/>
+	<app main="Main" path="bin" file="CairoSurfaceClip"/>
+	<window background="#202020" width="800" height="600" fps="60"/>
+	<source path="src"/>
+	<haxelib name="openfl" path="../.."/>
+	<haxedef name="openfl_count_surface_allocs"/>
+</project>

--- a/tests/cairo-surface-clip/src/AllocCounter.hx
+++ b/tests/cairo-surface-clip/src/AllocCounter.hx
@@ -10,6 +10,7 @@ package;
  *  - `cacheBitmapAllocs` -> `DisplayObjectRenderer.__cacheBitmapAllocs`
  *    (cacheAsBitmap / filters bitmap for `DisplayObject.__cacheBitmapData`)
  */
+#if (!flash && openfl_count_surface_allocs)
 @:access(openfl.display._internal.CairoGraphics)
 @:access(openfl.display.DisplayObjectRenderer)
 class AllocCounter
@@ -19,19 +20,22 @@ class AllocCounter
 
 	static function get_surfaceAllocs():Int
 	{
-		#if openfl_count_surface_allocs
 		return openfl.display._internal.CairoGraphics.__surfaceAllocs;
-		#else
-		return 0;
-		#end
 	}
 
 	static function get_cacheBitmapAllocs():Int
 	{
-		#if openfl_count_surface_allocs
 		return openfl.display.DisplayObjectRenderer.__cacheBitmapAllocs;
-		#else
-		return 0;
-		#end
 	}
 }
+#else
+class AllocCounter
+{
+	public static var surfaceAllocs(get, never):Int;
+	public static var cacheBitmapAllocs(get, never):Int;
+
+	static function get_surfaceAllocs():Int return 0;
+
+	static function get_cacheBitmapAllocs():Int return 0;
+}
+#end

--- a/tests/cairo-surface-clip/src/AllocCounter.hx
+++ b/tests/cairo-surface-clip/src/AllocCounter.hx
@@ -1,0 +1,37 @@
+package;
+
+/**
+ * Allocation counters for the visual repro. When built with
+ * `-D openfl_count_surface_allocs` the values read from instrumented fields
+ * in OpenFL; otherwise stay at zero so the demo runs on any target.
+ *
+ *  - `surfaceAllocs`     -> `CairoGraphics.__surfaceAllocs`
+ *    (cached Cairo image surface for `Graphics.__bitmap`)
+ *  - `cacheBitmapAllocs` -> `DisplayObjectRenderer.__cacheBitmapAllocs`
+ *    (cacheAsBitmap / filters bitmap for `DisplayObject.__cacheBitmapData`)
+ */
+@:access(openfl.display._internal.CairoGraphics)
+@:access(openfl.display.DisplayObjectRenderer)
+class AllocCounter
+{
+	public static var surfaceAllocs(get, never):Int;
+	public static var cacheBitmapAllocs(get, never):Int;
+
+	static function get_surfaceAllocs():Int
+	{
+		#if openfl_count_surface_allocs
+		return openfl.display._internal.CairoGraphics.__surfaceAllocs;
+		#else
+		return 0;
+		#end
+	}
+
+	static function get_cacheBitmapAllocs():Int
+	{
+		#if openfl_count_surface_allocs
+		return openfl.display.DisplayObjectRenderer.__cacheBitmapAllocs;
+		#else
+		return 0;
+		#end
+	}
+}

--- a/tests/cairo-surface-clip/src/Main.hx
+++ b/tests/cairo-surface-clip/src/Main.hx
@@ -1,0 +1,275 @@
+package;
+
+import openfl.display.BitmapData;
+import openfl.display.PNGEncoderOptions;
+import openfl.display.Shape;
+import openfl.display.Sprite;
+import openfl.display.StageQuality;
+import openfl.events.Event;
+import openfl.events.KeyboardEvent;
+import openfl.filters.GlowFilter;
+import openfl.geom.Rectangle;
+import openfl.text.TextField;
+import openfl.text.TextFormat;
+import openfl.ui.Keyboard;
+import openfl.utils.ByteArray;
+import openfl.Lib;
+
+/**
+ * Visual repro for the Cairo cache surface vs painted-region mismatch
+ * described in openfl/openfl#2866.
+ *
+ * Reproduces the production scenario described in TM-Haxe4 commit 8ad28032
+ * ("fix goal clipping in high-res video export"): a goal-like shape with a
+ * vertical post hugging the right edge of its drawn bounds, parented to a
+ * Sprite that carries an invisible GlowFilter — the filter triggers the
+ * cacheAsBitmap render path. When the parent is scaled up between frames
+ * (simulating UI->export pixelRatio jump), the upstream `>` check reuses
+ * the smaller cached Cairo surface; Cairo paints the new (larger) content
+ * into the old surface's sub-region; Context3DShape composites the full
+ * bitmap dims via worldTransform; the right post falls outside the painted
+ * sub-region and visibly disappears.
+ *
+ * Layout (top half = "buggy" path, bottom half = comparison):
+ *
+ *   TOP    : Sprite with GlowFilter(alpha=0) wrapping the goal Shape;
+ *            scaleX/scaleY tween simulates pixelRatio jump.
+ *   BOTTOM : Same Shape, no parent filter, same scale tween for visual
+ *            reference.
+ *
+ * The bug is visible at the FIRST frame after a scale increase: top goal
+ * shows missing right post; bottom goal is intact.
+ */
+class Main extends Sprite
+{
+	public static function main()
+	{
+		#if sys
+		try sys.io.File.saveContent("/tmp/cairo-surface-clip.log", "main() entered\n") catch (e:Dynamic) {}
+		#end
+		new Main();
+	}
+
+	// Goal bounds in shape-local coords. Post thickness 8, crossbar height 8,
+	// total area 220 wide x 110 tall. Right post hugs the right edge.
+	static inline var GOAL_W = 220.0;
+	static inline var GOAL_H = 110.0;
+	static inline var POST = 8.0;
+	static inline var FILL = 0xE0E0E0;
+	static inline var BACKDROP = 0x2A4030; // dark green pitch
+	static inline var REFERENCE_BAR = 0xFF00C0;
+
+	var topGoalWrapper:Sprite;
+	var topGoal:Shape;
+	var bottomGoal:Shape;
+	var stats:TextField;
+
+	var frame:Int = 0;
+	var allocBaseline:Int = 0;
+
+	public function new()
+	{
+		super();
+		addEventListener(Event.ADDED_TO_STAGE, onAdded);
+		Lib.current.addChild(this);
+	}
+
+	function onAdded(_)
+	{
+		removeEventListener(Event.ADDED_TO_STAGE, onAdded);
+		stage.quality = StageQuality.BEST;
+		stage.addEventListener(KeyboardEvent.KEY_DOWN, onKey);
+
+		drawBackground();
+
+		// TOP: goal inside a wrapper Sprite carrying an invisible GlowFilter.
+		// `DisplayObject.cacheAsBitmap` getter returns true whenever filters is
+		// non-null, regardless of the field. This routes rendering through the
+		// cached-bitmap path described in our PR.
+		topGoal = new Shape();
+		paintGoal(topGoal);
+		topGoalWrapper = new Sprite();
+		topGoalWrapper.x = 60;
+		topGoalWrapper.y = 130;
+		topGoalWrapper.filters = [new GlowFilter(0xFFFFFF, 0.0, 0, 0, 1, 1)];
+		topGoalWrapper.addChild(topGoal);
+		addChild(topGoalWrapper);
+
+		// BOTTOM: same goal, no filter, no wrapper — direct path for comparison.
+		bottomGoal = new Shape();
+		paintGoal(bottomGoal);
+		bottomGoal.x = 60;
+		bottomGoal.y = 380;
+		addChild(bottomGoal);
+
+		stats = makeText();
+		stats.x = 10;
+		stats.y = 10;
+		stats.width = 780;
+		stats.height = 96;
+		addChild(stats);
+
+		allocBaseline = AllocCounter.surfaceAllocs;
+		addEventListener(Event.ENTER_FRAME, onFrame);
+	}
+
+	function drawBackground()
+	{
+		graphics.beginFill(BACKDROP);
+		graphics.drawRect(0, 0, 800, 600);
+		graphics.endFill();
+
+		// Reference vertical bars below each goal at known positions; the goal
+		// occupies x = 60 .. 60 + GOAL_W*scaleMax, so bars 0..N anchor where
+		// the right post SHOULD be in each render.
+		graphics.beginFill(REFERENCE_BAR);
+		for (i in 0...10)
+		{
+			var x = 60 + i * 70;
+			graphics.drawRect(x, 270, 4, 12);
+			graphics.drawRect(x, 530, 4, 12);
+		}
+		graphics.endFill();
+	}
+
+	function paintGoal(shape:Shape)
+	{
+		// Use drawRoundRect so the shape routes through CairoGraphics (curves
+		// are not hardware-compatible; `Context3DGraphics.isCompatible` falls
+		// back to the software path). Plain drawRect would bypass the bug.
+		shape.graphics.clear();
+		shape.graphics.beginFill(FILL);
+		// Left post.
+		shape.graphics.drawRoundRect(0, 0, POST, GOAL_H, 2, 2);
+		// Right post — hugs right edge. The content the bug clips.
+		shape.graphics.drawRoundRect(GOAL_W - POST, 0, POST, GOAL_H, 2, 2);
+		// Crossbar across the top.
+		shape.graphics.drawRoundRect(0, 0, GOAL_W, POST, 2, 2);
+		// Back-support stripes near the right side.
+		shape.graphics.drawRoundRect(GOAL_W - 30, GOAL_H - POST, 30, POST, 2, 2);
+		shape.graphics.drawRoundRect(GOAL_W - 30, GOAL_H * 0.5 - POST * 0.5, 30, POST, 2, 2);
+		shape.graphics.endFill();
+	}
+
+	function onKey(e:KeyboardEvent)
+	{
+		switch (e.keyCode)
+		{
+			case Keyboard.R:
+				allocBaseline = AllocCounter.surfaceAllocs;
+				frame = 0;
+			case Keyboard.F:
+				topGoalWrapper.filters = (topGoalWrapper.filters == null)
+					? [new GlowFilter(0xFFFFFF, 0.0, 0, 0, 1, 1)] : null;
+		}
+	}
+
+	function onFrame(_)
+	{
+		frame++;
+		// Render schedule (60 fps):
+		//   frame   1- 60 : scale = 1.0   (UI-equivalent, baseline cache size)
+		//   frame  60     : capture "before jump"
+		//   frame  61     : scale jumps to 3.0 (export-equivalent)
+		//   frame  61     : capture "first frame after jump" — bug shows here
+		//                   if Cairo surface from prev frame is reused undersized
+		//   frame  90     : capture "settled at 3x"
+		//   frame 120     : scale drops back to 1.0
+		//   frame 121     : capture "first frame after shrink"
+		var scaleNow = scaleForFrame(frame);
+		topGoalWrapper.scaleX = topGoalWrapper.scaleY = scaleNow;
+		bottomGoal.scaleX = bottomGoal.scaleY = scaleNow;
+
+		updateStats(scaleNow);
+
+		// Capture via Context3D.drawToBitmapData -> Window.readPixels = real GL
+		// framebuffer. The framebuffer reflects the PREVIOUS frame's render
+		// (current frame's render happens after ENTER_FRAME), so capture one
+		// frame AFTER the phase change to read the post-change render.
+		switch (frame)
+		{
+			case 55:  capture('1_settled_scale1');       // mid-phase scale=1
+			case 65:  capture('2_just_after_jump');      // 5 frames after jump to 3
+			case 175: capture('3_settled_scale3');       // deep into scale=3
+			case 185: capture('4_just_after_shrink');    // 5 frames after drop to 1
+			case 235: capture('5_settled_scale1_again'); // deep into final scale=1
+		}
+
+		if (frame >= 240)
+		{
+			#if sys try sys.io.File.append("/tmp/cairo-surface-clip.log", false).writeString("done\n") catch (e:Dynamic) {} #end
+			removeEventListener(Event.ENTER_FRAME, onFrame);
+		}
+	}
+
+	function scaleForFrame(f:Int):Float
+	{
+		// Long phases so the GL swap chain (typically 2-3 frames deep) has
+		// fully reflected the post-change render by the time we capture.
+		if (f <= 60) return 1.0;
+		if (f <= 180) return 3.0;
+		return 1.0;
+	}
+
+	function capture(tag:String)
+	{
+		#if sys
+		try
+		{
+			var ctx = stage.context3D;
+			if (ctx == null)
+			{
+				sys.io.File.append("/tmp/cairo-surface-clip.log", false)
+					.writeString('capture $tag: no Context3D, skipping\n');
+				return;
+			}
+			var w = Std.int(stage.stageWidth);
+			var h = Std.int(stage.stageHeight);
+			var bmp = new BitmapData(w, h, false, 0x000000);
+			ctx.drawToBitmapData(bmp);
+			var ba:ByteArray = bmp.encode(new Rectangle(0, 0, w, h), new PNGEncoderOptions());
+			var path = '/tmp/cairo-surface-clip-$tag.png';
+			var out = sys.io.File.write(path, true);
+			ba.position = 0;
+			out.writeBytes(haxe.io.Bytes.ofData(ba), 0, ba.length);
+			out.close();
+			sys.io.File.append("/tmp/cairo-surface-clip.log", false)
+				.writeString('captured $path at frame=$frame scale=${topGoalWrapper.scaleX}\n');
+		}
+		catch (e:Dynamic)
+		{
+			#if sys
+			try sys.io.File.append("/tmp/cairo-surface-clip.log", false)
+				.writeString('capture $tag failed: $e\n') catch (e2:Dynamic) {}
+			#end
+		}
+		#end
+	}
+
+
+	function updateStats(scaleNow:Float)
+	{
+		var allocs = AllocCounter.surfaceAllocs - allocBaseline;
+		var cacheAllocs = AllocCounter.cacheBitmapAllocs;
+		stats.text = 'frame: $frame   scale: $scaleNow\n'
+			+ 'CairoGraphics surface allocs: $allocs   cacheBitmapData allocs: $cacheAllocs\n'
+			+ 'TOP    : Sprite with GlowFilter(alpha=0) -> cacheAsBitmap path\n'
+			+ 'Schedule: 1..60 scale=1, 61..120 scale=3, 121..180 scale=1   (r=reset, f=toggle filter)';
+		if (frame % 30 == 0)
+		{
+			#if sys
+			try sys.io.File.append("/tmp/cairo-surface-clip.log", false)
+				.writeString('frame=$frame scale=$scaleNow surfaceAllocs=$allocs cacheBitmapAllocs=$cacheAllocs\n') catch (e:Dynamic) {}
+			#end
+		}
+	}
+
+	static function makeText():TextField
+	{
+		var tf = new TextField();
+		tf.selectable = false;
+		tf.mouseEnabled = false;
+		tf.defaultTextFormat = new TextFormat("_sans", 13, 0xE0E0E0);
+		return tf;
+	}
+}

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -6,6 +6,7 @@ class Tests
 	public static function main()
 	{
 		var runner = new Runner();
+		runner.addCase(new CairoSurfaceSizeTest());
 		runner.addCase(new CapsStyleTest());
 		runner.addCase(new GradientTypeTest());
 		runner.addCase(new GraphicsBitmapFillTest());

--- a/tests/graphics/src/CairoSurfaceSizeTest.hx
+++ b/tests/graphics/src/CairoSurfaceSizeTest.hx
@@ -1,0 +1,203 @@
+package;
+
+import openfl.display.BitmapData;
+import openfl.display.Shape;
+import openfl.text.TextField;
+import openfl.text.TextFieldAutoSize;
+import openfl.text.TextFormat;
+import utest.Assert;
+import utest.Test;
+
+/**
+ * Regression test for openfl/openfl#2866 and its follow-up.
+ *
+ * Two related invariants are checked:
+ *
+ *  1. **High-water-mark surface** — the cached Cairo surface holds
+ *     `bitmap.width >= __width` and `bitmap.height >= __height` at all
+ *     times. It grows on demand and is reused on shrink (no per-frame
+ *     reallocation when bounds oscillate).
+ *
+ *  2. **Painted-region correctness** — the painted sub-region of the
+ *     surface (the leading `__width × __height` pixels) contains the
+ *     full drawn content. Context3DShape composites only this sub-region
+ *     via `BitmapData.getVertexBuffer(..., paintedWidth, paintedHeight)`,
+ *     so the right/bottom edges of the painted shape are never clipped
+ *     by oversize transparent padding (the original bug).
+ *
+ * The test drives the software path through `BitmapData.draw`, which
+ * routes to `CairoGraphics.render` on hxcpp/Cairo and exercises the
+ * same surface lifecycle the Context3D path observes via the shared
+ * `graphics.__bitmap`.
+ */
+@:access(openfl.display.Graphics)
+@:access(openfl.text.TextField)
+class CairoSurfaceSizeTest extends Test
+{
+	#if (cpp && lime_cairo)
+	public function test_surfaceHoldsHighWaterAfterShrink()
+	{
+		var shape = new Shape();
+
+		// First render: 200x100 fill -> surface allocated for the wider bounds.
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 200, 100);
+		shape.graphics.endFill();
+
+		var dst1 = new BitmapData(200, 100, true, 0);
+		dst1.draw(shape);
+
+		Assert.notNull(shape.graphics.__bitmap, "first render should produce a cached bitmap");
+		Assert.isTrue(shape.graphics.__bitmap.width >= shape.graphics.__width,
+			"first render: bitmap.width must cover painted width");
+		Assert.isTrue(shape.graphics.__bitmap.height >= shape.graphics.__height,
+			"first render: bitmap.height must cover painted height");
+
+		var peakWidth = shape.graphics.__bitmap.width;
+		var peakHeight = shape.graphics.__bitmap.height;
+
+		// Shrink: same shape, narrower bounds. High-water surface holds peak —
+		// `bitmap.width` stays at peakWidth, `bitmap.height` at peakHeight,
+		// painted region shrinks to 100x100. Upstream's `>` + 1.25x check
+		// produced the same hold but without the painted-region clamp at
+		// composite, so the oversize padding visually clipped content.
+		shape.graphics.clear();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 100, 100);
+		shape.graphics.endFill();
+
+		var dst2 = new BitmapData(100, 100, true, 0);
+		dst2.draw(shape);
+
+		Assert.isTrue(shape.graphics.__bitmap.width >= shape.graphics.__width,
+			"after shrink: bitmap.width must still cover painted width");
+		Assert.isTrue(shape.graphics.__bitmap.height >= shape.graphics.__height,
+			"after shrink: bitmap.height must still cover painted height");
+		Assert.equals(peakWidth, shape.graphics.__bitmap.width,
+			"after shrink: surface holds high-water (no reallocation)");
+		Assert.equals(peakHeight, shape.graphics.__bitmap.height,
+			"after shrink: surface holds high-water (no reallocation)");
+	}
+
+	public function test_surfaceGrowsOnGrow()
+	{
+		var shape = new Shape();
+
+		shape.graphics.beginFill(0x00FF00);
+		shape.graphics.drawRect(0, 0, 100, 100);
+		shape.graphics.endFill();
+
+		var dst1 = new BitmapData(100, 100, true, 0);
+		dst1.draw(shape);
+
+		Assert.isTrue(shape.graphics.__bitmap.width >= 100);
+		Assert.isTrue(shape.graphics.__bitmap.height >= 100);
+
+		// Grow: bounds expand to 200x100. Surface must grow to accommodate.
+		shape.graphics.clear();
+		shape.graphics.beginFill(0x00FF00);
+		shape.graphics.drawRect(0, 0, 200, 100);
+		shape.graphics.endFill();
+
+		var dst2 = new BitmapData(200, 100, true, 0);
+		dst2.draw(shape);
+
+		Assert.isTrue(shape.graphics.__bitmap.width >= 200,
+			"after grow: bitmap.width must cover new painted width");
+		Assert.isTrue(shape.graphics.__bitmap.height >= 100,
+			"after grow: bitmap.height must cover painted height");
+	}
+
+	public function test_textFieldSurfaceHoldsHighWaterAfterShrink()
+	{
+		// Same invariant for the parallel `CairoTextField` surface path. A
+		// TextField sized 400x60 followed by a 100x60 redraw must keep the
+		// wider surface around (high-water hold) while remaining at least
+		// as wide as the new painted region. Driving through `BitmapData.draw`
+		// routes to `CairoTextField.render` on hxcpp.
+		var tf = new TextField();
+		tf.autoSize = TextFieldAutoSize.NONE;
+		tf.background = true;
+		tf.backgroundColor = 0x00FF00;
+		tf.width = 400;
+		tf.height = 60;
+
+		new BitmapData(400, 60, true, 0).draw(tf);
+
+		Assert.notNull(tf.__graphics.__bitmap, "first render should produce a cached bitmap");
+		Assert.isTrue(tf.__graphics.__bitmap.width >= tf.__graphics.__width);
+		Assert.isTrue(tf.__graphics.__bitmap.height >= tf.__graphics.__height);
+
+		var peakWidth = tf.__graphics.__bitmap.width;
+		var peakHeight = tf.__graphics.__bitmap.height;
+
+		// Shrink the visible area.
+		tf.width = 100;
+		new BitmapData(100, 60, true, 0).draw(tf);
+
+		Assert.isTrue(tf.__graphics.__bitmap.width >= tf.__graphics.__width,
+			"after shrink: TextField surface must cover painted width");
+		Assert.isTrue(tf.__graphics.__bitmap.height >= tf.__graphics.__height,
+			"after shrink: TextField surface must cover painted height");
+		Assert.equals(peakWidth, tf.__graphics.__bitmap.width,
+			"after shrink: TextField surface holds high-water (no reallocation)");
+		Assert.equals(peakHeight, tf.__graphics.__bitmap.height,
+			"after shrink: TextField surface holds high-water (no reallocation)");
+	}
+
+	public function test_textFieldSurfaceGrowsOnGrow()
+	{
+		var tf = new TextField();
+		tf.autoSize = TextFieldAutoSize.NONE;
+		tf.background = true;
+		tf.backgroundColor = 0xFFFF00;
+		tf.width = 100;
+		tf.height = 60;
+
+		new BitmapData(100, 60, true, 0).draw(tf);
+
+		Assert.isTrue(tf.__graphics.__bitmap.width >= 100,
+			"first render: surface must cover painted width");
+
+		// Grow.
+		tf.width = 300;
+		new BitmapData(300, 60, true, 0).draw(tf);
+
+		Assert.isTrue(tf.__graphics.__bitmap.width >= tf.__graphics.__width,
+			"after grow: TextField surface must cover new painted width");
+	}
+
+	public function test_paintedRegionFullyOpaqueAtRightEdgeAfterShrink()
+	{
+		// End-to-end pixel-level check: after shrink, the rightmost column of
+		// the painted region must contain the fill color. The Context3DShape
+		// composite (via BitmapData.getVertexBuffer painted-region params)
+		// must clamp to `__width × __height`, never sampling the transparent
+		// padding that lives in the high-water surface past `__width`.
+		var shape = new Shape();
+
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 200, 100);
+		shape.graphics.endFill();
+		new BitmapData(200, 100, true, 0).draw(shape);
+
+		shape.graphics.clear();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 100, 100);
+		shape.graphics.endFill();
+
+		var dst = new BitmapData(100, 100, true, 0);
+		dst.draw(shape);
+
+		// Sample inside the right edge (x=98) of the painted region.
+		var px = dst.getPixel32(98, 50);
+		Assert.equals(0xFFFF0000, px & 0xFFFFFFFF);
+	}
+	#else
+	public function test_skippedOnNonCairoTarget()
+	{
+		// CairoGraphics surface allocation only runs on hxcpp/lime_cairo.
+		Assert.isTrue(true);
+	}
+	#end
+}


### PR DESCRIPTION
## Summary

The Cairo render path allocates `bitmap = width × height × 1.25` when
the previous surface is too small, and reuses any surface that satisfies
`width <= surface.width && height <= surface.height`. After a frame
where bounds grew (or after the legacy 1.25× upscale margin kicked in),
the surface stays oversized; Cairo paints only into the `width × height`
sub-region, and the empty padding renders into the final composited
output as transparency on the right/bottom edges of the shape.

This PR makes the surface match `width × height` exactly: reallocate
on any size mismatch, and drop the 1.25× upscale margin.

## The bug

In `CairoGraphics.render()`, surface reuse and allocation looked like:

```haxe
var needsUpscaling = false;

if (graphics.__cairo != null)
{
    var surface:CairoImageSurface = cast graphics.__cairo.target;

    if (width > surface.width || height > surface.height)
    {
        graphics.__cairo = null;
        needsUpscaling = true;
    }
}

if (graphics.__cairo == null || graphics.__bitmap == null)
{
    var bitmapWidth  = needsUpscaling ? Std.int(width * 1.25)  : width;
    var bitmapHeight = needsUpscaling ? Std.int(height * 1.25) : height;
    ...
}
```

Two related problems:

1. **Reuse with shrinking content.** If the previous frame produced
   `surface = 250×H` and the current frame has `width=200`, the
   `width > surface.width` check is `false`, so we keep the 250×H
   surface. Cairo then paints content into the `200×H` sub-region.
   `Context3DShape` composites the cached bitmap back into the
   framebuffer using `__worldTransform`, which is sized to the bitmap,
   not to the painted sub-region — the right 50 pixels of empty padding
   end up where content should be, visually clipping the shape.

2. **1.25× upscale margin amplifies the problem.** Even on the first
   reallocation after a growth, the surface is intentionally allocated
   25% larger than needed, so the very next frame already has an
   oversized surface and the above clipping pattern starts.

We hit this on a Context3DRenderer-driven workload (TextField caches
and scale-9 rounded-rect Shapes) where bounds oscillate as content
re-flows.

## Fix

```haxe
if (graphics.__cairo != null)
{
    var surface:CairoImageSurface = cast graphics.__cairo.target;

    if (width != surface.width || height != surface.height)
    {
        graphics.__cairo = null;
    }
}

if (graphics.__cairo == null || graphics.__bitmap == null)
{
    var bitmapWidth = width;
    var bitmapHeight = height;
    // existing Graphics.maxTextureWidth/Height clamping retained (per #2847)
    ...
}
```

- `>` → `!=` so a smaller-than-current shape forces reallocation
  instead of painting into an oversized surface.
- 1.25× margin gone; surface is allocated to exactly `width × height`,
  still clamped to `Graphics.maxTextureWidth/Height` from #2847.

## Trade-off

Rapid frame-to-frame resizes now reallocate every frame instead of
every fifth (when bounds grew by ≤25%). In practice
`new BitmapData()` is cheap on the Cairo path — one arena allocation
backing the image surface — and visual correctness on every frame
outweighs the saved allocation. No other code in CairoGraphics depends
on the surface being larger than the current content (verified by
grep for `surface.width` / `surface.height`).

## Test

Type-checked: `haxe --no-output -cp src -lib lime -D openfl=9.5.1 --macro 'include("openfl.display._internal")'` succeeds.

No deterministic repro app — Cairo path activates via specific
composite chains (`BitmapData.draw` with the software renderer,
Context3DShape compositing) rather than the default stage render, so
a standalone demo would need a contrived setup that wouldn't add
clarity beyond the explanation above. The fix was verified by running
our internal Context3DRenderer-driven app on this branch: scale-9
rounded-rect right/bottom edges no longer clip after layout shrinks.
Happy to add a sample if reviewers want one.

## Risk

- Single-render-pass shapes whose bounds never change: identical
  behaviour — `width == surface.width` on every frame after the first.
- Shapes with constantly-changing bounds: one extra `new BitmapData()`
  per frame compared to the 1.25× margin (which amortised over ≤5
  frames). In our profiling this didn't move the needle.
- Interaction with #2847 (`Graphics.maxTextureWidth/Height` clamp):
  unchanged — clamp logic is preserved verbatim.