### PR TITLE
Context3DGraphics: batch drawRect fills with exact even-odd geometry

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -66,11 +66,18 @@ import js.html.CanvasRenderingContext2D;
 	@:noCompletion private var __commands:DrawCommandBuffer;
 	@:noCompletion private var __dirty(default, set):Bool = true;
 	@:noCompletion private var __hardwareDirty:Bool;
+	@:noCompletion private var __hardwareCompatible:Bool = false;
+	@:noCompletion private var __hardwareCompatibilityKnown:Bool = false;
 	@:noCompletion private var __height:Int;
 	@:noCompletion private var __managed:Bool;
 	@:noCompletion private var __positionX:Float;
 	@:noCompletion private var __positionY:Float;
 	@:noCompletion private var __quadBuffer:Context3DBuffer;
+	@:noCompletion private var __rectangleBatchEnds:Vector<Int>;
+	@:noCompletion private var __rectangleBatchFills:Vector<Int>;
+	@:noCompletion private var __rectangleBatchRects:Array<Vector<Float>>;
+	@:noCompletion private var __rectangleBatchStarts:Vector<Int>;
+	@:noCompletion private var __solidRectangleBatchesOnly:Bool;
 	@:noCompletion private var __renderTransform:Matrix;
 	@:noCompletion private var __shaderBufferPool:ObjectPool<ShaderBuffer>;
 	@:noCompletion private var __softwareDirty:Bool;
@@ -2090,6 +2097,8 @@ import js.html.CanvasRenderingContext2D;
 		{
 			__softwareDirty = true;
 			__hardwareDirty = true;
+			__hardwareCompatible = false;
+			__hardwareCompatibilityKnown = false;
 		}
 
 		return __dirty = value;

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -73,6 +73,7 @@ import js.html.CanvasRenderingContext2D;
 	@:noCompletion private var __positionX:Float;
 	@:noCompletion private var __positionY:Float;
 	@:noCompletion private var __quadBuffer:Context3DBuffer;
+	@:noCompletion private var __rectangleBatchesRequired:Bool;
 	@:noCompletion private var __rectangleBatchEnds:Vector<Int>;
 	@:noCompletion private var __rectangleBatchFills:Vector<Int>;
 	@:noCompletion private var __rectangleBatchRects:Array<Vector<Float>>;

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -68,17 +68,13 @@ import js.html.CanvasRenderingContext2D;
 	@:noCompletion private var __hardwareDirty:Bool;
 	@:noCompletion private var __hardwareCompatible:Bool = false;
 	@:noCompletion private var __hardwareCompatibilityKnown:Bool = false;
+	@:noCompletion private var __hardwareCommands:DrawCommandBuffer;
 	@:noCompletion private var __height:Int;
 	@:noCompletion private var __managed:Bool;
 	@:noCompletion private var __positionX:Float;
 	@:noCompletion private var __positionY:Float;
 	@:noCompletion private var __quadBuffer:Context3DBuffer;
 	@:noCompletion private var __rectangleBatchesRequired:Bool;
-	@:noCompletion private var __rectangleBatchEnds:Vector<Int>;
-	@:noCompletion private var __rectangleBatchFills:Vector<Int>;
-	@:noCompletion private var __rectangleBatchRects:Array<Vector<Float>>;
-	@:noCompletion private var __rectangleBatchStarts:Vector<Int>;
-	@:noCompletion private var __solidRectangleBatchesOnly:Bool;
 	@:noCompletion private var __renderTransform:Matrix;
 	@:noCompletion private var __shaderBufferPool:ObjectPool<ShaderBuffer>;
 	@:noCompletion private var __softwareDirty:Bool;
@@ -2100,6 +2096,7 @@ import js.html.CanvasRenderingContext2D;
 			__hardwareDirty = true;
 			__hardwareCompatible = false;
 			__hardwareCompatibilityKnown = false;
+			__hardwareCommands = null;
 		}
 
 		return __dirty = value;

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -129,16 +129,15 @@ class Context3DGraphics
 
 		var finished = new Array<Array<Float>>();
 		var active = new Map<String, Array<Float>>();
-		var toggles = new Array<Bool>();
 
 		for (yIndex in 0...yCoordinates.length - 1)
 		{
 			var top = yCoordinates[yIndex];
 			var bottom = yCoordinates[yIndex + 1];
-			toggles.resize(xCoordinates.length);
-			for (xIndex in 0...toggles.length)
+			var toggles = new Array<Bool>();
+			for (xIndex in 0...xCoordinates.length)
 			{
-				toggles[xIndex] = false;
+				toggles.push(false);
 			}
 
 			i = 0;
@@ -185,19 +184,19 @@ class Context3DGraphics
 				}
 			}
 
-			for (key => rectangle in active)
+			for (key in active.keys())
 			{
 				if (!row.exists(key))
 				{
-					finished.push(rectangle);
+					finished.push(active.get(key));
 				}
 			}
 			active = row;
 		}
 
-		for (rectangle in active)
+		for (key in active.keys())
 		{
-			finished.push(rectangle);
+			finished.push(active.get(key));
 		}
 
 		finished.sort(function(a:Array<Float>, b:Array<Float>):Int

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -310,7 +310,18 @@ class Context3DGraphics
 
 	private static function buildBuffer(graphics:Graphics, renderer:OpenGLRenderer):Void
 	{
-		prepareRectangleBatches(graphics);
+		if (graphics.__rectangleBatchesRequired)
+		{
+			prepareRectangleBatches(graphics);
+		}
+		else if (graphics.__rectangleBatchRects != null)
+		{
+			graphics.__rectangleBatchStarts = null;
+			graphics.__rectangleBatchEnds = null;
+			graphics.__rectangleBatchFills = null;
+			graphics.__rectangleBatchRects = null;
+			graphics.__solidRectangleBatchesOnly = false;
+		}
 		var quadBufferPosition = 0;
 		var triangleIndexBufferPosition = 0;
 		var vertexBufferPosition = 0;
@@ -894,6 +905,11 @@ class Context3DGraphics
 			return graphics.__hardwareCompatible;
 		}
 
+		// Most hardware-compatible Graphics do not contain a multi-rectangle
+		// fill. Keep their buffer build on the original path without allocating
+		// rectangle batch metadata or walking the commands a second time.
+		graphics.__rectangleBatchesRequired = false;
+
 		inline function cacheCompatibility(result:Bool):Bool
 		{
 			graphics.__hardwareCompatible = result;
@@ -924,6 +940,10 @@ class Context3DGraphics
 				return false;
 			}
 			filledRectCommandCount++;
+			if (filledRectCommandCount > 1)
+			{
+				graphics.__rectangleBatchesRequired = true;
+			}
 
 			var right = x + width;
 			var bottom = y + height;

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -219,34 +219,25 @@ class Context3DGraphics
 		return result;
 	}
 
