### PR TITLE
Clip Context3D software fallback graphics to the visible viewport

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -74,6 +74,7 @@ import js.html.CanvasRenderingContext2D;
 	@:noCompletion private var __renderTransform:Matrix;
 	@:noCompletion private var __shaderBufferPool:ObjectPool<ShaderBuffer>;
 	@:noCompletion private var __softwareDirty:Bool;
+	@:noCompletion private var __softwareRenderBounds:Rectangle;
 	@:noCompletion private var __strokePadding:Float;
 	@:noCompletion private var __transformDirty:Bool;
 	@:noCompletion private var __triangleIndexBuffer:IndexBuffer3D;
@@ -1909,9 +1910,32 @@ import js.html.CanvasRenderingContext2D;
 		}
 	}
 
-	@:noCompletion private function __update(displayMatrix:Matrix, pixelRatio:Float):Void
+	@:noCompletion private function __setSoftwareRenderBounds(value:Rectangle):Void
 	{
-		if (__bounds == null || __bounds.width <= 0 || __bounds.height <= 0)
+		if (value == null)
+		{
+			if (__softwareRenderBounds != null)
+			{
+				__softwareRenderBounds = null;
+				__softwareDirty = true;
+			}
+		}
+		else if (__softwareRenderBounds == null || !__softwareRenderBounds.equals(value))
+		{
+			if (__softwareRenderBounds == null)
+			{
+				__softwareRenderBounds = new Rectangle();
+			}
+			__softwareRenderBounds.copyFrom(value);
+			__softwareDirty = true;
+		}
+	}
+
+	@:noCompletion private function __update(displayMatrix:Matrix, pixelRatio:Float, renderBounds:Rectangle = null):Void
+	{
+		var bounds = renderBounds != null ? renderBounds : __bounds;
+
+		if (bounds == null || bounds.width <= 0 || bounds.height <= 0)
 		{
 			if (__width >= 1 || __height >= 1) __dirty = true;
 			__width = 0;
@@ -1981,8 +2005,8 @@ import js.html.CanvasRenderingContext2D;
 		}
 		#end
 
-		var width = Math.abs(__bounds.width * scaleX);
-		var height = Math.abs(__bounds.height * scaleY);
+		var width = Math.abs(bounds.width * scaleX);
+		var height = Math.abs(bounds.height * scaleY);
 
 		if (width < 1 || height < 1)
 		{
@@ -1995,13 +2019,13 @@ import js.html.CanvasRenderingContext2D;
 		if (maxTextureWidth != null && width > maxTextureWidth)
 		{
 			width = maxTextureWidth;
-			scaleX = maxTextureWidth / __bounds.width;
+			scaleX = maxTextureWidth / bounds.width;
 		}
 
 		if (maxTextureWidth != null && height > maxTextureHeight)
 		{
 			height = maxTextureHeight;
-			scaleY = maxTextureHeight / __bounds.height;
+			scaleY = maxTextureHeight / bounds.height;
 		}
 
 		var inverseA:Float;
@@ -2016,8 +2040,8 @@ import js.html.CanvasRenderingContext2D;
 		}
 		else
 		{
-			__renderTransform.a = width / __bounds.width;
-			__renderTransform.d = height / __bounds.height;
+			__renderTransform.a = width / bounds.width;
+			__renderTransform.d = height / bounds.height;
 			inverseA = (1 / __renderTransform.a);
 			inverseD = (1 / __renderTransform.d);
 		}
@@ -2028,8 +2052,8 @@ import js.html.CanvasRenderingContext2D;
 		__worldTransform.c = inverseD * parentTransform.c;
 		__worldTransform.d = inverseD * parentTransform.d;
 
-		var x = __bounds.x;
-		var y = __bounds.y;
+		var x = bounds.x;
+		var y = bounds.y;
 		var tx = x * parentTransform.a + y * parentTransform.c + parentTransform.tx;
 		var ty = x * parentTransform.b + y * parentTransform.d + parentTransform.ty;
 

--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -883,8 +883,9 @@ class CairoGraphics
 
 		bounds = graphics.__bounds;
 
-		var offsetX = bounds.x;
-		var offsetY = bounds.y;
+		var renderBounds = graphics.__softwareRenderBounds != null ? graphics.__softwareRenderBounds : bounds;
+		var offsetX = renderBounds.x;
+		var offsetY = renderBounds.y;
 
 		var positionX = 0.0;
 		var positionY = 0.0;
@@ -1843,7 +1844,7 @@ class CairoGraphics
 
 			if (!stroke && hasFill)
 			{
-				cairo.translate(-bounds.x, -bounds.y);
+				cairo.translate(-offsetX, -offsetY);
 
 				var inverseTranslateX = 0.0;
 				var inverseTranslateY = 0.0;
@@ -1909,7 +1910,7 @@ class CairoGraphics
 					cairo.scale(inverseScaleX, inverseScaleY);
 				}
 
-				cairo.translate(bounds.x, bounds.y);
+				cairo.translate(offsetX, offsetY);
 				cairo.closePath();
 			}
 		}
