### PR TITLE
Fix TextField selection stuck when target stops mouseUp propagation

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -3381,7 +3381,7 @@ class TextField extends InteractiveObject
 
 		stage.removeEventListener(Event.ENTER_FRAME, this_onEnterFrame);
 		stage.removeEventListener(MouseEvent.MOUSE_MOVE, stage_onMouseMove);
-		stage.removeEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp);
+		stage.removeEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp, true);
 
 		if (this.stage != stage) return;
 
@@ -3528,7 +3528,9 @@ class TextField extends InteractiveObject
 		stage.addEventListener(Event.ENTER_FRAME, this_onEnterFrame);
 		#end
 		stage.addEventListener(MouseEvent.MOUSE_MOVE, stage_onMouseMove);
-		stage.addEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp);
+		// Capture phase: target listeners may call stopImmediatePropagation() on mouseUp
+		// (common in UI wrappers); Flash Player still ended selection in that case.
+		stage.addEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp, true);
 	}
 
 	@:noCompletion private function this_onMouseWheel(event:MouseEvent):Void

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -3528,8 +3528,10 @@ class TextField extends InteractiveObject
 		stage.addEventListener(Event.ENTER_FRAME, this_onEnterFrame);
 		#end
 		stage.addEventListener(MouseEvent.MOUSE_MOVE, stage_onMouseMove);
-		// Capture phase: target listeners may call stopImmediatePropagation() on mouseUp
-		// (common in UI wrappers); Flash Player still ended selection in that case.
+		// use capture phase so that other mouseUp listeners may call
+		// stopImmediatePropagation() without affecting this listener.
+		// prevents an issue where the selection continues to follow mouseMove
+		// events after mouseUp.
 		stage.addEventListener(MouseEvent.MOUSE_UP, stage_onMouseUp, true);
 	}
 


### PR DESCRIPTION
## Summary

Fixes a Flash/AIR parity issue where `TextField` text selection could remain in a "mouse drag" state after the button was released.

When application code adds a target-phase `mouseUp` listener on a `TextField` and calls `stopImmediatePropagation()` (a pattern used in Flash UIs to isolate clicks from gameplay), OpenFL's `stage_onMouseUp` handler never ran because it was registered on the stage in the **bubble** phase. The stage `MOUSE_MOVE` listener was never removed, so moving the pointer continued to extend the selection without `buttonDown`.

AIR did not show this behavior with the same listener setup.

## Fix

Register and remove `stage_onMouseUp` with `useCapture = true` so selection teardown runs during the capture phase, before target listeners can stop propagation.

## Repro

[OpenFLTextFieldMouseUpCaptureRepro.zip](https://github.com/user-attachments/files/28170360/OpenFLTextFieldMouseUpCaptureRepro.zip)
