### PR TITLE
Allocate Graphics render transforms lazily

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -109,9 +109,7 @@ import js.html.CanvasRenderingContext2D;
 		__strokePadding = 0;
 		__positionX = 0;
 		__positionY = 0;
-		__renderTransform = new Matrix();
 		__usedShaderBuffers = new List<ShaderBuffer>();
-		__worldTransform = new Matrix();
 		__width = 0;
 		__height = 0;
 
@@ -2006,6 +2004,16 @@ import js.html.CanvasRenderingContext2D;
 
 		var inverseA:Float;
 		var inverseD:Float;
+
+		if (__renderTransform == null)
+		{
+			__renderTransform = new Matrix();
+		}
+
+		if (__worldTransform == null)
+		{
+			__worldTransform = new Matrix();
+		}
 
 		if (__owner.__worldScale9Grid != null)
 		{

--- a/tests/graphics/src/GraphicsTest.hx
+++ b/tests/graphics/src/GraphicsTest.hx
@@ -10,6 +10,7 @@ import openfl.geom.Matrix;
 import utest.Assert;
 import utest.Test;
 
+@:access(openfl.display.Graphics)
 class GraphicsTest extends Test
 {
 	public function test_new_()
@@ -22,6 +23,32 @@ class GraphicsTest extends Test
 		Assert.notNull(graphics);
 	}
 
+	#if !flash
+	public function testRenderStateIsLazy()
+	{
+		var graphics = new Shape().graphics;
+
+		Assert.isNull(graphics.__renderTransform);
+		Assert.isNull(graphics.__worldTransform);
+
+		graphics.clear();
+
+		Assert.isNull(graphics.__renderTransform);
+		Assert.isNull(graphics.__worldTransform);
+	}
+
+	public function testUpdateInitializesRenderState()
+	{
+		var graphics = new Shape().graphics;
+
+		graphics.beginFill(0xFF0000);
+		graphics.drawRect(0, 0, 100, 100);
+		graphics.__update(new Matrix(), 1);
+
+		Assert.notNull(graphics.__renderTransform);
+		Assert.notNull(graphics.__worldTransform);
+	}
+	#end
 	#if flash
 	@Ignored
 	#end


### PR DESCRIPTION
## Summary
`Graphics` eagerly allocates `__renderTransform` and `__worldTransform` in its constructor, even when the graphics object is never rendered.

This changes both matrices to be allocated during the first non-empty `__update()` instead. Empty or cleared graphics therefore keep their render state unallocated.

The allocation happens after the existing zero-size early return and before the first matrix access.

## Tests

Added coverage verifying that:

- newly created or cleared `Graphics` instances keep both matrices null;
- drawing renderable content and calling `__update()` initializes both matrices.

The Graphics test suite passes on Neko and C++ with 71 assertions on each target.

## Real-world observation

These values should be considered indicative rather than a controlled benchmark.

| | Before | After |
|---|---:|---:|
| Live `Graphics` | 11,503 | 11,519 |
| Live `Matrix` | 92,659 | 76,648 |

This removed 16,011 live `Matrix` instances (-17.3%), representing approximately 1 MiB of shallow object size. Similar checkpoints showed reductions of roughly 13,000 to 19,000 matrices.

The total GC-time difference was small and within expected run-to-run variance.