@@ -1944,7 +1945,7 @@ class CairoGraphics
 	}
 	#end
 
-	public static function render(graphics:Graphics, renderer:CairoRenderer):Void
+	public static function render(graphics:Graphics, renderer:CairoRenderer, renderBounds:Rectangle = null):Void
 	{
 		#if lime_cairo
 		CairoGraphics.graphics = graphics;
@@ -1957,7 +1958,8 @@ class CairoGraphics
 		var pixelRatio = renderer.__pixelRatio;
 		#end
 
-		graphics.__update(renderer.__worldTransform, pixelRatio);
+		graphics.__setSoftwareRenderBounds(renderBounds);
+		graphics.__update(renderer.__worldTransform, pixelRatio, renderBounds);
 
 		if (!graphics.__softwareDirty || graphics.__managed)
 		{

--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -1056,8 +1056,9 @@ class CanvasGraphics
 		#if (js && html5)
 		bounds = graphics.__bounds;
 
-		var offsetX = bounds.x;
-		var offsetY = bounds.y;
+		var renderBounds = graphics.__softwareRenderBounds != null ? graphics.__softwareRenderBounds : bounds;
+		var offsetX = renderBounds.x;
+		var offsetY = renderBounds.y;
 
 		var positionX = 0.0;
 		var positionY = 0.0;
@@ -2042,7 +2043,7 @@ class CanvasGraphics
 			{
 				if (hasFill || bitmapFill != null)
 				{
-					context.translate(-bounds.x, -bounds.y);
+					context.translate(-offsetX, -offsetY);
 
 					var inverseTranslateX = 0.0;
 					var inverseTranslateY = 0.0;
@@ -2091,7 +2092,7 @@ class CanvasGraphics
 						context.scale(inverseScaleX, inverseScaleY);
 					}
 
-					context.translate(bounds.x, bounds.y);
+					context.translate(offsetX, offsetY);
 					context.closePath();
 				}
 			}
@@ -2105,7 +2106,7 @@ class CanvasGraphics
 		#end
 	}
 