-	private static function prepareRectangleBatches(graphics:Graphics):Void
+	private static function buildHardwareCommands(graphics:Graphics):DrawCommandBuffer
 	{
-		graphics.__rectangleBatchStarts = new Vector<Int>();
-		graphics.__rectangleBatchEnds = new Vector<Int>();
-		graphics.__rectangleBatchFills = new Vector<Int>();
-		graphics.__rectangleBatchRects = [];
-		graphics.__solidRectangleBatchesOnly = true;
+		var batchStarts = new Vector<Int>();
+		var batchEnds = new Vector<Int>();
+		var batchRects = new Array<Vector<Float>>();
 
 		var data = new DrawCommandReader(graphics.__commands);
 		var source = new Vector<Float>();
 		var sourceCount = 0;
 		var firstCommand = -1;
 		var commandIndex = 0;
-		var hasSolidFill = false;
-		var solidFill = 0;
 
 		function finalize(endCommand:Int):Void
 		{
 			if (sourceCount > 1)
 			{
-				graphics.__rectangleBatchStarts.push(firstCommand);
-				graphics.__rectangleBatchEnds.push(endCommand);
-				graphics.__rectangleBatchFills.push(solidFill);
-				graphics.__rectangleBatchRects.push(buildEvenOddRectangles(source));
-			}
-			else if (sourceCount == 1)
-			{
-				graphics.__solidRectangleBatchesOnly = false;
+				batchStarts.push(firstCommand);
+				batchEnds.push(endCommand);
+				batchRects.push(buildEvenOddRectangles(source));
 			}
 
 			source = new Vector<Float>();
@@ -258,26 +249,12 @@ class Context3DGraphics
 		{
 			switch (type)
 			{
-				case BEGIN_FILL:
+				case BEGIN_FILL, BEGIN_BITMAP_FILL, BEGIN_GRADIENT_FILL, BEGIN_SHADER_FILL:
 					finalize(commandIndex);
-					var fill = data.readBeginFill();
-					var color = Std.int(fill.color);
-					var alpha = Std.int(fill.alpha * 0xFF);
-					solidFill = (color & 0xFFFFFF) | (alpha << 24);
-					hasSolidFill = true;
-
-				case BEGIN_BITMAP_FILL, BEGIN_GRADIENT_FILL, BEGIN_SHADER_FILL:
-					finalize(commandIndex);
-					hasSolidFill = false;
-					graphics.__solidRectangleBatchesOnly = false;
 					data.skip(type);
 
 				case DRAW_RECT:
 					var rectangle = data.readDrawRect();
-					if (!hasSolidFill)
-					{
-						graphics.__solidRectangleBatchesOnly = false;
-					}
 					if (firstCommand == -1)
 					{
 						firstCommand = commandIndex;
@@ -290,45 +267,108 @@ class Context3DGraphics
 
 				case END_FILL:
 					finalize(commandIndex);
-					hasSolidFill = false;
+					data.skip(type);
+
+				case OVERRIDE_BLEND_MODE:
+					// A batch must not move rectangles across a blend-state change.
+					finalize(commandIndex);
 					data.skip(type);
 
 				default:
-					graphics.__solidRectangleBatchesOnly = false;
 					data.skip(type);
 			}
 			commandIndex++;
 		}
 
 		finalize(commandIndex);
-		if (graphics.__rectangleBatchRects.length == 0)
+		data.destroy();
+
+		var result = new DrawCommandBuffer();
+		data = new DrawCommandReader(graphics.__commands);
+		commandIndex = 0;
+		var batchIndex = 0;
+
+		for (type in graphics.__commands.types)
 		{
-			graphics.__solidRectangleBatchesOnly = false;
+			while (batchIndex < batchEnds.length && commandIndex >= batchEnds[batchIndex])
+			{
+				batchIndex++;
+			}
+
+			switch (type)
+			{
+				case BEGIN_BITMAP_FILL:
+					var c = data.readBeginBitmapFill();
+					result.beginBitmapFill(c.bitmap, c.matrix, c.repeat, c.smooth);
+
+				case BEGIN_FILL:
+					var c = data.readBeginFill();
+					result.beginFill(Std.int(c.color), c.alpha);
+
+				case BEGIN_SHADER_FILL:
+					var c = data.readBeginShaderFill();
+					result.beginShaderFill(c.shaderBuffer);
+
+				case DRAW_QUADS:
+					var c = data.readDrawQuads();
+					result.drawQuads(c.rects, c.indices, c.transforms);
+
+				case DRAW_RECT:
+					var c = data.readDrawRect();
+					var isBatched = batchIndex < batchStarts.length
+						&& commandIndex >= batchStarts[batchIndex]
+						&& commandIndex < batchEnds[batchIndex];
+					if (isBatched)
+					{
+						if (commandIndex == batchStarts[batchIndex])
+						{
+							result.drawQuads(batchRects[batchIndex], null, null);
+						}
+					}
+					else
+					{
+						result.drawRect(c.x, c.y, c.width, c.height);
+					}
+
+				case DRAW_TRIANGLES:
+					var c = data.readDrawTriangles();
+					result.drawTriangles(c.vertices, c.indices, c.uvtData, c.culling);
+
+				case END_FILL:
+					data.readEndFill();
+					result.endFill();
+
+				case LINE_STYLE:
+					var c = data.readLineStyle();
+					result.lineStyle(c.thickness, c.color, c.alpha, c.pixelHinting, c.scaleMode, c.caps, c.joints, c.miterLimit);
+
+				case MOVE_TO:
+					var c = data.readMoveTo();
+					result.moveTo(c.x, c.y);
+
+				case OVERRIDE_BLEND_MODE:
+					var c = data.readOverrideBlendMode();
+					result.overrideBlendMode(c.blendMode);
+
+				default:
+					data.skip(type);
+			}
+			commandIndex++;
 		}
 		data.destroy();
+		return result;
 	}
 
 	private static function buildBuffer(graphics:Graphics, renderer:OpenGLRenderer):Void
 	{
-		if (graphics.__rectangleBatchesRequired)
-		{
-			prepareRectangleBatches(graphics);
-		}
-		else if (graphics.__rectangleBatchRects != null)
-		{
-			graphics.__rectangleBatchStarts = null;
-			graphics.__rectangleBatchEnds = null;
-			graphics.__rectangleBatchFills = null;
-			graphics.__rectangleBatchRects = null;
-			graphics.__solidRectangleBatchesOnly = false;
-		}
 		var quadBufferPosition = 0;
 		var triangleIndexBufferPosition = 0;
 		var vertexBufferPosition = 0;
 		var vertexBufferPositionUVT = 0;
 		var bounds = graphics.__bounds;
 
-		var data = new DrawCommandReader(graphics.__commands);
+		var commands = graphics.__hardwareCommands != null ? graphics.__hardwareCommands : graphics.__commands;
+		var data = new DrawCommandReader(commands);
 
 		var context = renderer.__context3D;
 
@@ -448,93 +488,8 @@ class Context3DGraphics
 			}
 		}
 
-		function buildRectangleBatchBuffer(rectangles:Vector<Float>):Void
+		for (type in commands.types)
 		{
-			var length = rectangles.length >> 2;
-			if (length == 0)
-			{
-				return;
-			}
-
-			var dataPerVertex = 4;
-			var stride = dataPerVertex * 4;
-			if (graphics.__quadBuffer == null)
-			{
-				graphics.__quadBuffer = new Context3DBuffer(context, QUADS, quadBufferPosition + length, dataPerVertex);
-			}
-			else
-			{
-				graphics.__quadBuffer.resize(quadBufferPosition + length, dataPerVertex);
-			}
-
-			var bitmapWidth = 1;
-			var bitmapHeight = 1;
-			if (bitmap != null)
-			{
-				#if openfl_power_of_two
-				while (bitmapWidth < bitmap.width)
-				{
-					bitmapWidth <<= 1;
-				}
-				while (bitmapHeight < bitmap.height)
-				{
-					bitmapHeight <<= 1;
-				}
-				#else
-				bitmapWidth = bitmap.width;
-				bitmapHeight = bitmap.height;
-				#end
-			}
-
-			var vertexBufferData = graphics.__quadBuffer.vertexBufferData;
-			var rectangleOffset = 0;
-			for (i in 0...length)
-			{
-				var vertexOffset = (quadBufferPosition + i) * stride;
-				var left = rectangles[rectangleOffset];
-				var top = rectangles[rectangleOffset + 1];
-				var right = left + rectangles[rectangleOffset + 2];
-				var bottom = top + rectangles[rectangleOffset + 3];
-				var uvLeft = left / bitmapWidth;
-				var uvTop = top / bitmapHeight;
-				var uvRight = right / bitmapWidth;
-				var uvBottom = bottom / bitmapHeight;
-
-				vertexBufferData[vertexOffset] = left;
-				vertexBufferData[vertexOffset + 1] = top;
-				vertexBufferData[vertexOffset + 2] = uvLeft;
-				vertexBufferData[vertexOffset + 3] = uvTop;
-				vertexBufferData[vertexOffset + dataPerVertex] = right;
-				vertexBufferData[vertexOffset + dataPerVertex + 1] = top;
-				vertexBufferData[vertexOffset + dataPerVertex + 2] = uvRight;
-				vertexBufferData[vertexOffset + dataPerVertex + 3] = uvTop;
-				vertexBufferData[vertexOffset + dataPerVertex * 2] = left;
-				vertexBufferData[vertexOffset + dataPerVertex * 2 + 1] = bottom;
-				vertexBufferData[vertexOffset + dataPerVertex * 2 + 2] = uvLeft;
-				vertexBufferData[vertexOffset + dataPerVertex * 2 + 3] = uvBottom;
-				vertexBufferData[vertexOffset + dataPerVertex * 3] = right;
-				vertexBufferData[vertexOffset + dataPerVertex * 3 + 1] = bottom;
-				vertexBufferData[vertexOffset + dataPerVertex * 3 + 2] = uvRight;
-				vertexBufferData[vertexOffset + dataPerVertex * 3 + 3] = uvBottom;
-
-				rectangleOffset += 4;
-			}
-
-			quadBufferPosition += length;
-		}
-
-		var commandIndex = 0;
-		var rectangleBatchIndex = 0;
-		var hasRectangleBatches = graphics.__rectangleBatchEnds != null;
-		for (type in graphics.__commands.types)
-		{
-			while (hasRectangleBatches
-				&& rectangleBatchIndex < graphics.__rectangleBatchEnds.length
-				&& commandIndex >= graphics.__rectangleBatchEnds[rectangleBatchIndex])
-			{
-				rectangleBatchIndex++;
-			}
-
 			switch (type)
 			{
 				case BEGIN_BITMAP_FILL:
@@ -791,19 +746,7 @@ class Context3DGraphics
 
 				case DRAW_RECT:
 					var c = data.readDrawRect();
-					var isBatched = hasRectangleBatches
-						&& rectangleBatchIndex < graphics.__rectangleBatchStarts.length
-						&& commandIndex >= graphics.__rectangleBatchStarts[rectangleBatchIndex]
-						&& commandIndex < graphics.__rectangleBatchEnds[rectangleBatchIndex];
-
-					if (isBatched)
-					{
-						if (commandIndex == graphics.__rectangleBatchStarts[rectangleBatchIndex])
-						{
-							buildRectangleBatchBuffer(graphics.__rectangleBatchRects[rectangleBatchIndex]);
-						}
-					}
-					else if (bitmap != null)
+					if (bitmap != null)
 					{
 						tempVerticesVector.length = 8;
 						tempVerticesVector[0] = c.x;
@@ -832,7 +775,6 @@ class Context3DGraphics
 				default:
 					data.skip(type);
 			}
-			commandIndex++;
 		}
 
 		// TODO: Should we use static data specific to Context3DGraphics instead of each Graphics instance?
@@ -917,6 +859,10 @@ class Context3DGraphics
 		{
 			graphics.__hardwareCompatible = result;
 			graphics.__hardwareCompatibilityKnown = true;
+			if (!result)
+			{
+				graphics.__hardwareCommands = null;
+			}
 			return result;
 		}
 
@@ -925,61 +871,8 @@ class Context3DGraphics
 		// Multiple axis-aligned rectangles are converted to a single batched mesh
 		// that preserves the even-odd fill rule. Combinations with other filled
 		// primitives remain conservative and fall back to software.
-		var filledRectCount = 0;
-		var filledRectCommandCount = 0;
-		var hasUntrackedFilledShape = false;
-
-		inline function resetFilledShapeCompatibility():Void
-		{
-			filledRectCount = 0;
-			filledRectCommandCount = 0;
-			hasUntrackedFilledShape = false;
-		}
-
-		function addFilledRectCompatibility(x:Float, y:Float, width:Float, height:Float):Bool
-		{
-			if (hasUntrackedFilledShape || (hasShaderFill && filledRectCommandCount > 0))
-			{
-				return false;
-			}
-			filledRectCommandCount++;
-			if (filledRectCommandCount > 1)
-			{
-				graphics.__rectangleBatchesRequired = true;
-			}
-
-			var right = x + width;
-			var bottom = y + height;
-			var left = Math.min(x, right);
-			var top = Math.min(y, bottom);
-			right = Math.max(x, right);
-			bottom = Math.max(y, bottom);
-
-			if (!Math.isFinite(left) || !Math.isFinite(top) || !Math.isFinite(right) || !Math.isFinite(bottom))
-			{
-				return false;
-			}
-
-			// Empty rectangles have no filled interior and cannot create a cutout.
-			if (right <= left || bottom <= top)
-			{
-				return true;
-			}
-
-			filledRectCount++;
-			return true;
-		}
-
-		inline function addUntrackedFilledShapeCompatibility():Bool
-		{
-			if (hasUntrackedFilledShape || filledRectCount > 0)
-			{
-				return false;
-			}
-
-			hasUntrackedFilledShape = true;
-			return true;
-		}
+		var hasDrawnFilledShape = false;
+		var hasDrawnFilledRectangle = false;
 
 		for (type in graphics.__commands.types)
 		{
@@ -995,26 +888,30 @@ class Context3DGraphics
 					hasBitmapFill = true;
 					hasColorFill = false;
 					hasShaderFill = false;
-					resetFilledShapeCompatibility();
+					hasDrawnFilledShape = false;
+					hasDrawnFilledRectangle = false;
 					data.skip(type);
 
 				case BEGIN_FILL:
 					hasBitmapFill = false;
 					hasColorFill = true;
 					hasShaderFill = false;
-					resetFilledShapeCompatibility();
+					hasDrawnFilledShape = false;
+					hasDrawnFilledRectangle = false;
 					data.skip(type);
 
 				case BEGIN_SHADER_FILL:
 					hasBitmapFill = false;
 					hasColorFill = false;
 					hasShaderFill = true;
-					resetFilledShapeCompatibility();
+					hasDrawnFilledShape = false;
+					hasDrawnFilledRectangle = false;
 					data.skip(type);
 
 				case DRAW_QUADS:
-					if ((hasColorFill || hasBitmapFill || hasShaderFill) && addUntrackedFilledShapeCompatibility())
+					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
 					{
+						hasDrawnFilledShape = true;
 						data.skip(type);
 					}
 					else
@@ -1024,14 +921,16 @@ class Context3DGraphics
 					}
 
 				case DRAW_RECT:
-					if (hasColorFill || hasBitmapFill || hasShaderFill)
+					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
 					{
-						var c = data.readDrawRect();
-						if (!addFilledRectCompatibility(c.x, c.y, c.width, c.height))
-						{
-							data.destroy();
-							return cacheCompatibility(false);
-						}
+						hasDrawnFilledShape = true;
+						hasDrawnFilledRectangle = true;
+						data.skip(type);
+					}
+					else if (hasDrawnFilledRectangle && !hasShaderFill)
+					{
+						graphics.__rectangleBatchesRequired = true;
+						data.skip(type);
 					}
 					else
 					{
@@ -1040,8 +939,9 @@ class Context3DGraphics
 					}
 
 				case DRAW_TRIANGLES:
-					if ((hasColorFill || hasBitmapFill || hasShaderFill) && addUntrackedFilledShapeCompatibility())
+					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
 					{
+						hasDrawnFilledShape = true;
 						data.skip(type);
 					}
 					else
@@ -1063,7 +963,8 @@ class Context3DGraphics
 					hasBitmapFill = false;
 					hasColorFill = false;
 					hasShaderFill = false;
-					resetFilledShapeCompatibility();
+					hasDrawnFilledShape = false;
+					hasDrawnFilledRectangle = false;
 					data.skip(type);
 
 				case MOVE_TO:
@@ -1079,6 +980,7 @@ class Context3DGraphics
 		}
 
 		data.destroy();
+		graphics.__hardwareCommands = graphics.__rectangleBatchesRequired ? buildHardwareCommands(graphics) : null;
 		return cacheCompatibility(true);
 	}
 
