### PR TITLE
Context3D: remove redundant anisotropy extension checks on html5

### DIFF
--- a/src/openfl/display3D/Context3D.hx
+++ b/src/openfl/display3D/Context3D.hx
@@ -324,10 +324,8 @@ import lime.math.Vector2;
 			var extension:Dynamic = gl.getExtension("EXT_texture_filter_anisotropic");
 
 			#if (js && html5)
-			if (extension == null
-				|| !Reflect.hasField(extension, "MAX_TEXTURE_MAX_ANISOTROPY_EXT")) extension = gl.getExtension("MOZ_EXT_texture_filter_anisotropic");
-			if (extension == null
-				|| !Reflect.hasField(extension, "MAX_TEXTURE_MAX_ANISOTROPY_EXT")) extension = gl.getExtension("WEBKIT_EXT_texture_filter_anisotropic");
+			if (extension == null) extension = gl.getExtension("MOZ_EXT_texture_filter_anisotropic");
+			if (extension == null) extension = gl.getExtension("WEBKIT_EXT_texture_filter_anisotropic");
 			#end
 
 			if (extension != null)


### PR DESCRIPTION
The checks did not work as expected and caused the extension to remain null. `Reflect.hasField(extension, "MAX_TEXTURE_MAX_ANISOTROPY_EXT")` always returns false because it on html5 is transpiled to `Object.prototype.hasOwnProperty.call(extension, "MAX_TEXTURE_MAX_ANISOTROPY_EXT")` but the extension object exposes constants via the prototype instead of own properties.