-	public static function render(graphics:Graphics, renderer:CanvasRenderer):Void
+	public static function render(graphics:Graphics, renderer:CanvasRenderer, renderBounds:Rectangle = null):Void
 	{
 		#if (js && html5)
 		CanvasGraphics.graphics = graphics;
@@ -2118,7 +2119,8 @@ class CanvasGraphics
 		var pixelRatio = renderer.__pixelRatio;
 		#end
 
-		graphics.__update(renderer.__worldTransform, pixelRatio);
+		graphics.__setSoftwareRenderBounds(renderBounds);
+		graphics.__update(renderer.__worldTransform, pixelRatio, renderBounds);
 
 		if (!graphics.__softwareDirty || graphics.__managed)
 		{

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -27,7 +27,9 @@ import openfl.display._internal.stats.DrawCallContext;
 @:access(openfl.display3D.Context3D)
 @:access(openfl.display.DisplayObject)
 @:access(openfl.display.Graphics)
+@:access(openfl.display.OpenGLRenderer)
 @:access(openfl.display.Shader)
+@:access(openfl.display.Stage)
 @:access(openfl.geom.ColorTransform)
 @:access(openfl.geom.Matrix)
 @:access(openfl.geom.Rectangle)
@@ -631,6 +633,81 @@ class Context3DGraphics
 		return true;
 	}
 
+	private static function getClippedRenderBounds(graphicsBounds:Rectangle, transform:Matrix, clipBounds:Rectangle):Rectangle
+	{
+		if ((transform.a * transform.d - transform.b * transform.c) == 0)
+		{
+			return null;
+		}
+
+		var inverseTransform = Matrix.__pool.get();
+		inverseTransform.copyFrom(transform);
+		inverseTransform.invert();
+		var renderBounds = Rectangle.__pool.get();
+		clipBounds.__transform(renderBounds, inverseTransform);
+		renderBounds.__contract(graphicsBounds.x, graphicsBounds.y, graphicsBounds.width, graphicsBounds.height);
+		if (renderBounds.width < 0) renderBounds.width = 0;
+		if (renderBounds.height < 0) renderBounds.height = 0;
+
+		Matrix.__pool.release(inverseTransform);
+
+		if (renderBounds.equals(graphicsBounds))
+		{
+			Rectangle.__pool.release(renderBounds);
+			return null;
+		}
+
+		return renderBounds;
+	}
+
+	private static function getSoftwareRenderBounds(graphics:Graphics, renderer:OpenGLRenderer):Rectangle
+	{
+		var graphicsBounds = graphics.__bounds;
+		if (graphicsBounds == null || graphics.__owner.__worldScale9Grid != null)
+		{
+			return null;
+		}
+
+		var clipBounds = Rectangle.__pool.get();
+		if (renderer.__stage != null && renderer.__defaultRenderTarget == null)
+		{
+			clipBounds.copyFrom(renderer.__stage.__displayRect);
+			if (renderer.__worldTransform != null)
+			{
+				var transformedClipBounds = Rectangle.__pool.get();
+				clipBounds.__transform(transformedClipBounds, renderer.__worldTransform);
+				clipBounds.copyFrom(transformedClipBounds);
+				Rectangle.__pool.release(transformedClipBounds);
+			}
+		}
+		else
+		{
+			var pixelRatio = renderer.__pixelRatio > 0 ? renderer.__pixelRatio : 1;
+			clipBounds.setTo(renderer.__offsetX / pixelRatio, renderer.__offsetY / pixelRatio, renderer.__displayWidth / pixelRatio,
+				renderer.__displayHeight / pixelRatio);
+		}
+
+		if (renderer.__numClipRects > 0)
+		{
+			var activeClipBounds = renderer.__clipRects[renderer.__numClipRects - 1];
+			clipBounds.__contract(activeClipBounds.x, activeClipBounds.y, activeClipBounds.width, activeClipBounds.height);
+			if (clipBounds.width < 0) clipBounds.width = 0;
+			if (clipBounds.height < 0) clipBounds.height = 0;
+		}
+
+		var transform = Matrix.__pool.get();
+		transform.copyFrom(graphics.__owner.__renderTransform);
+		if (renderer.__worldTransform != null)
+		{
+			transform.concat(renderer.__worldTransform);
+		}
+
+		var renderBounds = getClippedRenderBounds(graphicsBounds, transform, clipBounds);
+		Matrix.__pool.release(transform);
+		Rectangle.__pool.release(clipBounds);
+		return renderBounds;
+	}
+
 	public static function render(graphics:Graphics, renderer:OpenGLRenderer):Void
 	{
 		if (!graphics.__visible || graphics.__commands.length == 0) return;
@@ -666,11 +743,15 @@ class Context3DGraphics
 				renderer.__softwareRenderer.__worldTransform = renderer.__worldTransform;
 			}
 
+			var renderBounds = getSoftwareRenderBounds(graphics, renderer);
+
 			#if (js && html5)
-			CanvasGraphics.render(graphics, cast renderer.__softwareRenderer);
+			CanvasGraphics.render(graphics, cast renderer.__softwareRenderer, renderBounds);
 			#elseif lime_cairo
-			CairoGraphics.render(graphics, cast renderer.__softwareRenderer);
+			CairoGraphics.render(graphics, cast renderer.__softwareRenderer, renderBounds);
 			#end
+
+			if (renderBounds != null) Rectangle.__pool.release(renderBounds);
 
 			renderer.__softwareRenderer.__worldTransform = cacheTransform;
 		}

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -15,6 +15,7 @@ class Tests
 		runner.addCase(new GraphicsPathTest());
 		runner.addCase(new GraphicsPathWindingTest());
 		runner.addCase(new GraphicsSolidFillTest());