@@ -1294,95 +1196,12 @@ class Context3DGraphics
 					}
 				}
 
-				function renderRectangleBatch(length:Int):Void
+				var commands = graphics.__hardwareCommands != null ? graphics.__hardwareCommands : graphics.__commands;
+				var data = new DrawCommandReader(commands);
+				for (type in commands.types)
 				{
-					if (length == 0 || (bitmap == null && fill == null))
+					switch (type)
 					{
-						return;
-					}
-
-					var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
-					var shader:Shader;
-
-					if (bitmap != null)
-					{
-						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
-						renderer.setShader(shader);
-						renderer.applyMatrix(uMatrix);
-						renderer.applyBitmapData(bitmap, smooth, repeat);
-						renderer.applyAlpha(graphics.__owner.__worldAlpha);
-						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
-						renderer.updateShader();
-					}
-					else
-					{
-						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
-						renderer.setShader(shader);
-						renderer.applyMatrix(uMatrix);
-						renderer.applyBitmapData(blankBitmapData, true, repeat);
-						#if lime
-						var color:ARGB = (fill : ARGB);
-						tempColorTransform.redOffset = color.r;
-						tempColorTransform.greenOffset = color.g;
-						tempColorTransform.blueOffset = color.b;
-						tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
-						renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
-						renderer.applyColorTransform(tempColorTransform);
-						#else
-						renderer.applyAlpha(graphics.__owner.__worldAlpha);
-						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
-						#end
-						renderer.updateShader();
-					}
-
-					var end = quadBufferPosition + length;
-					while (quadBufferPosition < end)
-					{
-						var drawLength = Std.int(Math.min(end - quadBufferPosition, context.__quadIndexBufferElements));
-						if (drawLength <= 0) break;
-
-						if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, graphics.__quadBuffer.vertexBuffer,
-							quadBufferPosition * 16, FLOAT_2);
-						if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, graphics.__quadBuffer.vertexBuffer,
-							(quadBufferPosition * 16) + 2, FLOAT_2);
-
-						context.drawTriangles(context.__quadIndexBuffer, 0, drawLength * 2);
-						quadBufferPosition += drawLength;
-
-						#if gl_stats
-						Context3DStats.incrementDrawCall(DrawCallContext.STAGE);
-						#end
-					}
-
-					renderer.__clearShader();
-				}
-
-				if (graphics.__solidRectangleBatchesOnly)
-				{
-					for (rectangleBatchIndex in 0...graphics.__rectangleBatchRects.length)
-					{
-						fill = graphics.__rectangleBatchFills[rectangleBatchIndex];
-						renderRectangleBatch(graphics.__rectangleBatchRects[rectangleBatchIndex].length >> 2);
-					}
-					context.setCulling(NONE);
-				}
-				else
-				{
-					var data = new DrawCommandReader(graphics.__commands);
-					var commandIndex = 0;
-					var rectangleBatchIndex = 0;
-					var hasRectangleBatches = graphics.__rectangleBatchEnds != null;
-					for (type in graphics.__commands.types)
-					{
-						while (hasRectangleBatches
-							&& rectangleBatchIndex < graphics.__rectangleBatchEnds.length
-							&& commandIndex >= graphics.__rectangleBatchEnds[rectangleBatchIndex])
-						{
-							rectangleBatchIndex++;
-						}
-
-						switch (type)
-						{
 						case BEGIN_BITMAP_FILL:
 							var c = data.readBeginBitmapFill();
 							bitmap = c.bitmap;
@@ -1555,19 +1374,7 @@ class Context3DGraphics
 
 						case DRAW_RECT:
 							var c = data.readDrawRect();
-							var isBatched = hasRectangleBatches
-								&& rectangleBatchIndex < graphics.__rectangleBatchStarts.length
-								&& commandIndex >= graphics.__rectangleBatchStarts[rectangleBatchIndex]
-								&& commandIndex < graphics.__rectangleBatchEnds[rectangleBatchIndex];
-
-							if (isBatched)
-							{
-								if (commandIndex == graphics.__rectangleBatchStarts[rectangleBatchIndex])
-								{
-									renderRectangleBatch(graphics.__rectangleBatchRects[rectangleBatchIndex].length >> 2);
-								}
-							}
-							else if (bitmap != null)
+							if (bitmap != null)
 							{
 								renderDrawTriangles(8, 6, 0, NONE);
 							}
@@ -1659,11 +1466,9 @@ class Context3DGraphics
 
 						default:
 							data.skip(type);
-						}
-						commandIndex++;
 					}
-					data.destroy();
 				}
+				data.destroy();
 
 				Matrix.__pool.release(matrix);
 			}

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -525,9 +525,11 @@ class Context3DGraphics
 
 		var commandIndex = 0;
 		var rectangleBatchIndex = 0;
