### PR TITLE
Fix OpenFL window fps being ignored with Lime frame timing

### DIFF
--- a/src/openfl/display/Application.hx
+++ b/src/openfl/display/Application.hx
@@ -60,6 +60,8 @@ class Application #if lime extends LimeApplication #end
 	public override function createWindow(attributes:WindowAttributes):Window
 	{
 		var window = new Window(this, attributes);
+		if (window.id == -1) return null;
+		__seedFrameConfiguration(attributes);
 
 		#if (!flash && !macro)
 		if (Lib.current.__loaderInfo.width == -1)

--- a/src/openfl/display/Application.hx
+++ b/src/openfl/display/Application.hx
@@ -60,8 +60,10 @@ class Application #if lime extends LimeApplication #end
 	public override function createWindow(attributes:WindowAttributes):Window
 	{
 		var window = new Window(this, attributes);
+		#if (lime >= "8.4.0")
 		if (window.id == -1) return null;
 		__seedFrameConfiguration(attributes);
+		#end
 
 		#if (!flash && !macro)
 		if (Lib.current.__loaderInfo.width == -1)


### PR DESCRIPTION
## Summary

OpenFL overrides Lime's `createWindow()` path and constructs `openfl.display.Window` directly, so it bypassed Lime's new `__seedFrameConfiguration(attributes)` call (https://github.com/openfl/lime/commit/a5d2a49dc1ff8279be31689e2fc94ddfe09acc17). As a result, the main loop stayed at Lime's default 60 FPS even when `project.xml` specified another window FPS.

## Changes

- Return early when the created window is invalid, matching Lime's default `__createWindow()` behavior.
- Seed application frame timing from the generated window attributes in OpenFL's `createWindow()` override.

## Repro

Any OpenFL project with a custom `fps` flag value will work.