+		runner.addCase(new GraphicsSoftwareRenderBoundsTest());
 		runner.addCase(new GraphicsStrokeTest());
 		runner.addCase(new GraphicsTest());
 		runner.addCase(new InterpolationMethodTest());

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -15,7 +15,9 @@ class Tests
 		runner.addCase(new GraphicsPathTest());
 		runner.addCase(new GraphicsPathWindingTest());
 		runner.addCase(new GraphicsSolidFillTest());
+		#if !flash
 		runner.addCase(new GraphicsSoftwareRenderBoundsTest());
+		#end
 		runner.addCase(new GraphicsStrokeTest());
 		runner.addCase(new GraphicsTest());
 		runner.addCase(new InterpolationMethodTest());

--- a/tests/graphics/src/GraphicsSoftwareRenderBoundsTest.hx
+++ b/tests/graphics/src/GraphicsSoftwareRenderBoundsTest.hx
@@ -1,0 +1,108 @@
+package;
+
+import openfl.display.Shape;
+import openfl.display._internal.Context3DGraphics;
+import openfl.geom.Matrix;
+import openfl.geom.Rectangle;
+import utest.Assert;
+import utest.Test;
+
+@:access(openfl.display.Graphics)
+@:access(openfl.display._internal.Context3DGraphics)
+@:access(openfl.geom.Rectangle)
+class GraphicsSoftwareRenderBoundsTest extends Test
+{
+	public function testViewportIsClippedToGraphicsLocalBounds():Void
+	{
+		var graphicsBounds = new Rectangle(-10000, -10000, 21920, 21080);
+		var renderBounds = Context3DGraphics.getClippedRenderBounds(graphicsBounds, new Matrix(), new Rectangle(0, 0, 1920, 1080));
+
+		Assert.notNull(renderBounds);
+		Assert.equals(0, renderBounds.x);
+		Assert.equals(0, renderBounds.y);
+		Assert.equals(1920, renderBounds.width);
+		Assert.equals(1080, renderBounds.height);
+		Rectangle.__pool.release(renderBounds);
+	}
+
+	public function testViewportIsConvertedFromWorldToLocalCoordinates():Void
+	{
+		var graphicsBounds = new Rectangle(-100, -100, 200, 200);
+		var transform = new Matrix(2, 0, 0, 2, 10, 20);
+		var renderBounds = Context3DGraphics.getClippedRenderBounds(graphicsBounds, transform, new Rectangle(10, 20, 100, 50));
+
+		Assert.notNull(renderBounds);
+		Assert.equals(0, renderBounds.x);
+		Assert.equals(0, renderBounds.y);
+		Assert.equals(50, renderBounds.width);
+		Assert.equals(25, renderBounds.height);
+		Rectangle.__pool.release(renderBounds);
+	}
+
+	public function testUpscaledViewportUsesRendererCoordinates():Void
+	{
+		var graphicsBounds = new Rectangle(-10000, -10000, 21920, 21080);
+		var displayTransform = new Matrix(4 / 3, 0, 0, 4 / 3);
+		var logicalViewport = new Rectangle(0, 0, 1920, 1080);
+		var rendererViewport = new Rectangle();
+		logicalViewport.__transform(rendererViewport, displayTransform);
+
+		var renderBounds = Context3DGraphics.getClippedRenderBounds(graphicsBounds, displayTransform, rendererViewport);
+
+		Assert.notNull(renderBounds);
+		Assert.equals(0, renderBounds.x);
+		Assert.equals(0, renderBounds.y);
+		Assert.equals(1920, renderBounds.width);
+		Assert.equals(1080, renderBounds.height);
+		Rectangle.__pool.release(renderBounds);
+	}
+
+	public function testRenderBoundsLimitRasterSizeAndPreserveOrigin():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(-1000, -1000, 2000, 2000);
+		shape.graphics.endFill();
+
+		shape.graphics.__update(null, 1, new Rectangle(20, 30, 100, 50));
+
+		Assert.equals(101, shape.graphics.__width);
+		Assert.equals(51, shape.graphics.__height);
+		Assert.equals(20, shape.graphics.__worldTransform.tx);
+		Assert.equals(30, shape.graphics.__worldTransform.ty);
+	}
+
+	public function testEmptyRenderBoundsProduceNoRaster():Void
+	{
+		var shape = new Shape();
+		shape.graphics.beginFill(0xFF0000);
+		shape.graphics.drawRect(-1000, -1000, 2000, 2000);
+		shape.graphics.endFill();
+
+		shape.graphics.__update(null, 1, new Rectangle());
+
+		Assert.equals(0, shape.graphics.__width);
+		Assert.equals(0, shape.graphics.__height);
+	}
+
+	public function testChangedRenderBoundsInvalidateSoftwareRaster():Void
+	{
+		var shape = new Shape();
+		var bounds = new Rectangle(0, 0, 100, 100);
+
+		shape.graphics.__softwareDirty = false;
+		shape.graphics.__setSoftwareRenderBounds(bounds);
+		Assert.isTrue(shape.graphics.__softwareDirty);
+
+		shape.graphics.__softwareDirty = false;
+		shape.graphics.__setSoftwareRenderBounds(bounds);
+		Assert.isFalse(shape.graphics.__softwareDirty);
+
+		shape.graphics.__setSoftwareRenderBounds(new Rectangle(10, 0, 100, 100));
+		Assert.isTrue(shape.graphics.__softwareDirty);
+
+		shape.graphics.__softwareDirty = false;
+		shape.graphics.__setSoftwareRenderBounds(null);
+		Assert.isTrue(shape.graphics.__softwareDirty);
+	}
+}