+		var hasRectangleBatches = graphics.__rectangleBatchEnds != null;
 		for (type in graphics.__commands.types)
 		{
-			while (rectangleBatchIndex < graphics.__rectangleBatchEnds.length
+			while (hasRectangleBatches
+				&& rectangleBatchIndex < graphics.__rectangleBatchEnds.length
 				&& commandIndex >= graphics.__rectangleBatchEnds[rectangleBatchIndex])
 			{
 				rectangleBatchIndex++;
@@ -789,7 +791,8 @@ class Context3DGraphics
 
 				case DRAW_RECT:
 					var c = data.readDrawRect();
-					var isBatched = rectangleBatchIndex < graphics.__rectangleBatchStarts.length
+					var isBatched = hasRectangleBatches
+						&& rectangleBatchIndex < graphics.__rectangleBatchStarts.length
 						&& commandIndex >= graphics.__rectangleBatchStarts[rectangleBatchIndex]
 						&& commandIndex < graphics.__rectangleBatchEnds[rectangleBatchIndex];
 
@@ -1368,9 +1371,11 @@ class Context3DGraphics
 					var data = new DrawCommandReader(graphics.__commands);
 					var commandIndex = 0;
 					var rectangleBatchIndex = 0;
+					var hasRectangleBatches = graphics.__rectangleBatchEnds != null;
 					for (type in graphics.__commands.types)
 					{
-						while (rectangleBatchIndex < graphics.__rectangleBatchEnds.length
+						while (hasRectangleBatches
+							&& rectangleBatchIndex < graphics.__rectangleBatchEnds.length
 							&& commandIndex >= graphics.__rectangleBatchEnds[rectangleBatchIndex])
 						{
 							rectangleBatchIndex++;
@@ -1550,7 +1555,8 @@ class Context3DGraphics
 
 						case DRAW_RECT:
 							var c = data.readDrawRect();
-							var isBatched = rectangleBatchIndex < graphics.__rectangleBatchStarts.length
+							var isBatched = hasRectangleBatches
+								&& rectangleBatchIndex < graphics.__rectangleBatchStarts.length
 								&& commandIndex >= graphics.__rectangleBatchStarts[rectangleBatchIndex]
 								&& commandIndex < graphics.__rectangleBatchEnds[rectangleBatchIndex];
 

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -42,8 +42,276 @@ class Context3DGraphics
 	private static var tempUvtVector:Vector<Float> = new Vector<Float>();
 	private static var tempScale9VerticesVector:Vector<Float>;
 
+	private static function buildEvenOddRectangles(source:Vector<Float>):Vector<Float>
+	{
+		var normalized = new Vector<Float>();
+		var xCoordinates = new Array<Float>();
+		var yCoordinates = new Array<Float>();
+		var i = 0;
+
+		while (i < source.length)
+		{
+			var x = source[i];
+			var y = source[i + 1];
+			var right = x + source[i + 2];
+			var bottom = y + source[i + 3];
+			var left = Math.min(x, right);
+			var top = Math.min(y, bottom);
+			right = Math.max(x, right);
+			bottom = Math.max(y, bottom);
+
+			if (Math.isFinite(left) && Math.isFinite(top) && Math.isFinite(right) && Math.isFinite(bottom) && right > left && bottom > top)
+			{
+				normalized.push(left);
+				normalized.push(top);
+				normalized.push(right);
+				normalized.push(bottom);
+				xCoordinates.push(left);
+				xCoordinates.push(right);
+				yCoordinates.push(top);
+				yCoordinates.push(bottom);
+			}
+
+			i += 4;
+		}
+
+		var result = new Vector<Float>();
+		if (normalized.length == 0)
+		{
+			return result;
+		}
+
+		function compareCoordinates(a:Float, b:Float):Int
+		{
+			return a < b ? -1 : (a > b ? 1 : 0);
+		}
+
+		function sortAndDeduplicate(values:Array<Float>):Array<Float>
+		{
+			values.sort(compareCoordinates);
+			var unique = new Array<Float>();
+			for (value in values)
+			{
+				if (unique.length == 0 || unique[unique.length - 1] != value)
+				{
+					unique.push(value);
+				}
+			}
+			return unique;
+		}
+
+		function findCoordinate(values:Array<Float>, value:Float):Int
+		{
+			var low = 0;
+			var high = values.length - 1;
+			while (low <= high)
+			{
+				var middle = (low + high) >> 1;
+				var current = values[middle];
+				if (current < value)
+				{
+					low = middle + 1;
+				}
+				else if (current > value)
+				{
+					high = middle - 1;
+				}
+				else
+				{
+					return middle;
+				}
+			}
+			return -1;
+		}
+
+		xCoordinates = sortAndDeduplicate(xCoordinates);
+		yCoordinates = sortAndDeduplicate(yCoordinates);
+
+		var finished = new Array<Array<Float>>();
+		var active = new Map<String, Array<Float>>();
+		var toggles = new Array<Bool>();
+
+		for (yIndex in 0...yCoordinates.length - 1)
+		{
+			var top = yCoordinates[yIndex];
+			var bottom = yCoordinates[yIndex + 1];
+			toggles.resize(xCoordinates.length);
+			for (xIndex in 0...toggles.length)
+			{
+				toggles[xIndex] = false;
+			}
+
+			i = 0;
+			while (i < normalized.length)
+			{
+				if (normalized[i + 1] < bottom && normalized[i + 3] > top)
+				{
+					var leftIndex = findCoordinate(xCoordinates, normalized[i]);
+					var rightIndex = findCoordinate(xCoordinates, normalized[i + 2]);
+					toggles[leftIndex] = !toggles[leftIndex];
+					toggles[rightIndex] = !toggles[rightIndex];
+				}
+				i += 4;
+			}
+
+			var row = new Map<String, Array<Float>>();
+			var parity = false;
+			var spanStart = -1;
+			for (xIndex in 0...xCoordinates.length)
+			{
+				var previousParity = parity;
+				if (toggles[xIndex])
+				{
+					parity = !parity;
+				}
+
+				if (!previousParity && parity)
+				{
+					spanStart = xIndex;
+				}
+				else if (previousParity && !parity)
+				{
+					var key = spanStart + ":" + xIndex;
+					var rectangle = active.get(key);
+					if (rectangle == null)
+					{
+						rectangle = [xCoordinates[spanStart], top, xCoordinates[xIndex] - xCoordinates[spanStart], bottom - top];
+					}
+					else
+					{
+						rectangle[3] = bottom - rectangle[1];
+					}
+					row.set(key, rectangle);
+				}
+			}
+
+			for (key => rectangle in active)
+			{
+				if (!row.exists(key))
+				{
+					finished.push(rectangle);
+				}
+			}
+			active = row;
+		}
+
+		for (rectangle in active)
+		{
+			finished.push(rectangle);
+		}
+
+		finished.sort(function(a:Array<Float>, b:Array<Float>):Int
+		{
+			var comparison = compareCoordinates(a[1], b[1]);
+			if (comparison == 0) comparison = compareCoordinates(a[0], b[0]);
+			if (comparison == 0) comparison = compareCoordinates(a[3], b[3]);
+			if (comparison == 0) comparison = compareCoordinates(a[2], b[2]);
+			return comparison;
+		});
+
+		for (rectangle in finished)
+		{
+			for (value in rectangle)
+			{
+				result.push(value);
+			}
+		}
+
+		return result;
+	}
+
+	private static function prepareRectangleBatches(graphics:Graphics):Void
+	{
+		graphics.__rectangleBatchStarts = new Vector<Int>();
+		graphics.__rectangleBatchEnds = new Vector<Int>();
+		graphics.__rectangleBatchFills = new Vector<Int>();
+		graphics.__rectangleBatchRects = [];
+		graphics.__solidRectangleBatchesOnly = true;
+
+		var data = new DrawCommandReader(graphics.__commands);
+		var source = new Vector<Float>();
+		var sourceCount = 0;
+		var firstCommand = -1;
+		var commandIndex = 0;
+		var hasSolidFill = false;
+		var solidFill = 0;
+
+		function finalize(endCommand:Int):Void
+		{
+			if (sourceCount > 1)
+			{
+				graphics.__rectangleBatchStarts.push(firstCommand);
+				graphics.__rectangleBatchEnds.push(endCommand);
+				graphics.__rectangleBatchFills.push(solidFill);
+				graphics.__rectangleBatchRects.push(buildEvenOddRectangles(source));
+			}
+			else if (sourceCount == 1)
+			{
+				graphics.__solidRectangleBatchesOnly = false;
+			}
+
+			source = new Vector<Float>();
+			sourceCount = 0;
+			firstCommand = -1;
+		}
+
+		for (type in graphics.__commands.types)
+		{
+			switch (type)
+			{
+				case BEGIN_FILL:
+					finalize(commandIndex);
+					var fill = data.readBeginFill();
+					var color = Std.int(fill.color);
+					var alpha = Std.int(fill.alpha * 0xFF);
+					solidFill = (color & 0xFFFFFF) | (alpha << 24);
+					hasSolidFill = true;
+
+				case BEGIN_BITMAP_FILL, BEGIN_GRADIENT_FILL, BEGIN_SHADER_FILL:
+					finalize(commandIndex);
+					hasSolidFill = false;
+					graphics.__solidRectangleBatchesOnly = false;
+					data.skip(type);
+
+				case DRAW_RECT:
+					var rectangle = data.readDrawRect();
+					if (!hasSolidFill)
+					{
+						graphics.__solidRectangleBatchesOnly = false;
+					}
+					if (firstCommand == -1)
+					{
+						firstCommand = commandIndex;
+					}
+					sourceCount++;
+					source.push(rectangle.x);
+					source.push(rectangle.y);
+					source.push(rectangle.width);
+					source.push(rectangle.height);
+
+				case END_FILL:
+					finalize(commandIndex);
+					hasSolidFill = false;
+					data.skip(type);
+
+				default:
+					graphics.__solidRectangleBatchesOnly = false;
+					data.skip(type);
+			}
+			commandIndex++;
+		}
+
+		finalize(commandIndex);
+		if (graphics.__rectangleBatchRects.length == 0)
+		{
+			graphics.__solidRectangleBatchesOnly = false;
+		}
+		data.destroy();
+	}
+
 	private static function buildBuffer(graphics:Graphics, renderer:OpenGLRenderer):Void
 	{
+		prepareRectangleBatches(graphics);
 		var quadBufferPosition = 0;
 		var triangleIndexBufferPosition = 0;
 		var vertexBufferPosition = 0;
@@ -170,8 +438,91 @@ class Context3DGraphics
 			}
 		}
 
+		function buildRectangleBatchBuffer(rectangles:Vector<Float>):Void
+		{
+			var length = rectangles.length >> 2;
+			if (length == 0)
+			{
+				return;
+			}
+
+			var dataPerVertex = 4;
+			var stride = dataPerVertex * 4;
+			if (graphics.__quadBuffer == null)
+			{
+				graphics.__quadBuffer = new Context3DBuffer(context, QUADS, quadBufferPosition + length, dataPerVertex);
+			}
+			else
+			{
+				graphics.__quadBuffer.resize(quadBufferPosition + length, dataPerVertex);
+			}
+
+			var bitmapWidth = 1;
+			var bitmapHeight = 1;
+			if (bitmap != null)
+			{
+				#if openfl_power_of_two
+				while (bitmapWidth < bitmap.width)
+				{
+					bitmapWidth <<= 1;
+				}
+				while (bitmapHeight < bitmap.height)
+				{
+					bitmapHeight <<= 1;
+				}
+				#else
+				bitmapWidth = bitmap.width;
+				bitmapHeight = bitmap.height;
+				#end
+			}
+
+			var vertexBufferData = graphics.__quadBuffer.vertexBufferData;
+			var rectangleOffset = 0;
+			for (i in 0...length)
+			{
+				var vertexOffset = (quadBufferPosition + i) * stride;
+				var left = rectangles[rectangleOffset];
+				var top = rectangles[rectangleOffset + 1];
+				var right = left + rectangles[rectangleOffset + 2];
+				var bottom = top + rectangles[rectangleOffset + 3];
+				var uvLeft = left / bitmapWidth;
+				var uvTop = top / bitmapHeight;
+				var uvRight = right / bitmapWidth;
+				var uvBottom = bottom / bitmapHeight;
+
+				vertexBufferData[vertexOffset] = left;
+				vertexBufferData[vertexOffset + 1] = top;
+				vertexBufferData[vertexOffset + 2] = uvLeft;
+				vertexBufferData[vertexOffset + 3] = uvTop;
+				vertexBufferData[vertexOffset + dataPerVertex] = right;
+				vertexBufferData[vertexOffset + dataPerVertex + 1] = top;
+				vertexBufferData[vertexOffset + dataPerVertex + 2] = uvRight;
+				vertexBufferData[vertexOffset + dataPerVertex + 3] = uvTop;
+				vertexBufferData[vertexOffset + dataPerVertex * 2] = left;
+				vertexBufferData[vertexOffset + dataPerVertex * 2 + 1] = bottom;
+				vertexBufferData[vertexOffset + dataPerVertex * 2 + 2] = uvLeft;
+				vertexBufferData[vertexOffset + dataPerVertex * 2 + 3] = uvBottom;
+				vertexBufferData[vertexOffset + dataPerVertex * 3] = right;
+				vertexBufferData[vertexOffset + dataPerVertex * 3 + 1] = bottom;
+				vertexBufferData[vertexOffset + dataPerVertex * 3 + 2] = uvRight;
+				vertexBufferData[vertexOffset + dataPerVertex * 3 + 3] = uvBottom;
+
+				rectangleOffset += 4;
+			}
+
+			quadBufferPosition += length;
+		}
+
+		var commandIndex = 0;
+		var rectangleBatchIndex = 0;
 		for (type in graphics.__commands.types)
 		{
+			while (rectangleBatchIndex < graphics.__rectangleBatchEnds.length
+				&& commandIndex >= graphics.__rectangleBatchEnds[rectangleBatchIndex])
+			{
+				rectangleBatchIndex++;
+			}
+
 			switch (type)
 			{
 				case BEGIN_BITMAP_FILL:
@@ -427,10 +778,20 @@ class Context3DGraphics
 					buildDrawTrianglesBuffer(tempVerticesVector, tempIndicesVector, null, NONE);
 
 				case DRAW_RECT:
-					if (bitmap != null)
-					{
-						var c = data.readDrawRect();
+					var c = data.readDrawRect();
+					var isBatched = rectangleBatchIndex < graphics.__rectangleBatchStarts.length
+						&& commandIndex >= graphics.__rectangleBatchStarts[rectangleBatchIndex]
+						&& commandIndex < graphics.__rectangleBatchEnds[rectangleBatchIndex];
 
+					if (isBatched)
+					{
+						if (commandIndex == graphics.__rectangleBatchStarts[rectangleBatchIndex])
+						{
+							buildRectangleBatchBuffer(graphics.__rectangleBatchRects[rectangleBatchIndex]);
+						}
+					}
+					else if (bitmap != null)
+					{
 						tempVerticesVector.length = 8;
 						tempVerticesVector[0] = c.x;
 						tempVerticesVector[1] = c.y;
@@ -458,6 +819,7 @@ class Context3DGraphics
 				default:
 					data.skip(type);
 			}
+			commandIndex++;
 		}
 
 		// TODO: Should we use static data specific to Context3DGraphics instead of each Graphics instance?
@@ -521,31 +883,48 @@ class Context3DGraphics
 		return true;
 		#end
 
+		// The owner's scale9 state can change without changing the Graphics
+		// command stream, so it must not be part of the cached result.
 		if (graphics.__owner.__worldScale9Grid != null)
 		{
 			return false;
 		}
 
+		if (!graphics.__hardwareDirty && graphics.__hardwareCompatibilityKnown)
+		{
+			return graphics.__hardwareCompatible;
+		}
+
+		inline function cacheCompatibility(result:Bool):Bool
+		{
+			graphics.__hardwareCompatible = result;
+			graphics.__hardwareCompatibilityKnown = true;
+			return result;
+		}
+
 		var data = new DrawCommandReader(graphics.__commands);
 		var hasColorFill = false, hasBitmapFill = false, hasShaderFill = false;
-		// Multiple axis-aligned rectangles are safe on the legacy hardware path
-		// when their interiors do not overlap. Other shape combinations remain
-		// conservative and fall back to software.
-		var filledRectBounds = new Vector<Float>();
+		// Multiple axis-aligned rectangles are converted to a single batched mesh
+		// that preserves the even-odd fill rule. Combinations with other filled
+		// primitives remain conservative and fall back to software.
+		var filledRectCount = 0;
+		var filledRectCommandCount = 0;
 		var hasUntrackedFilledShape = false;
 
 		inline function resetFilledShapeCompatibility():Void
 		{
-			filledRectBounds.length = 0;
+			filledRectCount = 0;
+			filledRectCommandCount = 0;
 			hasUntrackedFilledShape = false;
 		}
 
 		function addFilledRectCompatibility(x:Float, y:Float, width:Float, height:Float):Bool
 		{
-			if (hasUntrackedFilledShape)
+			if (hasUntrackedFilledShape || (hasShaderFill && filledRectCommandCount > 0))
 			{
 				return false;
 			}
+			filledRectCommandCount++;
 
 			var right = x + width;
 			var bottom = y + height;
@@ -554,7 +933,7 @@ class Context3DGraphics
 			right = Math.max(x, right);
 			bottom = Math.max(y, bottom);
 
-			if (Math.isNaN(left) || Math.isNaN(top) || Math.isNaN(right) || Math.isNaN(bottom))
+			if (!Math.isFinite(left) || !Math.isFinite(top) || !Math.isFinite(right) || !Math.isFinite(bottom))
 			{
 				return false;
 			}
@@ -565,33 +944,13 @@ class Context3DGraphics
 				return true;
 			}
 
-			var i = 0;
-			while (i < filledRectBounds.length)
-			{
-				var otherLeft = filledRectBounds[i];
-				var otherTop = filledRectBounds[i + 1];
-				var otherRight = filledRectBounds[i + 2];
-				var otherBottom = filledRectBounds[i + 3];
-
-				// Touching edges have no shared interior, so they cannot create a cutout.
-				if (left < otherRight && right > otherLeft && top < otherBottom && bottom > otherTop)
-				{
-					return false;
-				}
-
-				i += 4;
-			}
-
-			filledRectBounds.push(left);
-			filledRectBounds.push(top);
-			filledRectBounds.push(right);
-			filledRectBounds.push(bottom);
+			filledRectCount++;
 			return true;
 		}
 
 		inline function addUntrackedFilledShapeCompatibility():Bool
 		{
-			if (hasUntrackedFilledShape || filledRectBounds.length > 0)
+			if (hasUntrackedFilledShape || filledRectCount > 0)
 			{
 				return false;
 			}
@@ -609,7 +968,7 @@ class Context3DGraphics
 					if (c.matrix != null)
 					{
 						data.destroy();
-						return false;
+						return cacheCompatibility(false);
 					}
 					hasBitmapFill = true;
 					hasColorFill = false;
@@ -639,7 +998,7 @@ class Context3DGraphics
 					else
 					{
 						data.destroy();
-						return false;
+						return cacheCompatibility(false);
 					}
 
 				case DRAW_RECT:
@@ -649,13 +1008,13 @@ class Context3DGraphics
 						if (!addFilledRectCompatibility(c.x, c.y, c.width, c.height))
 						{
 							data.destroy();
-							return false;
+							return cacheCompatibility(false);
 						}
 					}
 					else
 					{
 						data.destroy();
-						return false;
+						return cacheCompatibility(false);
 					}
 
 				case DRAW_TRIANGLES:
@@ -666,7 +1025,7 @@ class Context3DGraphics
 					else
 					{
 						data.destroy();
-						return false;
+						return cacheCompatibility(false);
 					}
 
 				case LINE_STYLE:
@@ -674,7 +1033,7 @@ class Context3DGraphics
 					if (c.thickness != null)
 					{
 						data.destroy();
-						return false;
+						return cacheCompatibility(false);
 					}
 					data.skip(type);
 
@@ -693,12 +1052,12 @@ class Context3DGraphics
 
 				default:
 					data.destroy();
-					return false;
+					return cacheCompatibility(false);
 			}
 		}
 
 		data.destroy();
-		return true;
+		return cacheCompatibility(true);
 	}
 
 	public static function render(graphics:Graphics, renderer:OpenGLRenderer):Void
@@ -777,8 +1136,6 @@ class Context3DGraphics
 				{
 					scale9Grid = null;
 				}
-
-				var data = new DrawCommandReader(graphics.__commands);
 
 				var context = renderer.__context3D;
 				var gl = context.gl;
@@ -915,10 +1272,93 @@ class Context3DGraphics
 					}
 				}
 
-				for (type in graphics.__commands.types)
+				function renderRectangleBatch(length:Int):Void
 				{
-					switch (type)
+					if (length == 0 || (bitmap == null && fill == null))
 					{
+						return;
+					}
+
+					var uMatrix = renderer.__getMatrix(graphics.__owner.__renderTransform, AUTO);
+					var shader:Shader;
+
+					if (bitmap != null)
+					{
+						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
+						renderer.setShader(shader);
+						renderer.applyMatrix(uMatrix);
+						renderer.applyBitmapData(bitmap, smooth, repeat);
+						renderer.applyAlpha(graphics.__owner.__worldAlpha);
+						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
+						renderer.updateShader();
+					}
+					else
+					{
+						shader = maskRender ? renderer.__maskShader : renderer.__initGraphicsShader(null);
+						renderer.setShader(shader);
+						renderer.applyMatrix(uMatrix);
+						renderer.applyBitmapData(blankBitmapData, true, repeat);
+						#if lime
+						var color:ARGB = (fill : ARGB);
+						tempColorTransform.redOffset = color.r;
+						tempColorTransform.greenOffset = color.g;
+						tempColorTransform.blueOffset = color.b;
+						tempColorTransform.__combine(graphics.__owner.__worldColorTransform);
+						renderer.applyAlpha((color.a / 0xFF) * graphics.__owner.__worldAlpha);
+						renderer.applyColorTransform(tempColorTransform);
+						#else
+						renderer.applyAlpha(graphics.__owner.__worldAlpha);
+						renderer.applyColorTransform(graphics.__owner.__worldColorTransform);
+						#end
+						renderer.updateShader();
+					}
+
+					var end = quadBufferPosition + length;
+					while (quadBufferPosition < end)
+					{
+						var drawLength = Std.int(Math.min(end - quadBufferPosition, context.__quadIndexBufferElements));
+						if (drawLength <= 0) break;
+
+						if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, graphics.__quadBuffer.vertexBuffer,
+							quadBufferPosition * 16, FLOAT_2);
+						if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, graphics.__quadBuffer.vertexBuffer,
+							(quadBufferPosition * 16) + 2, FLOAT_2);
+
+						context.drawTriangles(context.__quadIndexBuffer, 0, drawLength * 2);
+						quadBufferPosition += drawLength;
+
+						#if gl_stats
+						Context3DStats.incrementDrawCall(DrawCallContext.STAGE);
+						#end
+					}
+
+					renderer.__clearShader();
+				}
+
+				if (graphics.__solidRectangleBatchesOnly)
+				{
+					for (rectangleBatchIndex in 0...graphics.__rectangleBatchRects.length)
+					{
+						fill = graphics.__rectangleBatchFills[rectangleBatchIndex];
+						renderRectangleBatch(graphics.__rectangleBatchRects[rectangleBatchIndex].length >> 2);
+					}
+					context.setCulling(NONE);
+				}
+				else
+				{
+					var data = new DrawCommandReader(graphics.__commands);
+					var commandIndex = 0;
+					var rectangleBatchIndex = 0;
+					for (type in graphics.__commands.types)
+					{
+						while (rectangleBatchIndex < graphics.__rectangleBatchEnds.length
+							&& commandIndex >= graphics.__rectangleBatchEnds[rectangleBatchIndex])
+						{
+							rectangleBatchIndex++;
+						}
+
+						switch (type)
+						{
 						case BEGIN_BITMAP_FILL:
 							var c = data.readBeginBitmapFill();
 							bitmap = c.bitmap;
@@ -1091,8 +1531,18 @@ class Context3DGraphics
 
 						case DRAW_RECT:
 							var c = data.readDrawRect();
+							var isBatched = rectangleBatchIndex < graphics.__rectangleBatchStarts.length
+								&& commandIndex >= graphics.__rectangleBatchStarts[rectangleBatchIndex]
+								&& commandIndex < graphics.__rectangleBatchEnds[rectangleBatchIndex];
 
-							if (bitmap != null)
+							if (isBatched)
+							{
+								if (commandIndex == graphics.__rectangleBatchStarts[rectangleBatchIndex])
+								{
+									renderRectangleBatch(graphics.__rectangleBatchRects[rectangleBatchIndex].length >> 2);
+								}
+							}
+							else if (bitmap != null)
 							{
 								renderDrawTriangles(8, 6, 0, NONE);
 							}
@@ -1184,7 +1634,10 @@ class Context3DGraphics
 
 						default:
 							data.skip(type);
+						}
+						commandIndex++;
 					}
+					data.destroy();
 				}
 
 				Matrix.__pool.release(matrix);

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -528,9 +528,77 @@ class Context3DGraphics
 
 		var data = new DrawCommandReader(graphics.__commands);
 		var hasColorFill = false, hasBitmapFill = false, hasShaderFill = false;
