### PR TITLE
Fix GlowFilter alpha handling across blur passes

### DIFF
--- a/src/openfl/filters/DropShadowFilter.hx
+++ b/src/openfl/filters/DropShadowFilter.hx
@@ -340,8 +340,9 @@ import lime._internal.graphics.ImageDataUtil; // TODO
 			shader.uColor.value[0] = ((color >> 16) & 0xFF) / 255;
 			shader.uColor.value[1] = ((color >> 8) & 0xFF) / 255;
 			shader.uColor.value[2] = (color & 0xFF) / 255;
-			shader.uColor.value[3] = alpha;
-			shader.uStrength.value[0] = blurPass == (numBlurPasses - 1) ? __strength : 1.0;
+			var finalBlurPass = blurPass == (numBlurPasses - 1);
+			shader.uColor.value[3] = finalBlurPass ? alpha : 1.0;
+			shader.uStrength.value[0] = finalBlurPass ? __strength : 1.0;
 			return shader;
 		}
 		if (__inner)

--- a/src/openfl/filters/GlowFilter.hx
+++ b/src/openfl/filters/GlowFilter.hx
@@ -302,8 +302,9 @@ import lime._internal.graphics.ImageDataUtil; // TODO
 			shader.uColor.value[0] = ((color >> 16) & 0xFF) / 255;
 			shader.uColor.value[1] = ((color >> 8) & 0xFF) / 255;
 			shader.uColor.value[2] = (color & 0xFF) / 255;
-			shader.uColor.value[3] = alpha;
-			shader.uStrength.value[0] = blurPass == (numBlurPasses - 1) ? __strength : 1.0;
+			var finalBlurPass = blurPass == (numBlurPasses - 1);
+			shader.uColor.value[3] = finalBlurPass ? alpha : 1.0;
+			shader.uStrength.value[0] = finalBlurPass ? __strength : 1.0;
 			return shader;
 		}
 		if (__inner)


### PR DESCRIPTION
## Summary

Fixes OpenFL's shader-based `GlowFilter`/`DropShadowFilter` rendering when `alpha` is below `1`.

Previously, the filter alpha was applied during every blur pass. For multi-pass glows, this compounded the alpha value (`alpha^passes`), making semi-transparent glows much fainter than intended.
The fix applies `alpha` only on the final blur pass, matching how `strength` is already applied.

## Changes

- Apply `GlowFilter.alpha` only on the final blur pass
- Apply the same fix to `DropShadowFilter`, which reuses the glow blur shader path

## Repro

[OpenFLGlowFilterProjectileRepro.zip](https://github.com/user-attachments/files/28422435/OpenFLGlowFilterProjectileRepro.zip)


Note: I also tested an alternative that applied alpha once per blur axis instead of only on the final blur pass. It made this specific repro visually closer to Flash, but it regressed some real-game cases. This PR intentionally keeps the narrower fix: avoid compounding alpha on every internal shader pass. More exact Flash parity for GlowFilter rendering should be handled separately with broader visual test coverage.