### PR DESCRIPTION
## Problem

`Context3DGraphics` falls back to Cairo or Canvas when a `Graphics` instance
contains commands that are not supported by the hardware path.

The software renderer currently rasterizes the complete graphics bounds, even
when most of the geometry is outside the visible viewport. Large transparent
or otherwise invisible geometry can therefore create an enormous intermediate
surface and increase memory usage by one or more GiB.

This differs significantly from Flash, where the same content does not require
a full-size offscreen allocation.

## Fix

This PR limits software-rendered graphics to the intersection of:

- the graphics bounds
- the visible renderer viewport
- the active clip rectangle, when present

The renderer-space clipping bounds are converted back to the graphics local
coordinate space before rasterization. The resulting origin is preserved when
the bitmap is rendered, and the software cache is invalidated whenever its
clipped bounds change.

Graphics using scale9 grids retain the previous behavior because their
coordinate transformations require separate handling.

## Reproduction
[OpenFLContext3DSoftwareFallbackClippingRepro.zip](https://github.com/user-attachments/files/30249787/OpenFLContext3DSoftwareFallbackClippingRepro.zip)

It creates a single `Graphics` instance containing:

- a transparent `21920 × 21080` outlined rectangle that forces the software
  fallback
- a visible panel confirming that the same graphics instance rendered
  successfully

Before this change, OpenFL attempts to allocate a software surface covering the
complete graphics bounds, causing a very large memory increase and potentially
a slow or failed startup.

After this change, the software surface is limited to the visible viewport and
memory usage remains bounded by the window size.

## Testing

The graphics test suite passes with:

- 90 assertions
- 84 successes
- 0 errors
- 0 failures

Additional coverage verifies:

- clipping to local graphics bounds
- transformed viewports
- empty intersections
- preservation of the raster origin
- software-cache invalidation when clipping bounds change