-		// for each fill, allow drawing one shape only because the two shapes
-		// might intersect and require a cutout. fall back to software for that.
-		var hasDrawnFilledShape = false;
+		// Multiple axis-aligned rectangles are safe on the legacy hardware path
+		// when their interiors do not overlap. Other shape combinations remain
+		// conservative and fall back to software.
+		var filledRectBounds = new Vector<Float>();
+		var hasUntrackedFilledShape = false;
+
+		inline function resetFilledShapeCompatibility():Void
+		{
+			filledRectBounds.length = 0;
+			hasUntrackedFilledShape = false;
+		}
+
+		function addFilledRectCompatibility(x:Float, y:Float, width:Float, height:Float):Bool
+		{
+			if (hasUntrackedFilledShape)
+			{
+				return false;
+			}
+
+			var right = x + width;
+			var bottom = y + height;
+			var left = Math.min(x, right);
+			var top = Math.min(y, bottom);
+			right = Math.max(x, right);
+			bottom = Math.max(y, bottom);
+
+			if (Math.isNaN(left) || Math.isNaN(top) || Math.isNaN(right) || Math.isNaN(bottom))
+			{
+				return false;
+			}
+
+			// Empty rectangles have no filled interior and cannot create a cutout.
+			if (right <= left || bottom <= top)
+			{
+				return true;
+			}
+
+			var i = 0;
+			while (i < filledRectBounds.length)
+			{
+				var otherLeft = filledRectBounds[i];
+				var otherTop = filledRectBounds[i + 1];
+				var otherRight = filledRectBounds[i + 2];
+				var otherBottom = filledRectBounds[i + 3];
+
+				// Touching edges have no shared interior, so they cannot create a cutout.
+				if (left < otherRight && right > otherLeft && top < otherBottom && bottom > otherTop)
+				{
+					return false;
+				}
+
+				i += 4;
+			}
+
+			filledRectBounds.push(left);
+			filledRectBounds.push(top);
+			filledRectBounds.push(right);
+			filledRectBounds.push(bottom);
+			return true;
+		}
+
+		inline function addUntrackedFilledShapeCompatibility():Bool
+		{
+			if (hasUntrackedFilledShape || filledRectBounds.length > 0)
+			{
+				return false;
+			}
+
+			hasUntrackedFilledShape = true;
+			return true;
+		}
 
 		for (type in graphics.__commands.types)
 		{
@@ -546,27 +614,26 @@ class Context3DGraphics
 					hasBitmapFill = true;
 					hasColorFill = false;
 					hasShaderFill = false;
-					hasDrawnFilledShape = false;
+					resetFilledShapeCompatibility();
 					data.skip(type);
 
 				case BEGIN_FILL:
 					hasBitmapFill = false;
 					hasColorFill = true;
 					hasShaderFill = false;
-					hasDrawnFilledShape = false;
+					resetFilledShapeCompatibility();
 					data.skip(type);
 
 				case BEGIN_SHADER_FILL:
 					hasBitmapFill = false;
 					hasColorFill = false;
 					hasShaderFill = true;
-					hasDrawnFilledShape = false;
+					resetFilledShapeCompatibility();
 					data.skip(type);
 
 				case DRAW_QUADS:
-					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
+					if ((hasColorFill || hasBitmapFill || hasShaderFill) && addUntrackedFilledShapeCompatibility())
 					{
-						hasDrawnFilledShape = true;
 						data.skip(type);
 					}
 					else
@@ -576,10 +643,14 @@ class Context3DGraphics
 					}
 
 				case DRAW_RECT:
