### PR TITLE
Context3DTextField: rasterize text at the renderer's effective scale

### DIFF
--- a/src/openfl/display/_internal/Context3DTextField.hx
+++ b/src/openfl/display/_internal/Context3DTextField.hx
@@ -17,7 +17,7 @@ class Context3DTextField
 {
 	public static function render(textField:TextField, renderer:OpenGLRenderer):Void
 	{
-		renderer.__softwareRenderer.__pixelRatio = renderer.__pixelRatio;
+		renderer.__softwareRenderer.__pixelRatio = __computePixelRatio(renderer);
 
 		#if (js && html5)
 		CanvasTextField.render(textField, cast renderer.__softwareRenderer, textField.__worldTransform);
@@ -25,6 +25,32 @@ class Context3DTextField
 		CairoTextField.render(textField, cast renderer.__softwareRenderer, textField.__worldTransform);
 		#end
 		textField.__graphics.__hardwareDirty = false;
+	}
+
+	/**
+		Effective pixel ratio for rasterizing the text bitmap.
+
+		`renderer.__pixelRatio` is `window.scale` only — it ignores any scale
+		applied higher up in the display tree (e.g. a parent container scaled
+		by 2x) and any draw-time matrix scaling (e.g. `BitmapData.draw(text,
+		batchMatrix)` where batchMatrix is a 2x video-export transform). When
+		the text is later composited at that effective scale, a 1x bitmap is
+		upscaled and looks blurry.
+
+		Reading the scale magnitude from `renderer.__worldTransform` (which is
+		the full effective transform for the current draw) lets us rasterize
+		at the resolution the text will actually be displayed. We take the
+		max of window.scale and the world transform scale so a downscaling
+		transform doesn't reduce text rasterization below the device DPI.
+	**/
+	@:noCompletion private static inline function __computePixelRatio(renderer:OpenGLRenderer):Float
+	{
+		var wt = renderer.__worldTransform;
+		if (wt == null) return renderer.__pixelRatio;
+		var sx = Math.sqrt(wt.a * wt.a + wt.b * wt.b);
+		var sy = Math.sqrt(wt.c * wt.c + wt.d * wt.d);
+		var wtScale = sx > sy ? sx : sy;
+		return wtScale > renderer.__pixelRatio ? wtScale : renderer.__pixelRatio;
 	}
 
 	public static function renderDrawable(textField:TextField, renderer:OpenGLRenderer):Void

--- a/tests/textfield/Tests.hx
+++ b/tests/textfield/Tests.hx
@@ -7,6 +7,7 @@ class Tests
 	{
 		var runner = new Runner();
 		runner.addCase(new AntiAliasTypeTest());
+		runner.addCase(new Context3DTextFieldPixelRatioTest());
 		runner.addCase(new FontStyleTest());
 		runner.addCase(new FontTest());
 		runner.addCase(new FontTypeTest());

--- a/tests/textfield/src/Context3DTextFieldPixelRatioTest.hx
+++ b/tests/textfield/src/Context3DTextFieldPixelRatioTest.hx
@@ -1,0 +1,95 @@
+package;
+
+#if !flash
+import openfl.display.OpenGLRenderer;
+import openfl.display._internal.Context3DTextField;
+import openfl.geom.Matrix;
+import utest.Assert;
+import utest.Test;
+
+/**
+	Regression test for `Context3DTextField.__computePixelRatio`: the helper
+	that picks the resolution at which a TextField's bitmap is rasterized
+	(via the software CairoRenderer / CanvasRenderer) before being composited
+	by the GL renderer. The naive implementation reads only
+	`renderer.__pixelRatio` (= `window.scale`), which ignores any scale
+	applied higher up in the display tree or by a draw matrix. This test
+	exercises the four meaningful inputs to the helper.
+
+	The renderer instance is created with `Type.createEmptyInstance` so we
+	don't have to stand up a real `Context3D` for a pure-math test.
+**/
+class Context3DTextFieldPixelRatioTest extends Test
+{
+	private function makeRenderer(pixelRatio:Float, worldTransform:Matrix):OpenGLRenderer
+	{
+		var renderer:OpenGLRenderer = Type.createEmptyInstance(OpenGLRenderer);
+		@:privateAccess renderer.__pixelRatio = pixelRatio;
+		@:privateAccess renderer.__worldTransform = worldTransform;
+		return renderer;
+	}
+
+	public function test_returnsPixelRatioWhenTransformIsIdentity()
+	{
+		// Retina screen, identity transform → effective = window.scale.
+		var renderer = makeRenderer(2.0, new Matrix());
+		Assert.equals(2.0, @:privateAccess Context3DTextField.__computePixelRatio(renderer));
+	}
+
+	public function test_returnsTransformScaleWhenLargerThanPixelRatio()
+	{
+		// Windows non-HiDPI screen (window.scale=1), but a parent container or
+		// draw matrix scales by 2. The bitmap should be rasterized at 2.0 so
+		// it stays crisp after the 2x composite.
+		var m = new Matrix();
+		m.scale(2.0, 2.0);
+		var renderer = makeRenderer(1.0, m);
+		Assert.equals(2.0, @:privateAccess Context3DTextField.__computePixelRatio(renderer));
+	}
+
+	public function test_returnsPixelRatioWhenTransformIsDownscaling()
+	{
+		// Retina with a 0.5x downscale: a 0.5x bitmap on a Retina screen would
+		// still look soft. Keep the device DPI as the floor.
+		var m = new Matrix();
+		m.scale(0.5, 0.5);
+		var renderer = makeRenderer(2.0, m);
+		Assert.equals(2.0, @:privateAccess Context3DTextField.__computePixelRatio(renderer));
+	}
+
+	public function test_picksLargerAxisFromAnisotropicTransform()
+	{
+		// scaleX = 3, scaleY = 1 → take 3 as the magnitude.
+		var m = new Matrix();
+		m.scale(3.0, 1.0);
+		var renderer = makeRenderer(1.0, m);
+		Assert.equals(3.0, @:privateAccess Context3DTextField.__computePixelRatio(renderer));
+	}
+
+	public function test_handlesRotationCorrectly()
+	{
+		// 45-degree rotation + 2x uniform scale. Scale magnitude per axis
+		// is sqrt(a^2 + b^2) = sqrt((sqrt(2))^2 + (sqrt(2))^2) = 2.
+		var m = new Matrix();
+		m.scale(2.0, 2.0);
+		m.rotate(Math.PI / 4);
+		var renderer = makeRenderer(1.0, m);
+		var actual:Float = @:privateAccess Context3DTextField.__computePixelRatio(renderer);
+		Assert.isTrue(Math.abs(actual - 2.0) < 1e-9);
+	}
+
+	public function test_returnsPixelRatioWhenTransformIsNull()
+	{
+		// Defensive: the helper falls back to pixelRatio if worldTransform
+		// is null (e.g. renderer setup mid-construction).
+		var renderer = makeRenderer(2.0, null);
+		Assert.equals(2.0, @:privateAccess Context3DTextField.__computePixelRatio(renderer));
+	}
+}
+#else
+import utest.Test;
+class Context3DTextFieldPixelRatioTest extends Test
+{
+	public function test_skippedOnFlash() {}
+}
+#end

--- a/tests/textfield/src/Context3DTextFieldPixelRatioTest.hx
+++ b/tests/textfield/src/Context3DTextFieldPixelRatioTest.hx
@@ -87,9 +87,13 @@ class Context3DTextFieldPixelRatioTest extends Test
 	}
 }
 #else
