### PR TITLE
CanvasGraphics: introduce __managed contract to preserve __bitmapScale across cache hits

### DIFF
--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -1849,6 +1849,22 @@ class CairoGraphics
 		// no scale9Grid for rotation 0.02 degrees or higher (less than 0.02 is allowed in flash)
 		var hasScale9Grid = scale9Grid != null && !graphics.__owner.__isMask && Math.abs(graphics.__owner.__rotation) < 0.02;
 		#end
+		graphics.__update(renderer.__worldTransform, pixelRatio);
+
+		if (!graphics.__softwareDirty || graphics.__managed)
+		{
+			CairoGraphics.graphics = null;
+			return;
+		}
+
+		// __bitmapScaleX/Y must only be reset when we are actually re-rendering
+		// the Cairo commands. CairoTextField writes a non-1 bitmapScale (pixelRatio,
+		// e.g. 2 on Retina) when it owns the bitmap, and CairoShape uses that value
+		// to composite the text bitmap back into the framebuffer at 1:1. Resetting
+		// it to 1 on every render() call — including cache-hit early-returns —
+		// would leave the composite path with bitmapScale=1, displaying the
+		// 2x-pixel text bitmap without the matching 1/pixelRatio downscale, i.e.
+		// text appears 2x as large until the next full re-render.
 		if (hasScale9Grid)
 		{
 			graphics.__bitmapScaleX = graphics.__owner.scaleX;
@@ -1858,14 +1874,6 @@ class CairoGraphics
 		{
 			graphics.__bitmapScaleX = 1;
 			graphics.__bitmapScaleY = 1;
-		}
-
-		graphics.__update(renderer.__worldTransform, pixelRatio);
-
-		if (!graphics.__softwareDirty || graphics.__managed)
-		{
-			CairoGraphics.graphics = null;
-			return;
 		}
 
 		bounds = graphics.__bounds;

--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -2001,21 +2001,31 @@ class CanvasGraphics
 		// no scale9Grid for rotation 0.02 degrees or higher (less than 0.02 is allowed in flash)
 		var hasScale9Grid = scale9Grid != null && !graphics.__owner.__isMask && Math.abs(graphics.__owner.__rotation) < 0.02;
 		#end
-		if (hasScale9Grid)
-		{
-			graphics.__bitmapScaleX = graphics.__owner.scaleX;
-			graphics.__bitmapScaleY = graphics.__owner.scaleY;
-		}
-		else
-		{
-			graphics.__bitmapScaleX = 1;
-			graphics.__bitmapScaleY = 1;
-		}
 
 		graphics.__update(renderer.__worldTransform, pixelRatio);
 
-		if (graphics.__softwareDirty)
+		if (graphics.__softwareDirty && !graphics.__managed)
 		{
+			// __bitmapScaleX/Y must only be reset when we are actually
+			// re-rendering the Canvas commands. On a cache hit
+			// (__softwareDirty=false) or when the graphics is externally
+			// managed (e.g. by CanvasTextField, which paints glyphs into
+			// __canvas at pixelRatio resolution and sets __bitmapScale =
+			// pixelRatio for the CanvasShape composite step), clobbering
+			// these here would break the composite math and trigger a
+			// redundant re-render every frame via the CanvasTextField
+			// self-heal at __bitmapScale != pixelRatio.
+			if (hasScale9Grid)
+			{
+				graphics.__bitmapScaleX = graphics.__owner.scaleX;
+				graphics.__bitmapScaleY = graphics.__owner.scaleY;
+			}
+			else
+			{
+				graphics.__bitmapScaleX = 1;
+				graphics.__bitmapScaleY = 1;
+			}
+
 			hitTesting = false;
 
 			CanvasGraphics.graphics = graphics;

--- a/src/openfl/display/_internal/CanvasShape.hx
+++ b/src/openfl/display/_internal/CanvasShape.hx
@@ -48,7 +48,19 @@ class CanvasShape
 					context.globalAlpha = alpha;
 
 					var renderTransform = Matrix.__pool.get();
-					renderTransform.scale(1 / graphics.__bitmapScaleX, 1 / graphics.__bitmapScaleY);
+					if (!graphics.__managed)
+					{
+						// scale(1/bitmapScale) is meaningful for scale9Grid graphics
+						// (where bitmapScale = owner.scaleX cancels the owner's scale)
+						// and a no-op for plain graphics (where bitmapScale = 1). For
+						// __managed graphics (i.e. those whose __canvas is owned by
+						// CanvasTextField at pixelRatio resolution), the source-to-
+						// destination scale is already encoded in drawImage's (width,
+						// height) destination args together with the renderer's
+						// pixelRatio-scaled __worldTransform; applying an additional
+						// 1/pixelRatio factor here would halve the rendered size.
+						renderTransform.scale(1 / graphics.__bitmapScaleX, 1 / graphics.__bitmapScaleY);
+					}
 					renderTransform.concat(transform);
 
 					renderer.setTransform(renderTransform, context);

--- a/src/openfl/display/_internal/CanvasTextField.hx
+++ b/src/openfl/display/_internal/CanvasTextField.hx
@@ -96,12 +96,19 @@ class CanvasTextField
 		var pixelRatio = renderer.__pixelRatio;
 		#end
 
-		if (graphics.__bitmapScaleX != pixelRatio || graphics.__bitmapScaleY != pixelRatio)
+		// Detect a pixelRatio mismatch via the actual size of the glyph canvas
+		// rather than via graphics.__bitmapScaleX. On Canvas, `__bitmapScaleX`
+		// is the layout-scale divisor used by CanvasShape (and equals 1 for
+		// non-scale9-grid drawables), so it can't be reused to encode the
+		// glyph-bitmap's rasterization density.
+		if (graphics.__canvas != null)
 		{
-			// the TextField might have rendered in a context that requires a
-			// different pixel ratio than normal, such as when drawing to
-			// BitmapData.
-			graphics.__softwareDirty = true;
+			var expectedCanvasW = Std.int(graphics.__width * pixelRatio);
+			var expectedCanvasH = Std.int(graphics.__height * pixelRatio);
+			if (graphics.__canvas.width != expectedCanvasW || graphics.__canvas.height != expectedCanvasH)
+			{
+				graphics.__softwareDirty = true;
+			}
 		}
 
 		graphics.__update(renderer.__worldTransform, pixelRatio);
@@ -417,9 +424,20 @@ class CanvasTextField
 					graphics.__bitmap.image.version++;
 				}
 
-				graphics.__bitmapScaleX = pixelRatio;
-				graphics.__bitmapScaleY = pixelRatio;
+				// Don't write __bitmapScaleX/Y here. The Canvas composite path
+				// (CanvasShape.render) applies `scale(1 / __bitmapScale)` to the
+				// shape's renderTransform, so __bitmapScale acts as a
+				// layout-scale divisor and must stay at 1 for plain
+				// (non-scale9-grid) drawables. The glyph canvas's pixelRatio
+				// rasterization density is already encoded in canvas.width /
+				// graphics.__width (see the mismatch detection above).
 				graphics.__visible = true;
+				// Mark the graphics as externally managed so CanvasGraphics.render()
+				// will not try to redraw the empty __commands list or stomp on
+				// __bitmapScale — matches the CairoTextField/CairoGraphics
+				// __managed contract (see CairoTextField.hx and CairoGraphics
+				// early-return at !__softwareDirty || __managed).
+				graphics.__managed = true;
 				textField.__dirty = false;
 				graphics.__softwareDirty = false;
 				graphics.__dirty = false;

--- a/tests/demo-canvas-filter-dpr/project.xml
+++ b/tests/demo-canvas-filter-dpr/project.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+	<app main="Main" path="bin"/>
+	<source path="src"/>
+	<haxelib name="openfl" path="../.."/>
+	<window width="480" height="360" background="#202028" allow-high-dpi="true" hardware="false"/>
+</project>

--- a/tests/demo-canvas-filter-dpr/src/Main.hx
+++ b/tests/demo-canvas-filter-dpr/src/Main.hx
@@ -1,0 +1,58 @@
+package;
+
+import openfl.display.Sprite;
+import openfl.events.Event;
+import openfl.filters.GlowFilter;
+import openfl.text.TextField;
+import openfl.text.TextFormat;
+
+class Main extends Sprite
+{
+	public function new()
+	{
+		super();
+		addEventListener(Event.ADDED_TO_STAGE, onAdded);
+	}
+
+	private function onAdded(_):Void
+	{
+		removeEventListener(Event.ADDED_TO_STAGE, onAdded);
+		buildRow(20, "plain", false, false);
+		buildRow(70, "cacheAsBitmap", true, false);
+		buildRow(120, "filter", false, true);
+		buildRow(170, "filter + cacheAsBitmap", true, true);
+
+		var ref = new Sprite();
+		ref.graphics.beginFill(0x55ffaa);
+		ref.graphics.drawRect(0, 0, 24, 24);
+		ref.graphics.endFill();
+		ref.x = 10;
+		ref.y = 240;
+		addChild(ref);
+
+		var label = mkText("24px reference square ↑");
+		label.x = 40;
+		label.y = 240;
+		addChild(label);
+	}
+
+	private function buildRow(y:Float, name:String, cab:Bool, withFilter:Bool):Void
+	{
+		var tf = mkText("TEST " + name);
+		tf.x = 10;
+		tf.y = y;
+		if (withFilter) tf.filters = [new GlowFilter(0xff5566, 1, 4, 4, 1)];
+		tf.cacheAsBitmap = cab;
+		addChild(tf);
+	}
+
+	private function mkText(s:String):TextField
+	{
+		var tf = new TextField();
+		tf.defaultTextFormat = new TextFormat("_sans", 24, 0xffffff);
+		tf.autoSize = LEFT;
+		tf.selectable = false;
+		tf.text = s;
+		return tf;
+	}
+}

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -6,6 +6,7 @@ class Tests
 	public static function main()
 	{
 		var runner = new Runner();
+		runner.addCase(new CairoTextBitmapScaleTest());
 		runner.addCase(new CapsStyleTest());
 		runner.addCase(new GradientTypeTest());
 		runner.addCase(new GraphicsBitmapFillTest());

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -7,6 +7,7 @@ class Tests
 	{
 		var runner = new Runner();
 		runner.addCase(new CairoTextBitmapScaleTest());
+		runner.addCase(new CanvasGraphicsBitmapScaleTest());
 		runner.addCase(new CapsStyleTest());
 		runner.addCase(new GradientTypeTest());
 		runner.addCase(new GraphicsBitmapFillTest());

--- a/tests/graphics/src/CairoTextBitmapScaleTest.hx
+++ b/tests/graphics/src/CairoTextBitmapScaleTest.hx
@@ -86,7 +86,7 @@ class CairoTextBitmapScaleTest extends Test
 {
 	public function test_skippedOnNonCairo()
 	{
-		Assert.isTrue(true);
+		Assert.pass();
 	}
 }
 #end

--- a/tests/graphics/src/CairoTextBitmapScaleTest.hx
+++ b/tests/graphics/src/CairoTextBitmapScaleTest.hx
@@ -80,9 +80,13 @@ class CairoTextBitmapScaleTest extends Test
 	}
 }
 #else
+import utest.Assert;
 import utest.Test;
 class CairoTextBitmapScaleTest extends Test
 {
-	public function test_skippedOnNonCairo() {}
+	public function test_skippedOnNonCairo()
+	{
+		Assert.isTrue(true);
+	}
 }
 #end

--- a/tests/graphics/src/CairoTextBitmapScaleTest.hx
+++ b/tests/graphics/src/CairoTextBitmapScaleTest.hx
@@ -1,0 +1,88 @@
+package;
+
+#if (!flash && lime_cairo)
+import lime.graphics.cairo.Cairo;
+import openfl.display.BitmapData;
+import openfl.display.CairoRenderer;
+import openfl.display.Sprite;
+import openfl.display._internal.CairoGraphics;
+import openfl.geom.Matrix;
+import utest.Assert;
+import utest.Test;
+
+/**
+	Regression test for the Retina text-doubling bug in CairoGraphics.render():
+	when a TextField (via CairoTextField) writes a non-1 bitmapScale (= pixelRatio,
+	e.g. 2 on Retina) and the graphics object then renders with `__softwareDirty=false`
+	(a cache hit), the early-return must NOT have reset `__bitmapScaleX/Y` to 1
+	beforehand — otherwise CairoShape composites the high-DPI text bitmap without
+	the corresponding 1/pixelRatio downscale and the text visually doubles.
+
+	The test uses an empty graphics (no draw commands → `__bounds == null`), so
+	`Graphics.__update` returns early without touching `__dirty` / `__softwareDirty`.
+	That isolates the bitmapScale-reset behaviour from the unrelated update path.
+**/
+class CairoTextBitmapScaleTest extends Test
+{
+	private function buildRenderer(pixelRatio:Float):CairoRenderer
+	{
+		var bmd = new BitmapData(10, 10, true, 0);
+		var cairo = new Cairo(bmd.getSurface());
+		var renderer = @:privateAccess new CairoRenderer(cairo);
+		@:privateAccess renderer.__pixelRatio = pixelRatio;
+		@:privateAccess renderer.__worldTransform = new Matrix();
+		return renderer;
+	}
+
+	public function test_cacheHitPreservesNonOneBitmapScale()
+	{
+		var sprite = new Sprite();
+		// Force-create the Graphics instance via the getter, but draw nothing
+		// so __bounds stays null and Graphics.__update early-returns without
+		// invalidating __softwareDirty.
+		sprite.graphics;
+
+		var g = @:privateAccess sprite.__graphics;
+
+		// Simulate CairoTextField setting a Retina pixelRatio on the cached bitmap.
+		@:privateAccess g.__bitmapScaleX = 2.0;
+		@:privateAccess g.__bitmapScaleY = 2.0;
+
+		// Simulate a cache hit: nothing in the graphics changed, so render() must
+		// early-return without touching bitmapScale.
+		@:privateAccess g.__softwareDirty = false;
+		@:privateAccess g.__managed = false;
+
+		@:privateAccess CairoGraphics.render(g, buildRenderer(2.0));
+
+		// With the fix: the early-return preserves the 2.0 we set.
+		// Without the fix: render() resets bitmapScaleX/Y to 1 before the early-return.
+		Assert.equals(2.0, @:privateAccess g.__bitmapScaleX);
+		Assert.equals(2.0, @:privateAccess g.__bitmapScaleY);
+	}
+
+	public function test_managedGraphicsAlsoPreservesBitmapScale()
+	{
+		// Same scenario, but __managed=true (the other half of the early-return condition).
+		var sprite = new Sprite();
+		sprite.graphics;
+		var g = @:privateAccess sprite.__graphics;
+
+		@:privateAccess g.__bitmapScaleX = 1.5;
+		@:privateAccess g.__bitmapScaleY = 1.5;
+		@:privateAccess g.__softwareDirty = true; // would normally proceed
+		@:privateAccess g.__managed = true; // but __managed forces early-return
+
+		@:privateAccess CairoGraphics.render(g, buildRenderer(1.5));
+
+		Assert.equals(1.5, @:privateAccess g.__bitmapScaleX);
+		Assert.equals(1.5, @:privateAccess g.__bitmapScaleY);
+	}
+}
+#else
+import utest.Test;
+class CairoTextBitmapScaleTest extends Test
+{
+	public function test_skippedOnNonCairo() {}
+}
+#end

--- a/tests/graphics/src/CanvasGraphicsBitmapScaleTest.hx
+++ b/tests/graphics/src/CanvasGraphicsBitmapScaleTest.hx
@@ -1,0 +1,186 @@
+package;
+
+#if (js && html5)
+import openfl.display.CanvasRenderer;
+import openfl.display.Sprite;
+import openfl.display._internal.CanvasGraphics;
+import openfl.display._internal.CanvasTextField;
+import openfl.filters.GlowFilter;
+import openfl.geom.ColorTransform;
+import openfl.geom.Matrix;
+import openfl.text.TextField;
+import openfl.text.TextFieldAutoSize;
+import openfl.text.TextFormat;
+import utest.Assert;
+import utest.Test;
+
+/**
+	Companion to CairoTextBitmapScaleTest, asserting the same structural
+	property for the Canvas renderer.
+
+	CanvasGraphics.render() resets `graphics.__bitmapScaleX/Y` to 1
+	(or `__owner.scaleX/Y` for scale9Grid) BEFORE the
+	`if (graphics.__softwareDirty)` work gate. On a cache hit
+	(__softwareDirty=false) the function still clobbers the bitmapScale
+	value that CanvasTextField wrote on the previous dirty render
+	(== pixelRatio).
+
+	The reset on cache hits is currently masked by a self-heal in
+	CanvasTextField (`if (__bitmapScale != pixelRatio) __softwareDirty = true`,
+	~CanvasTextField.hx:99-105), which forces a re-render every frame and
+	restores the value. So stock html5 looks visually correct but pays an
+	avoidable re-render cost; and a literal port of the Cairo fix (move the
+	reset past the dirty gate) without auditing the filter pipeline can
+	surface a separate half-size symptom on filtered TextFields (see
+	openfl/openfl#2867 discussion).
+
+	This test isolates the reset behaviour from the surrounding pipeline so
+	the structural bug can be asserted directly: empty Graphics (no draw
+	commands → __bounds == null → Graphics.__update early-returns without
+	touching __dirty / __softwareDirty), pre-seeded bitmapScale, then a
+	single CanvasGraphics.render() call.
+**/
+class CanvasGraphicsBitmapScaleTest extends Test
+{
+	private function buildRenderer(pixelRatio:Float):CanvasRenderer
+	{
+		var canvas:js.html.CanvasElement = cast js.Browser.document.createElement("canvas");
+		canvas.width = 10;
+		canvas.height = 10;
+		var context:js.html.CanvasRenderingContext2D = cast canvas.getContext("2d");
+		var renderer = @:privateAccess new CanvasRenderer(context);
+		@:privateAccess renderer.__pixelRatio = pixelRatio;
+		@:privateAccess renderer.__worldTransform = new Matrix();
+		return renderer;
+	}
+
+	public function test_cacheHitPreservesNonOneBitmapScale()
+	{
+		var sprite = new Sprite();
+		// Force-create the Graphics instance via the getter, but draw nothing
+		// so __bounds stays null and Graphics.__update early-returns without
+		// invalidating __softwareDirty.
+		sprite.graphics;
+
+		var g = @:privateAccess sprite.__graphics;
+
+		// Simulate CanvasTextField setting a Retina pixelRatio on the cached bitmap.
+		@:privateAccess g.__bitmapScaleX = 2.0;
+		@:privateAccess g.__bitmapScaleY = 2.0;
+
+		// Simulate a cache hit: nothing in the graphics changed, so render()
+		// must NOT clobber bitmapScale.
+		@:privateAccess g.__softwareDirty = false;
+
+		@:privateAccess CanvasGraphics.render(g, buildRenderer(2.0));
+
+		// Expected (after a structural fix mirroring PR #2867 for Canvas):
+		//   bitmapScale stays at the 2.0 written by CanvasTextField.
+		// Current stock behaviour:
+		//   render() resets to 1 unconditionally before the softwareDirty gate
+		//   and this assertion fails — documenting the same bug as Cairo.
+		Assert.equals(2.0, @:privateAccess g.__bitmapScaleX);
+		Assert.equals(2.0, @:privateAccess g.__bitmapScaleY);
+	}
+
+	/**
+		Visual regression test: a filtered TextField rendered at pixelRatio=2
+		must populate its `__cacheBitmap.__bitmapData` with glyphs at PIXEL
+		resolution (i.e. fontSize × pixelRatio device pixels tall), not at
+		LOGICAL resolution (fontSize device pixels tall, which is what a
+		literal port of openfl/openfl#2867's Cairo fix produces).
+
+		The mechanism: `CanvasShape.render()` composites via
+		`drawImage(canvas, 0, 0, graphics.__width, graphics.__height)`, where
+		the (W, H) args already account for the source canvas being at
+		`pixelRatio` resolution. The renderer's `__worldTransform` is
+		pre-scaled by `pixelRatio` for cache rendering (see
+		DisplayObjectRenderer.hx:590). For the composite to land at 1:1
+		source-pixel-to-cache-bitmap-pixel mapping, the `scale(1/bitmapScale)`
+		applied by CanvasShape must be identity — i.e. `__bitmapScale` must be
+		`1` at composite time. CanvasGraphics.render()'s pre-gate reset to 1
+		is what enforces that invariant; moving the reset past the
+		softwareDirty gate (the natural Cairo-style fix) leaves
+		`__bitmapScale = pixelRatio` from CanvasTextField, causing
+		`scale(1/2) * scale(pixelRatio) = scale(1)` instead of the required
+		`scale(1) * scale(pixelRatio) = scale(2)`, which halves glyph height
+		in the cache bitmap.
+	**/
+	public function test_filteredTextFieldCacheBitmapKeepsPixelResolutionAtDpr2()
+	{
+		var tf = new TextField();
+		tf.defaultTextFormat = new TextFormat("_sans", 24, 0xffffff);
+		tf.autoSize = TextFieldAutoSize.LEFT;
+		tf.text = "T";
+		tf.filters = [new GlowFilter(0xff5566, 1, 4, 4, 1)];
+
+		// Initialise world transforms so __updateCacheBitmap can run.
+		@:privateAccess tf.__update(false, true);
+
+		// CanvasRenderer at DPR=2 backed by an off-DOM canvas.
+		var canvas:js.html.CanvasElement = cast js.Browser.document.createElement("canvas");
+		canvas.width = 400;
+		canvas.height = 200;
+		var context:js.html.CanvasRenderingContext2D = cast canvas.getContext("2d");
+		var renderer = @:privateAccess new CanvasRenderer(context);
+		@:privateAccess renderer.__pixelRatio = 2.0;
+		@:privateAccess renderer.__worldTransform = new Matrix();
+		@:privateAccess renderer.__worldAlpha = 1.0;
+		@:privateAccess renderer.__worldColorTransform = new ColorTransform();
+
+		// Drive the cache bitmap pipeline (filter forces cacheAsBitmap).
+		@:privateAccess renderer.__updateCacheBitmap(tf, true);
+
+		var cacheBitmap = @:privateAccess tf.__cacheBitmap;
+		Assert.notNull(cacheBitmap, "cache bitmap should have been allocated");
+		if (cacheBitmap == null) return;
+
+		var bmd = cacheBitmap.bitmapData;
+		Assert.notNull(bmd, "cache bitmap data should have been populated");
+		if (bmd == null) return;
+
+		// Measure vertical bounding box of non-transparent pixels (the glyph
+		// plus its glow halo).
+		var minY = bmd.height;
+		var maxY = -1;
+		for (y in 0...bmd.height)
+		{
+			var rowHasPixel = false;
+			var x = 0;
+			while (x < bmd.width)
+			{
+				if ((bmd.getPixel32(x, y) >>> 24) != 0)
+				{
+					rowHasPixel = true;
+					break;
+				}
+				x++;
+			}
+			if (rowHasPixel)
+			{
+				if (y < minY) minY = y;
+				if (y > maxY) maxY = y;
+			}
+		}
+		var glyphHeight = maxY < 0 ? 0 : (maxY - minY + 1);
+
+		// At fontSize=24, pixelRatio=2: glyph height in the cache bitmap
+		// should be approximately 48 device pixels (logical 24px × DPR 2),
+		// plus glow halo (~4-8px on each side). Stock CanvasGraphics: ~50-60px.
+		// Literal-Cairo-port half-size regression: ~24-32px.
+		Assert.isTrue(glyphHeight > 36,
+			"cache bitmap glyph too small at DPR=2 — half-size regression? height=" + glyphHeight + "px");
+	}
+}
+#else
+import utest.Assert;
+import utest.Test;
+
+class CanvasGraphicsBitmapScaleTest extends Test
+{
+	public function test_skippedOnNonHtml5()
+	{
+		Assert.pass();
+	}
+}
+#end


### PR DESCRIPTION
## Summary

Companion to #2867 for the **Canvas (2D) renderer**. Same root pattern as the Cairo bug: stock `CanvasGraphics.render()` unconditionally resets `graphics.__bitmapScaleX/Y` to `1` before the `__softwareDirty` gate, so every cache-hit frame clobbers whatever `CanvasTextField` wrote on the previous dirty render. On Canvas this is *masked* by the `CanvasTextField` self-heal (`if (__bitmapScale != pixelRatio) __softwareDirty = true`, lines 99-105), which forces a full glyph re-render every frame — a hidden per-frame redraw, but visually correct.

Per the discussion in #2867: a literal port of the Cairo reorder (move the reset past the `softwareDirty` gate) regresses filtered TextFields at HiDPI to **half-size**. Canvas's composite path (`drawImage(canvas, 0, 0, W, H)`) already encodes source-pixel-density compression in its destination size args — unlike Cairo's `cairo.paint()` which is 1:1 source-to-dest through the current matrix. On Canvas, `__bitmapScale` must be `1` at composite time for non-scale9-grid paths; the stock reset was load-bearing.

This PR aligns Canvas with the Cairo `__managed` convention rather than reusing the reorder pattern verbatim.

## Changes

- **`CanvasGraphics.render()`** — gate the `__bitmapScale` reset (and the empty-graphics `__canvas`/`__bitmap` nuke that's reachable through it) on `softwareDirty && !managed`. Externally-managed graphics (i.e. those owned by `CanvasTextField`) are skipped entirely.

- **`CanvasShape.render()`** — skip the `scale(1 / __bitmapScale)` factor for `__managed` graphics. The source canvas is at `pixelRatio` resolution and the cache-renderer's pre-scaled `__worldTransform` already produces 1:1 source-to-dest mapping via `drawImage`'s `(width, height)` dest-size arguments; applying an additional `1/pixelRatio` would halve the rendered size.

- **`CanvasTextField.render()`** — stop writing `__bitmapScale = pixelRatio` (which only worked because the stock reset immediately undid it). Mark `__managed = true` after rendering glyphs (mirrors `CairoTextField`). Detect pixelRatio mismatch via the actual `graphics.__canvas.width != Std.int(graphics.__width * pixelRatio)` rather than via `__bitmapScale`, which on Canvas means "layout-scale divisor for scale9Grid" and must stay at `1` for plain drawables.

## Tests

New `tests/graphics/src/CanvasGraphicsBitmapScaleTest.hx` (registered in `Tests.hx`) with two cases:

- **`test_cacheHitPreservesNonOneBitmapScale`** — structural: set `bitmapScale = 2.0`, mark `__softwareDirty = false`, call `CanvasGraphics.render()`, assert preserved at `2.0`. Fails on stock (clobbered to `1`); passes after this PR.

- **`test_filteredTextFieldCacheBitmapKeepsPixelResolutionAtDpr2`** — visual integration: render a filtered TextField via the cache-bitmap path at `pixelRatio = 2` and measure the non-transparent bounding-box height in `__cacheBitmap.bitmapData`. Asserts height is at pixel resolution (>36px for `fontSize = 24`), not at logical resolution (~24px which is the half-size symptom from a literal Cairo-style port). Catches both the original bug and the would-be regression.

Existing `test_scale9Grid` in `tests/displayobject/` passes unchanged — scale9Grid graphics have `__managed = false`, so both the `CanvasGraphics` reset and the `CanvasShape` `scale(1/bitmapScale)` continue to apply for that path.

Adds `tests/demo-canvas-filter-dpr/` as a standalone html5 visual repro project (four TextField variants at DPR=2: plain, cacheAsBitmap, filter, filter+cacheAsBitmap, with a 24px reference square). With `<window hardware="false"/>` (Canvas renderer), all four rows render at identical size after this PR.

## Scope

This PR is **Canvas (2D) renderer only**. The OpenGL renderer has a separate filter pipeline that is not touched (and that #2867 also does not touch).

## Dependency on #2867

This branch is currently based on `bugfix/cairo-text-retina-2x-size` (#2867), so this PR's diff includes the three commits from that PR. Happy to rebase onto `develop` once #2867 is merged.

## Test plan

- [x] `haxelib run openfl test html5` in `tests/graphics` — all tests pass (66/66) with the refactor applied; the structural test fails on stock, confirming bug presence.
- [x] `tests/demo-canvas-filter-dpr/` (Canvas renderer, DPR=2) visually identical to stock: all 4 rows render at the same size.
- [x] `tests/displayobject/test_scale9Grid` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)