-					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
+					if (hasColorFill || hasBitmapFill || hasShaderFill)
 					{
-						hasDrawnFilledShape = true;
-						data.skip(type);
+						var c = data.readDrawRect();
+						if (!addFilledRectCompatibility(c.x, c.y, c.width, c.height))
+						{
+							data.destroy();
+							return false;
+						}
 					}
 					else
 					{
@@ -588,9 +659,8 @@ class Context3DGraphics
 					}
 
 				case DRAW_TRIANGLES:
-					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
+					if ((hasColorFill || hasBitmapFill || hasShaderFill) && addUntrackedFilledShapeCompatibility())
 					{
-						hasDrawnFilledShape = true;
 						data.skip(type);
 					}
 					else
@@ -612,7 +682,7 @@ class Context3DGraphics
 					hasBitmapFill = false;
 					hasColorFill = false;
 					hasShaderFill = false;
-					hasDrawnFilledShape = false;
+					resetFilledShapeCompatibility();
 					data.skip(type);
 
 				case MOVE_TO:

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -7,6 +7,7 @@ class Tests
 	{
 		var runner = new Runner();
 		runner.addCase(new CapsStyleTest());
+		runner.addCase(new Context3DGraphicsTest());
 		runner.addCase(new GradientTypeTest());
 		runner.addCase(new GraphicsBitmapFillTest());
 		runner.addCase(new GraphicsEndFillTest());

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -7,7 +7,9 @@ class Tests
 	{
 		var runner = new Runner();
 		runner.addCase(new CapsStyleTest());
+		#if !flash
 		runner.addCase(new Context3DGraphicsTest());
+		#end
 		runner.addCase(new GradientTypeTest());
 		runner.addCase(new GraphicsBitmapFillTest());
 		runner.addCase(new GraphicsEndFillTest());

--- a/tests/graphics/src/Context3DGraphicsTest.hx
+++ b/tests/graphics/src/Context3DGraphicsTest.hx
@@ -2,12 +2,90 @@ package;
 
 import openfl.display.Shape;
 import openfl.display._internal.Context3DGraphics;
+import openfl.geom.Rectangle;
+import openfl.Vector;
 import utest.Assert;
 import utest.Test;
 
 @:access(openfl.display._internal.Context3DGraphics)
+@:access(openfl.display.DisplayObject)
+@:access(openfl.display.Graphics)
 class Context3DGraphicsTest extends Test
 {
+	private function buildEvenOddRectangles(values:Array<Float>):Vector<Float>
+	{
+		return Context3DGraphics.buildEvenOddRectangles(Vector.ofArray(values));
+	}
+
+	private function getArea(rectangles:Vector<Float>):Float
+	{
+		var area = 0.0;
+		var i = 0;
+		while (i < rectangles.length)
+		{
+			area += rectangles[i + 2] * rectangles[i + 3];
+			i += 4;
+		}
+		return area;
+	}
+
+	private function isCovered(rectangles:Vector<Float>, x:Float, y:Float):Bool
+	{
+		var i = 0;
+		while (i < rectangles.length)
+		{
+			if (x >= rectangles[i]
+				&& x < rectangles[i] + rectangles[i + 2]
+				&& y >= rectangles[i + 1]
+				&& y < rectangles[i + 1] + rectangles[i + 3])
+			{
+				return true;
+			}
+			i += 4;
+		}
+		return false;
+	}
+
+	private function isEvenOddCovered(source:Array<Float>, x:Float, y:Float):Bool
+	{
+		var covered = false;
+		var i = 0;
+		while (i < source.length)
+		{
+			var right = source[i] + source[i + 2];
+			var bottom = source[i + 1] + source[i + 3];
+			var left = Math.min(source[i], right);
+			var top = Math.min(source[i + 1], bottom);
+			right = Math.max(source[i], right);
+			bottom = Math.max(source[i + 1], bottom);
+			if (x >= left && x < right && y >= top && y < bottom)
+			{
+				covered = !covered;
+			}
+			i += 4;
+		}
+		return covered;
+	}
+
+	private function assertRectanglesDoNotOverlap(rectangles:Vector<Float>):Void
+	{
+		var first = 0;
+		while (first < rectangles.length)
+		{
+			var second = first + 4;
+			while (second < rectangles.length)
+			{
+				var overlaps = rectangles[first] < rectangles[second] + rectangles[second + 2]
+					&& rectangles[first] + rectangles[first + 2] > rectangles[second]
+					&& rectangles[first + 1] < rectangles[second + 1] + rectangles[second + 3]
+					&& rectangles[first + 1] + rectangles[first + 3] > rectangles[second + 1];
+				Assert.isFalse(overlaps);
+				second += 4;
+			}
+			first += 4;
+		}
+	}
+
 	public function testDisjointDrawRectsAreCompatible():Void
 	{
 		var shape = new Shape();
@@ -30,7 +108,7 @@ class Context3DGraphicsTest extends Test
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 	}
 
-	public function testOverlappingDrawRectsAreIncompatible():Void
+	public function testOverlappingDrawRectsAreCompatible():Void
 	{
 		var shape = new Shape();
 		shape.graphics.beginFill(0xFF0000);
@@ -38,10 +116,10 @@ class Context3DGraphicsTest extends Test
 		shape.graphics.drawRect(5, 5, 10, 10);
 		shape.graphics.endFill();
 
-		Assert.isFalse(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 	}
 
-	public function testNestedDrawRectsAreIncompatible():Void
+	public function testNestedDrawRectsAreCompatible():Void
 	{
 		var shape = new Shape();
 		shape.graphics.beginFill(0xFF0000);
@@ -49,7 +127,7 @@ class Context3DGraphicsTest extends Test
 		shape.graphics.drawRect(5, 5, 5, 5);
 		shape.graphics.endFill();
 
-		Assert.isFalse(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 	}
 
 	public function testNegativeSizeDrawRectsUseNormalizedBounds():Void
@@ -61,5 +139,159 @@ class Context3DGraphicsTest extends Test
 		shape.graphics.endFill();
 
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testCompatibilityCacheIsInvalidatedWhenCommandsChange():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.drawRect(20, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		shape.graphics.__hardwareDirty = false;
+		Assert.isTrue(shape.graphics.__hardwareCompatibilityKnown);
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		shape.graphics.lineStyle(1);
+		shape.graphics.lineTo(30, 10);
+		Assert.isFalse(shape.graphics.__hardwareCompatibilityKnown);
+		Assert.isFalse(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testScale9GridIsNotStoredInCommandCompatibilityCache():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.drawRect(20, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		shape.graphics.__hardwareDirty = false;
+		shape.__worldScale9Grid = new Rectangle(0, 0, 10, 10);
+		Assert.isFalse(Context3DGraphics.isCompatible(shape.graphics));
+		shape.__worldScale9Grid = null;
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testSolidRectangleBatchMetadataAvoidsCommandTraversal():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0x123456, 0.5);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.drawRect(10, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Context3DGraphics.prepareRectangleBatches(shape.graphics);
+
+		Assert.isTrue(shape.graphics.__solidRectangleBatchesOnly);
+		Assert.equals(1, shape.graphics.__rectangleBatchRects.length);
+		Assert.equals(4, shape.graphics.__rectangleBatchRects[0].length);
+		Assert.equals(0x7F123456, shape.graphics.__rectangleBatchFills[0]);
+	}
+
+	public function testSingleRectangleDoesNotUseBatchOnlyFastPath():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Context3DGraphics.prepareRectangleBatches(shape.graphics);
+
+		Assert.isFalse(shape.graphics.__solidRectangleBatchesOnly);
+	}
+
+	public function testTouchingDrawRectsMergeIntoOneQuad():Void
+	{
+		var rectangles = buildEvenOddRectangles([0, 0, 10, 10, 10, 0, 10, 10]);
+
+		Assert.equals(4, rectangles.length);
+		Assert.equals(200.0, getArea(rectangles));
+		Assert.isTrue(isCovered(rectangles, 5, 5));
+		Assert.isTrue(isCovered(rectangles, 15, 5));
+	}
+
+	public function testOverlappingDrawRectsPreserveEvenOddCutout():Void
+	{
+		var rectangles = buildEvenOddRectangles([0, 0, 10, 10, 5, 0, 10, 10]);
+
+		Assert.equals(8, rectangles.length);
+		Assert.equals(100.0, getArea(rectangles));
+		Assert.isTrue(isCovered(rectangles, 2, 5));
+		Assert.isFalse(isCovered(rectangles, 7, 5));
+		Assert.isTrue(isCovered(rectangles, 12, 5));
+	}
+
+	public function testNestedDrawRectsPreserveEvenOddHole():Void
+	{
+		var rectangles = buildEvenOddRectangles([0, 0, 20, 20, 5, 5, 5, 5]);
+
+		Assert.equals(16, rectangles.length);
+		Assert.equals(375.0, getArea(rectangles));
+		Assert.isTrue(isCovered(rectangles, 2, 2));
+		Assert.isFalse(isCovered(rectangles, 7, 7));
+		Assert.isTrue(isCovered(rectangles, 15, 15));
+	}
+
+	public function testIdenticalDrawRectsCancel():Void
+	{
+		var rectangles = buildEvenOddRectangles([0, 0, 10, 10, 0, 0, 10, 10]);
+
+		Assert.equals(0, rectangles.length);
+	}
+
+	public function testThreeIdenticalDrawRectsRemainFilled():Void
+	{
+		var rectangles = buildEvenOddRectangles([0, 0, 10, 10, 0, 0, 10, 10, 0, 0, 10, 10]);
+
+		Assert.equals(4, rectangles.length);
+		Assert.equals(100.0, getArea(rectangles));
+	}
+
+	public function testNegativeDrawRectDimensionsAreNormalized():Void
+	{
+		var rectangles = buildEvenOddRectangles([10, 10, -10, -10, 20, 0, -5, 5]);
+
+		Assert.equals(8, rectangles.length);
+		Assert.equals(125.0, getArea(rectangles));
+		Assert.isTrue(isCovered(rectangles, 5, 5));
+		Assert.isTrue(isCovered(rectangles, 17, 2));
+	}
+
+	public function testMixedRectanglesPreserveExactEvenOddCoverageWithoutOverlap():Void
+	{
+		var source = [0.0, 0.0, 8.0, 8.0, 3.0, -2.0, 8.0, 6.0, 2.0, 2.0, 3.0, 9.0, 12.0, 8.0, -7.0, -5.0];
+		var rectangles = buildEvenOddRectangles(source);
+
+		for (y in -3...12)
+		{
+			for (x in -1...14)
+			{
+				Assert.equals(isEvenOddCovered(source, x + 0.5, y + 0.5), isCovered(rectangles, x + 0.5, y + 0.5));
+			}
+		}
+		assertRectanglesDoNotOverlap(rectangles);
+	}
+
+	public function testLetterboxRectanglesPreserveOffscreenCutouts():Void
+	{
+		var size = 10000.0;
+		var viewWidth = 1920.0;
+		var viewHeight = 1080.0;
+		var rectangles = buildEvenOddRectangles([
+			-size, -size, size + viewWidth + size, size,
+			-size, viewHeight, size + viewWidth + size, size,
+			-size, 0, size, size,
+			viewWidth, 0, size, size
+		]);
+
+		Assert.isTrue(isCovered(rectangles, 100, -1));
+		Assert.isTrue(isCovered(rectangles, -1, 100));
+		Assert.isFalse(isCovered(rectangles, 100, 100));
+		Assert.isTrue(isCovered(rectangles, 100, viewHeight + 1));
+		Assert.isFalse(isCovered(rectangles, -1, viewHeight + 1));
+		Assert.isFalse(isCovered(rectangles, viewWidth + 1, viewHeight + 1));
 	}
 }

--- a/tests/graphics/src/Context3DGraphicsTest.hx
+++ b/tests/graphics/src/Context3DGraphicsTest.hx
@@ -2,6 +2,8 @@ package;
 
 import openfl.display.Shape;
 import openfl.display._internal.Context3DGraphics;
+import openfl.display._internal.DrawCommandReader;
+import openfl.display._internal.DrawCommandType;
 import openfl.geom.Rectangle;
 import openfl.Vector;
 import utest.Assert;
@@ -95,10 +97,7 @@ class Context3DGraphicsTest extends Test
 
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 		Assert.isFalse(shape.graphics.__rectangleBatchesRequired);
-		Assert.isNull(shape.graphics.__rectangleBatchStarts);
-		Assert.isNull(shape.graphics.__rectangleBatchEnds);
-		Assert.isNull(shape.graphics.__rectangleBatchFills);
-		Assert.isNull(shape.graphics.__rectangleBatchRects);
+		Assert.isNull(shape.graphics.__hardwareCommands);
 	}
 
 	public function testSingleDrawRectDoesNotRequireRectangleBatchPreparation():Void
@@ -110,10 +109,7 @@ class Context3DGraphicsTest extends Test
 
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 		Assert.isFalse(shape.graphics.__rectangleBatchesRequired);
-		Assert.isNull(shape.graphics.__rectangleBatchStarts);
-		Assert.isNull(shape.graphics.__rectangleBatchEnds);
-		Assert.isNull(shape.graphics.__rectangleBatchFills);
-		Assert.isNull(shape.graphics.__rectangleBatchRects);
+		Assert.isNull(shape.graphics.__hardwareCommands);
 	}
 
 	public function testDisjointDrawRectsAreCompatible():Void
@@ -203,10 +199,12 @@ class Context3DGraphicsTest extends Test
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 		shape.graphics.__hardwareDirty = false;
 		Assert.isTrue(shape.graphics.__hardwareCompatibilityKnown);
+		Assert.notNull(shape.graphics.__hardwareCommands);
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 		shape.graphics.lineStyle(1);
 		shape.graphics.lineTo(30, 10);
 		Assert.isFalse(shape.graphics.__hardwareCompatibilityKnown);
+		Assert.isNull(shape.graphics.__hardwareCommands);
 		Assert.isFalse(Context3DGraphics.isCompatible(shape.graphics));
 	}
 
@@ -226,7 +224,7 @@ class Context3DGraphicsTest extends Test
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 	}
 
-	public function testSolidRectangleBatchMetadataAvoidsCommandTraversal():Void
+	public function testMultipleRectanglesUsePreparedHardwareCommands():Void
 	{
 		var shape = new Shape();
 		shape.graphics.beginFill(0x123456, 0.5);
@@ -234,24 +232,27 @@ class Context3DGraphicsTest extends Test
 		shape.graphics.drawRect(10, 0, 10, 10);
 		shape.graphics.endFill();
 
-		Context3DGraphics.prepareRectangleBatches(shape.graphics);
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.notNull(shape.graphics.__hardwareCommands);
+		Assert.equals(3, shape.graphics.__hardwareCommands.types.length);
+		Assert.equals(DrawCommandType.DRAW_QUADS, shape.graphics.__hardwareCommands.types[1]);
 
-		Assert.isTrue(shape.graphics.__solidRectangleBatchesOnly);
-		Assert.equals(1, shape.graphics.__rectangleBatchRects.length);
-		Assert.equals(4, shape.graphics.__rectangleBatchRects[0].length);
-		Assert.equals(0x7F123456, shape.graphics.__rectangleBatchFills[0]);
+		var data = new DrawCommandReader(shape.graphics.__hardwareCommands);
+		data.skip(DrawCommandType.BEGIN_FILL);
+		var quads = data.readDrawQuads();
+		Assert.equals(4, quads.rects.length);
+		data.destroy();
 	}
 
-	public function testSingleRectangleDoesNotUseBatchOnlyFastPath():Void
+	public function testSingleRectangleKeepsOriginalHardwareCommands():Void
 	{
 		var shape = new Shape();
 		shape.graphics.beginFill(0xFF0000);
 		shape.graphics.drawRect(0, 0, 10, 10);
 		shape.graphics.endFill();
 
-		Context3DGraphics.prepareRectangleBatches(shape.graphics);
-
-		Assert.isFalse(shape.graphics.__solidRectangleBatchesOnly);
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isNull(shape.graphics.__hardwareCommands);
 	}
 
 	public function testTouchingDrawRectsMergeIntoOneQuad():Void

--- a/tests/graphics/src/Context3DGraphicsTest.hx
+++ b/tests/graphics/src/Context3DGraphicsTest.hx
@@ -95,6 +95,10 @@ class Context3DGraphicsTest extends Test
 
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 		Assert.isFalse(shape.graphics.__rectangleBatchesRequired);
+		Assert.isNull(shape.graphics.__rectangleBatchStarts);
+		Assert.isNull(shape.graphics.__rectangleBatchEnds);
+		Assert.isNull(shape.graphics.__rectangleBatchFills);
+		Assert.isNull(shape.graphics.__rectangleBatchRects);
 	}
 
 	public function testSingleDrawRectDoesNotRequireRectangleBatchPreparation():Void
