### PR TITLE
Allocate Graphics shader fill state lazily

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -110,15 +110,12 @@ import js.html.CanvasRenderingContext2D;
 		__positionX = 0;
 		__positionY = 0;
 		__renderTransform = new Matrix();
-		__usedShaderBuffers = new List<ShaderBuffer>();
 		__worldTransform = new Matrix();
 		__width = 0;
 		__height = 0;
 
 		__bitmapScaleX = 1;
 		__bitmapScaleY = 1;
-
-		__shaderBufferPool = new ObjectPool<ShaderBuffer>(function() return new ShaderBuffer());
 
 		#if (js && html5)
 		moveTo(0, 0);
@@ -393,6 +390,12 @@ import js.html.CanvasRenderingContext2D;
 		if (shader != null)
 		{
 			#if lime
+			if (__shaderBufferPool == null)
+			{
+				__shaderBufferPool = new ObjectPool<ShaderBuffer>(function() return new ShaderBuffer());
+				__usedShaderBuffers = new List<ShaderBuffer>();
+			}
+
 			var shaderBuffer = __shaderBufferPool.get();
 			__usedShaderBuffers.add(shaderBuffer);
 			shaderBuffer.update(cast shader);
@@ -410,13 +413,17 @@ import js.html.CanvasRenderingContext2D;
 	public function clear():Void
 	{
 		#if lime
-		for (shaderBuffer in __usedShaderBuffers)
+		if (__usedShaderBuffers != null)
 		{
-			__shaderBufferPool.release(shaderBuffer);
+			for (shaderBuffer in __usedShaderBuffers)
+			{
+				__shaderBufferPool.release(shaderBuffer);
+			}
+
+			__usedShaderBuffers.clear();
 		}
 		#end
 
-		__usedShaderBuffers.clear();
 		__commands.clear();
 		__strokePadding = 0;
 

--- a/tests/graphics/src/GraphicsTest.hx
+++ b/tests/graphics/src/GraphicsTest.hx
@@ -4,12 +4,16 @@ import openfl.display.Bitmap;
 import openfl.display.BitmapData;
 import openfl.display.GradientType;
 import openfl.display.Graphics;
+import openfl.display.GraphicsShader;
 import openfl.display.Shape;
 import openfl.display.Sprite;
 import openfl.geom.Matrix;
 import utest.Assert;
 import utest.Test;
 
+#if !flash
+@:access(openfl.display.Graphics)
+#end
 class GraphicsTest extends Test
 {
 	public function test_new_()
@@ -20,6 +24,45 @@ class GraphicsTest extends Test
 		var graphics = shape.graphics;
 
 		Assert.notNull(graphics);
+	}
+
+	public function testShaderStateIsLazy()
+	{
+		#if !flash
+		var graphics = new Shape().graphics;
+
+		Assert.isNull(graphics.__shaderBufferPool);
+		Assert.isNull(graphics.__usedShaderBuffers);
+
+		graphics.clear();
+
+		Assert.isNull(graphics.__shaderBufferPool);
+		Assert.isNull(graphics.__usedShaderBuffers);
+		#end
+	}
+
+	public function testBeginShaderFillInitializesShaderState()
+	{
+		#if (lime && !flash)
+		var graphics = new Shape().graphics;
+
+		graphics.beginShaderFill(new GraphicsShader());
+
+		Assert.notNull(graphics.__shaderBufferPool);
+		Assert.notNull(graphics.__usedShaderBuffers);
+		Assert.equals(1, graphics.__usedShaderBuffers.length);
+
+		var shaderBufferPool = graphics.__shaderBufferPool;
+		graphics.clear();
+
+		Assert.equals(shaderBufferPool, graphics.__shaderBufferPool);
+		Assert.equals(0, graphics.__usedShaderBuffers.length);
+
+		graphics.beginShaderFill(new GraphicsShader());
+
+		Assert.equals(shaderBufferPool, graphics.__shaderBufferPool);
+		Assert.equals(1, graphics.__usedShaderBuffers.length);
+		#end
 	}
 
 	#if flash

--- a/tests/graphics/src/GraphicsTest.hx
+++ b/tests/graphics/src/GraphicsTest.hx
@@ -4,7 +4,9 @@ import openfl.display.Bitmap;
 import openfl.display.BitmapData;
 import openfl.display.GradientType;
 import openfl.display.Graphics;
+#if (lime && !flash)
 import openfl.display.GraphicsShader;
+#end
 import openfl.display.Shape;
 import openfl.display.Sprite;
 import openfl.geom.Matrix;
@@ -26,9 +28,9 @@ class GraphicsTest extends Test
 		Assert.notNull(graphics);
 	}
 
+	#if !flash
 	public function testShaderStateIsLazy()
 	{
-		#if !flash
 		var graphics = new Shape().graphics;
 
 		Assert.isNull(graphics.__shaderBufferPool);
@@ -38,12 +40,12 @@ class GraphicsTest extends Test
 
 		Assert.isNull(graphics.__shaderBufferPool);
 		Assert.isNull(graphics.__usedShaderBuffers);
-		#end
 	}
+	#end
 
+	#if (lime && !flash)
 	public function testBeginShaderFillInitializesShaderState()
 	{
-		#if (lime && !flash)
 		var graphics = new Shape().graphics;
 
 		graphics.beginShaderFill(new GraphicsShader());
@@ -62,8 +64,8 @@ class GraphicsTest extends Test
 
 		Assert.equals(shaderBufferPool, graphics.__shaderBufferPool);
 		Assert.equals(1, graphics.__usedShaderBuffers.length);
-		#end
 	}
+	#end
 
 	#if flash
 	@Ignored


### PR DESCRIPTION
## Summary

- Allocate the shader buffer pool and used-buffer list only when
  `beginShaderFill()` is first called
- Keep the pool and its buffers reusable across `clear()` calls
- Allow `clear()` to be called before shader state has been initialized
- Add tests for lazy initialization and shader buffer reuse

## Motivation

Every `Graphics` instance currently creates shader-fill bookkeeping eagerly,
even if it only uses ordinary solid, bitmap, or gradient fills.

This includes an `ObjectPool`, its internal `ObjectMap` and `List`, and a second
`List` used to track active shader buffers. Applications that retain many
ordinary `Graphics` instances therefore retain several unused managed objects
per instance, increasing both memory usage and the object graph visited by the
GC.

## Repro
[OpenFLGraphicsShaderStateMemoryRepro.zip](https://github.com/user-attachments/files/30394790/OpenFLGraphicsShaderStateMemoryRepro.zip)
It creates and retains 100,000 ordinary `Graphics`
instances without calling `beginShaderFill()`.

Results on Linux x86_64 with Haxe 4.3.6:

| Metric | Before | After |
|---|---:|---:|
| Allocation time | 144–155 ms | 129–136 ms |
| Retained hxcpp heap | 156.0 MiB | 132.4 MiB |
| First full GC | 26–28 ms | 19–27 ms |
| Median compacting GC | 51–52 ms | 39–42 ms |

## Real-world observation

These values should be considered indicative rather than a controlled benchmark.

| Class | Before | After |
|---|---:|---:|
| `openfl.display.Graphics` | 11,920 | 12,650 |
| `lime.utils.ObjectPool` | 12,002 | 70 |
| `haxe.ds.List` | 23,924 | 72 |

## Tests

The OpenFL graphics test suite passes on Neko and C++.