### PR TITLE
Add tags to haxelib

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -2,7 +2,7 @@
 	"name": "openfl",
 	"url": "http://www.openfl.org",
 	"license": "MIT",
-	"tags": [],
+	"tags": ["openfl", "lime", "flash"],
 	"description": "The \"Open Flash Library\" for fast 2D development",
 	"version": "9.5.2",
 	"releasenote": "Various bug fixes",


### PR DESCRIPTION
OpenFL doesn't show up when you search "openfl" in lib.haxe.org: https://lib.haxe.org/t/openfl/