@@ -106,6 +110,10 @@ class Context3DGraphicsTest extends Test
 
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
 		Assert.isFalse(shape.graphics.__rectangleBatchesRequired);
+		Assert.isNull(shape.graphics.__rectangleBatchStarts);
+		Assert.isNull(shape.graphics.__rectangleBatchEnds);
+		Assert.isNull(shape.graphics.__rectangleBatchFills);
+		Assert.isNull(shape.graphics.__rectangleBatchRects);
 	}
 
 	public function testDisjointDrawRectsAreCompatible():Void

--- a/tests/graphics/src/Context3DGraphicsTest.hx
+++ b/tests/graphics/src/Context3DGraphicsTest.hx
@@ -1,0 +1,65 @@
+package;
+
+import openfl.display.Shape;
+import openfl.display._internal.Context3DGraphics;
+import utest.Assert;
+import utest.Test;
+
+@:access(openfl.display._internal.Context3DGraphics)
+class Context3DGraphicsTest extends Test
+{
+	public function testDisjointDrawRectsAreCompatible():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.drawRect(20, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testTouchingDrawRectsAreCompatible():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.drawRect(10, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testOverlappingDrawRectsAreIncompatible():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.drawRect(5, 5, 10, 10);
+		shape.graphics.endFill();
+
+		Assert.isFalse(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testNestedDrawRectsAreIncompatible():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 20, 20);
+		shape.graphics.drawRect(5, 5, 5, 5);
+		shape.graphics.endFill();
+
+		Assert.isFalse(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testNegativeSizeDrawRectsUseNormalizedBounds():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(10, 10, -10, -10);
+		shape.graphics.drawRect(20, 0, -5, 5);
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+	}
+}

--- a/tests/graphics/src/Context3DGraphicsTest.hx
+++ b/tests/graphics/src/Context3DGraphicsTest.hx
@@ -86,6 +86,28 @@ class Context3DGraphicsTest extends Test
 		}
 	}
 
