### PR TITLE
Allocate DisplayObject render transforms lazily

### DIFF
--- a/src/openfl/display/CairoRenderer.hx
+++ b/src/openfl/display/CairoRenderer.hx
@@ -183,6 +183,7 @@ class CairoRenderer extends DisplayObjectRenderer
 	@:noCompletion private function __renderDrawable(object:IBitmapDrawable):Void
 	{
 		if (object == null) return;
+		if (object.__drawableType != BITMAP_DATA) __ensureRenderTransform(cast object);
 
 		switch (object.__drawableType)
 		{
@@ -209,6 +210,7 @@ class CairoRenderer extends DisplayObjectRenderer
 	@:noCompletion private function __renderDrawableMask(object:IBitmapDrawable):Void
 	{
 		if (object == null) return;
+		if (object.__drawableType != BITMAP_DATA) __ensureRenderTransform(cast object);
 
 		switch (object.__drawableType)
 		{

--- a/src/openfl/display/CanvasRenderer.hx
+++ b/src/openfl/display/CanvasRenderer.hx
@@ -187,6 +187,7 @@ class CanvasRenderer extends DisplayObjectRenderer
 	@:noCompletion private function __renderDrawable(object:IBitmapDrawable):Void
 	{
 		if (object == null) return;
+		if (object.__drawableType != BITMAP_DATA) __ensureRenderTransform(cast object);
 
 		switch (object.__drawableType)
 		{
@@ -213,6 +214,7 @@ class CanvasRenderer extends DisplayObjectRenderer
 	@:noCompletion private function __renderDrawableMask(object:IBitmapDrawable):Void
 	{
 		if (object == null) return;
+		if (object.__drawableType != BITMAP_DATA) __ensureRenderTransform(cast object);
 
 		switch (object.__drawableType)
 		{

--- a/src/openfl/display/DOMRenderer.hx
+++ b/src/openfl/display/DOMRenderer.hx
@@ -305,6 +305,7 @@ class DOMRenderer extends DisplayObjectRenderer
 	@:noCompletion private function __renderDrawable(object:IBitmapDrawable):Void
 	{
 		if (object == null) return;
+		if (object.__drawableType != BITMAP_DATA) __ensureRenderTransform(cast object);
 
 		switch (object.__drawableType)
 		{

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1143,9 +1143,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 		__worldAlpha = 1;
 		__worldBlendMode = NORMAL;
-		__worldTransform = new Matrix();
 		__worldColorTransform = new ColorTransform();
-		__renderTransform = new Matrix();
 		__worldVisible = true;
 
 		name = "instance" + (++__instanceCount);
@@ -1666,7 +1664,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 	@:noCompletion private function __getWorldTransform():Matrix
 	{
-		var transformDirty = __transformDirty || __worldTransformInvalid;
+		var transformDirty = __transformDirty || __worldTransformInvalid || __worldTransform == null || __renderTransform == null;
 
 		if (transformDirty)
 		{

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1677,12 +1677,17 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 			}
 			else
 			{
-				while (current != stage)
+				// Include Stage: lazy transforms must be initialized before children combine against them.
+				while (current != null)
 				{
 					list.push(current);
-					current = current.parent;
 
-					if (current == null) break;
+					if (current == stage)
+					{
+						break;
+					}
+
+					current = current.parent;
 				}
 			}
 
@@ -1967,6 +1972,11 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 		if (!overrided && parent != null)
 		{
+			if (parent.__worldTransform == null)
+			{
+				parent.__updateTransforms();
+			}
+
 			__calculateAbsoluteTransform(local, parent.__worldTransform, __worldTransform);
 		}
 		else
@@ -1976,6 +1986,11 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if (open
 
 		if (!overrided && renderParent != null)
 		{
+			if (renderParent.__renderTransform == null)
+			{
+				renderParent.__updateTransforms();
+			}
+
 			__calculateAbsoluteTransform(local, renderParent.__renderTransform, __renderTransform);
 		}
 		else

--- a/src/openfl/display/DisplayObjectRenderer.hx
+++ b/src/openfl/display/DisplayObjectRenderer.hx
@@ -71,9 +71,24 @@ class DisplayObjectRenderer extends EventDispatcher
 
 	@:noCompletion private function __clear():Void {}
 
+	@:noCompletion private function __createCacheBitmap():Bitmap
+	{
+		var bitmap = new Bitmap();
+		__ensureRenderTransform(bitmap);
+		return bitmap;
+	}
+
 	@:noCompletion private function __getAlpha(value:Float):Float
 	{
 		return value * __worldAlpha;
+	}
+
+	@:noCompletion private inline function __ensureRenderTransform(displayObject:DisplayObject):Void
+	{
+		if (displayObject.__worldTransform == null || displayObject.__renderTransform == null)
+		{
+			displayObject.__getWorldTransform();
+		}
 	}
 
 	@:noCompletion private function __getColorTransform(value:ColorTransform):ColorTransform
@@ -430,7 +445,10 @@ class DisplayObjectRenderer extends EventDispatcher
 					{
 						displayObject.__cacheBitmapData = new BitmapData(bitmapWidth, bitmapHeight, true, bitmapColor);
 
-						if (displayObject.__cacheBitmap == null) displayObject.__cacheBitmap = new Bitmap();
+						if (displayObject.__cacheBitmap == null)
+						{
+							displayObject.__cacheBitmap = __createCacheBitmap();
+						}
 						displayObject.__cacheBitmap.__bitmapData = displayObject.__cacheBitmapData;
 						displayObject.__cacheBitmapRenderer = null;
 					}

--- a/src/openfl/display/OpenGLRenderer.hx
+++ b/src/openfl/display/OpenGLRenderer.hx
@@ -871,6 +871,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private function __renderDrawable(object:IBitmapDrawable):Void
 	{
 		if (object == null) return;
+		if (object.__drawableType != BITMAP_DATA) __ensureRenderTransform(cast object);
 
 		switch (object.__drawableType)
 		{
@@ -897,6 +898,7 @@ class OpenGLRenderer extends DisplayObjectRenderer
 	@:noCompletion private function __renderDrawableMask(object:IBitmapDrawable):Void
 	{
 		if (object == null) return;
+		if (object.__drawableType != BITMAP_DATA) __ensureRenderTransform(cast object);
 
 		switch (object.__drawableType)
 		{

--- a/src/openfl/display/Sprite.hx
+++ b/src/openfl/display/Sprite.hx
@@ -287,7 +287,7 @@ class Sprite extends DisplayObjectContainer
 	#end
 	@:noCompletion private function __bind(library:AssetLibrary, className:String):Void
 	{
-		if (__worldTransform == null) // super() has not been called
+		if (__worldColorTransform == null) // super() has not been called
 		{
 			__pendingBindLibrary = library;
 			__pendingBindClassName = className;

--- a/tests/displayobject/src/DisplayObjectTest.hx
+++ b/tests/displayobject/src/DisplayObjectTest.hx
@@ -47,6 +47,28 @@ class DisplayObjectTest extends Test
 		Assert.notNull(child.__worldTransform);
 	}
 
+	public function testUpdateTransformsInitializesNullParentTransforms()
+	{
+		var parent = new Sprite();
+		var child = new Sprite();
+		parent.x = 10;
+		child.x = 5;
+		parent.addChild(child);
+
+		// Parent may still have lazily-null transforms (e.g. Stage before first render).
+		parent.__worldTransform = null;
+		parent.__renderTransform = null;
+
+		child.__updateTransforms();
+
+		Assert.notNull(parent.__worldTransform);
+		Assert.notNull(parent.__renderTransform);
+		Assert.notNull(child.__worldTransform);
+		Assert.notNull(child.__renderTransform);
+		Assert.equals(15, child.__worldTransform.tx);
+		Assert.equals(0, child.__worldTransform.ty);
+	}
+
 	public function testRendererInitializesRenderStateBeforeRendering()
 	{
 		var renderer = new TestDisplayObjectRenderer();

--- a/tests/displayobject/src/DisplayObjectTest.hx
+++ b/tests/displayobject/src/DisplayObjectTest.hx
@@ -3,6 +3,8 @@ package;
 import openfl.display.Bitmap;
 import openfl.display.BitmapData;
 import openfl.display.BlendMode;
+import openfl.display.DisplayObject;
+import openfl.display.DisplayObjectRenderer;
 import openfl.display.Sprite;
 import openfl.filters.BitmapFilter;
 import openfl.filters.DropShadowFilter;
@@ -15,8 +17,57 @@ import openfl.Lib;
 import utest.Assert;
 import utest.Test;
 
+@:access(openfl.display.DisplayObject)
 class DisplayObjectTest extends Test
 {
+	#if !flash
+	public function testRenderStateIsLazy()
+	{
+		var sprite = new Sprite();
+
+		Assert.isNull(sprite.__renderTransform);
+		Assert.isNull(sprite.__worldTransform);
+	}
+
+	public function testCoordinateConversionInitializesRenderState()
+	{
+		var parent = new Sprite();
+		var child = new Sprite();
+		parent.x = 10;
+		child.x = 5;
+		parent.addChild(child);
+
+		var global = child.localToGlobal(new Point());
+
+		Assert.equals(15, global.x);
+		Assert.equals(0, global.y);
+		Assert.notNull(parent.__renderTransform);
+		Assert.notNull(parent.__worldTransform);
+		Assert.notNull(child.__renderTransform);
+		Assert.notNull(child.__worldTransform);
+	}
+
+	public function testRendererInitializesRenderStateBeforeRendering()
+	{
+		var renderer = new TestDisplayObjectRenderer();
+		var sprite = new Sprite();
+
+		renderer.ensureRenderTransform(sprite);
+
+		Assert.notNull(sprite.__renderTransform);
+		Assert.notNull(sprite.__worldTransform);
+	}
+
+	public function testCacheBitmapInitializesRenderState()
+	{
+		var renderer = new TestDisplayObjectRenderer();
+		var bitmap = renderer.createCacheBitmap();
+
+		Assert.notNull(bitmap.__renderTransform);
+		Assert.notNull(bitmap.__worldTransform);
+	}
+	#end
+
 	public function test_getBounds()
 	{
 		var sprite = new Sprite();
@@ -862,3 +913,24 @@ class DisplayObjectTest extends Test
 
 	// public function test_z() {}
 }
+
+#if !flash
+@:access(openfl.display.DisplayObjectRenderer)
+private class TestDisplayObjectRenderer extends DisplayObjectRenderer
+{
+	public function new()
+	{
+		super();
+	}
+
+	public function createCacheBitmap():Bitmap
+	{
+		return __createCacheBitmap();
+	}
+
+	public function ensureRenderTransform(object:DisplayObject):Void
+	{
+		__ensureRenderTransform(object);
+	}
+}
+#end


### PR DESCRIPTION
## Summary
`DisplayObject` eagerly allocates `__worldTransform` and `__renderTransform` in its constructor, even when the object is never updated or rendered.

This removes those eager allocations and lets the existing transform update path create the matrices when they are first needed.

Additional safeguards handle objects that reach a renderer before their first display-list update, including objects added between the update and render phases. Internal cache bitmaps are also initialized before their transform matrices are accessed.

The constructor-state check used by `Sprite.__bind()` now relies on `__worldColorTransform`, since a null world matrix is valid after construction.

## Tests

Added coverage verifying that:

- newly created display objects keep both matrices null;
- coordinate conversion initializes the complete parent chain;
- rendering an object before its first update initializes its transforms;
- internal cache bitmaps are created with usable transform state.

The display object test suite passes on Neko and C++ with 1,475 assertions on each target.

## Real-world observation

These values should be considered indicative rather than a controlled benchmark.

| Approximate checkpoint | Before | After | Difference |
|---|---:|---:|---:|
| 160 seconds | 60,643 matrices | 43,647 matrices | -16,996 (-28.0%) |
| 400 seconds | 76,648 matrices | 54,009 matrices | -22,639 (-29.5%) |

The later checkpoint represents approximately 1.38 MiB less shallow `Matrix` object memory.

Total GC time remained effectively unchanged in these runs (0.812% before and 0.807% after).