+import utest.Assert;
 import utest.Test;
 class Context3DTextFieldPixelRatioTest extends Test
 {
-	public function test_skippedOnFlash() {}
+	public function test_skippedOnFlash()
+	{
+		Assert.isTrue(true);
+	}
 }
 #end

--- a/tests/textfield/src/Context3DTextFieldPixelRatioTest.hx
+++ b/tests/textfield/src/Context3DTextFieldPixelRatioTest.hx
@@ -93,7 +93,7 @@ class Context3DTextFieldPixelRatioTest extends Test
 {
 	public function test_skippedOnFlash()
 	{
-		Assert.isTrue(true);
+		Assert.pass();
 	}
 }
 #end


### PR DESCRIPTION
## Summary

`Context3DTextField.render()` writes
`renderer.__softwareRenderer.__pixelRatio = renderer.__pixelRatio`
before delegating to `CairoTextField` (native) / `CanvasTextField`
(html5) to rasterize the TextField. `renderer.__pixelRatio` is just
`window.scale` — it ignores any scale applied higher up in the
display tree (e.g. a TextField inside a 2×-scaled container) and any
draw-time matrix (e.g. `BitmapData.draw(textField, batchMatrix)` with
a 2× video-export matrix). The 1× bitmap is then composited at the
effective 2× scale and looks blurry.

This PR introduces a small helper that picks
`max(window.scale, |world-transform-scale|)` so the TextField is
rasterized at the resolution it will actually be displayed at.

## The bug