+	public function testOrdinaryHardwareGraphicsDoNotRequireRectangleBatchPreparation():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawTriangles(Vector.ofArray([0.0, 0.0, 10.0, 0.0, 0.0, 10.0]));
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isFalse(shape.graphics.__rectangleBatchesRequired);
+	}
+
+	public function testSingleDrawRectDoesNotRequireRectangleBatchPreparation():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isFalse(shape.graphics.__rectangleBatchesRequired);
+	}
+
 	public function testDisjointDrawRectsAreCompatible():Void
 	{
 		var shape = new Shape();
@@ -95,6 +117,7 @@ class Context3DGraphicsTest extends Test
 		shape.graphics.endFill();
 
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isTrue(shape.graphics.__rectangleBatchesRequired);
 	}
 
 	public function testTouchingDrawRectsAreCompatible():Void
@@ -106,6 +129,26 @@ class Context3DGraphicsTest extends Test
 		shape.graphics.endFill();
 
 		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+	}
+
+	public function testRectangleBatchRequirementIsClearedWhenCommandsChange():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(0, 0, 10, 10);
+		shape.graphics.drawRect(20, 0, 10, 10);
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isTrue(shape.graphics.__rectangleBatchesRequired);
+
+		shape.graphics.clear();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawTriangles(Vector.ofArray([0.0, 0.0, 10.0, 0.0, 0.0, 10.0]));
+		shape.graphics.endFill();
+
+		Assert.isTrue(Context3DGraphics.isCompatible(shape.graphics));
+		Assert.isFalse(shape.graphics.__rectangleBatchesRequired);
 	}
 
 	public function testOverlappingDrawRectsAreCompatible():Void


### PR DESCRIPTION
## Summary

- Keep consecutive filled `drawRect` commands on the Context3D path, including overlapping and nested rectangles.
- Preserve the `evenOdd` fill rule by decomposing the covered area into non-overlapping rectangles.
- Submit each rectangle fill as a batched GPU mesh, subject only to Context3D index-buffer chunking.
- Normalize negative dimensions and ignore empty rectangles.
- Prepare a separate GPU command stream only for fills that contain multiple rectangles, while ordinary Graphics and single rectangles retain the original Context3D build and render paths.
- Retain the software fallback for fills mixed with primitives that this path cannot combine safely.

## Implementation

The rectangle coordinates are compressed into a grid, coverage parity is toggled for every source rectangle, and adjacent covered cells are merged into larger quads. Because the emitted quads do not overlap, translucent fills are not blended more than once.

The decomposed rectangles are stored as a `DRAW_QUADS` command in a hardware-only command stream. The original command stream remains unchanged, and `buildBuffer()` and `render()` select the appropriate stream once, without rectangle-batch checks in their per-command hot paths.

The resulting geometry depends on the rectangle decomposition rather than the pixel dimensions of the combined bounds, while unchanged geometry remains cached on the GPU.

## Manual reproduction

The following shape uses four oversized, overlapping rectangles in one fill:

```haxe
var extent = 2048.0;
var opening = 200.0;
var shape = new Shape();
shape.x = 250;
shape.y = 200;
shape.graphics.beginFill(0x3366FF, 0.5);
shape.graphics.drawRect(-extent, -extent, extent * 2, extent);
shape.graphics.drawRect(-extent, opening, extent * 2, extent);
shape.graphics.drawRect(-extent, -extent, extent, extent * 2);
shape.graphics.drawRect(opening, -extent, extent, extent * 2);
shape.graphics.endFill();
addChild(shape);
```

Areas covered by an odd number of rectangles should be translucent blue; areas covered by an even number should remain transparent. Increasing `extent` (for example, from 2048 to 4096) does not change the visible result. On the base branch, the shape uses the software fallback and its bitmap allocation grows with these bounds. With this change, it remains on the Context3D path and the allocation is geometry-based instead.

## Tests

The graphics suite passes on Neko and Linux native (386 assertions). Coverage includes:

- disjoint, touching, overlapping, nested, identical, empty, and negative-size rectangles;
- exact `evenOdd` coverage and non-overlapping output quads;
- translucent solid fills, prepared hardware-command generation, and cache invalidation;
- scale9 state changes and preservation of the original command stream for ordinary Graphics and single rectangles.

A native Release microbenchmark found no measurable regression for ordinary static or per-frame rebuilt rectangles after isolating batch handling from the legacy command loops.