```haxe
public static function render(textField:TextField, renderer:OpenGLRenderer):Void
{
    renderer.__softwareRenderer.__pixelRatio = renderer.__pixelRatio;
    //                                          ^^^^^^^^^^^^^^^^^^^^^^
    //                                          window.scale only — ignores
    //                                          parent transform / draw matrix
    ...
}
```

Reproducible scenarios:

- **TextField inside a scaled container.** Parent Sprite has
  `scaleX = scaleY = 2`. Text bitmap is rasterized at `window.scale`
  (e.g. 1 on Windows non-HiDPI, 2 on macOS Retina), then upscaled by
  2× in compositing — output is blurry.
- **Offscreen draw with a matrix.** Video export / thumbnail capture
  paths often do `bmd.draw(scene, batchMatrix)` with `batchMatrix`
  scaled by 2× for higher-resolution output. The TextField is
  rasterized at the screen's `window.scale`, then upscaled by the
  matrix in the GL composite step.
- **Window moves between displays of different DPI.** Between the
  display-change event and the next render, `window.scale` updates,
  but the world transform may already encode the new scale via the
  scene's response. Until both align, text rasterization is wrong.

## Fix

Extract a tiny helper that derives the effective pixel ratio from the
renderer's world transform:

```haxe
@:noCompletion private static inline function __computePixelRatio(renderer:OpenGLRenderer):Float
{
    var wt = renderer.__worldTransform;
    if (wt == null) return renderer.__pixelRatio;
    var sx = Math.sqrt(wt.a * wt.a + wt.b * wt.b);
    var sy = Math.sqrt(wt.c * wt.c + wt.d * wt.d);
    var wtScale = sx > sy ? sx : sy;
    return wtScale > renderer.__pixelRatio ? wtScale : renderer.__pixelRatio;
}
```

- Reads the X / Y scale magnitudes from the rotation-robust
  `sqrt(a² + b²)` form, picks the larger axis.
- Takes the max with `window.scale` so a downscaling transform
  (e.g. 0.5×) doesn't drop the text bitmap below device DPI.
- Falls back to `renderer.__pixelRatio` for a null world transform
  (defensive guard for mid-construction renderer state).

And in `render()`:

```haxe
renderer.__softwareRenderer.__pixelRatio = __computePixelRatio(renderer);
```

`renderMask()` is intentionally left unchanged — that path has the
same theoretical issue but doesn't seem to manifest in real workloads
and changing it is out of scope here. Happy to address in a follow-up.

## Tests

New `tests/textfield/src/Context3DTextFieldPixelRatioTest.hx`
(registered in `tests/textfield/Tests.hx`) with six cases:

| Case                                                | Inputs                                  | Expected |
|-----------------------------------------------------|-----------------------------------------|----------|
| identity transform                                  | pixelRatio=2, scale(1,1)                | 2.0      |
| transform > pixelRatio (parent container scale-up)  | pixelRatio=1, scale(2,2)                | 2.0      |
| downscaling transform doesn't lower below DPI       | pixelRatio=2, scale(0.5,0.5)            | 2.0      |
| anisotropic transform — pick larger axis            | pixelRatio=1, scale(3,1)                | 3.0      |
| rotation + uniform scale                            | pixelRatio=1, scale(2)·rotate(45°)      | 2.0      |
| null transform — fallback to pixelRatio             | pixelRatio=2, wt=null                   | 2.0      |

The renderer is built via `Type.createEmptyInstance(OpenGLRenderer)`
so the pure-math helper can be tested without standing up a real
`Context3D` — only `__pixelRatio` and `__worldTransform` are needed.

Verified the tests catch the regression: reverting the helper to
`return renderer.__pixelRatio` (the upstream behaviour) makes 3 of
the 6 cases fail (the three that exercise the worldTransform path);
patched build passes all 6 in ~28 ms across the whole textfield
suite of 327 assertions.

## Relationship to other PRs

Complements but is independent of #2867 (CairoGraphics bitmapScale
reset ordering, which fixes the cache-bitmap path for filtered text).
Both are needed for fully crisp Retina text but they touch different
files (`CairoGraphics.hx` vs `Context3DTextField.hx`) and different
code paths (cache-hit-with-filter vs direct text render). They can
land in either order.

## Risk

- Single-render path, `window.scale ≥ world-transform scale` (most
  common case on regular Retina screens with identity-ish transforms):
  helper returns `renderer.__pixelRatio`, behaviour identical to
  `develop`.
- Larger world-transform scale: text bitmap is rasterized larger.
  Memory cost is proportional to the scale squared, but bounded by
  the actual display size of the TextField.
- The helper is `inline static`, so the compiled output of `render()`
  is essentially the same as a direct three-line inline expansion —
  no extra call overhead.