### PR TITLE
Allocate DrawCommandBuffer streams independently

### DIFF
--- a/src/openfl/display/_internal/DrawCommandBuffer.hx
+++ b/src/openfl/display/_internal/DrawCommandBuffer.hx
@@ -21,13 +21,22 @@ import openfl.Vector;
 @SuppressWarnings("checkstyle:FieldDocComment")
 class DrawCommandBuffer
 {
+	private static inline var COW_TYPES:Int = 1;
+	private static inline var COW_B:Int = 2;
+	private static inline var COW_I:Int = 4;
+	private static inline var COW_F:Int = 8;
+	private static inline var COW_O:Int = 16;
+	private static inline var COW_FF:Int = 32;
+	private static inline var COW_II:Int = 64;
+	private static inline var COW_ALL:Int = COW_TYPES | COW_B | COW_I | COW_F | COW_O | COW_FF | COW_II;
+
 	private static var empty:DrawCommandBuffer = new DrawCommandBuffer();
 
 	public var length(get, never):Int;
 	public var types:Array<DrawCommandType>;
 
 	private var b:Array<Bool>;
-	private var copyOnWrite:Bool;
+	private var copyOnWrite:Int;
 	private var f:Array<Float>;
 	private var ff:Array<Array<Float>>;
 	private var i:Array<Int>;
@@ -47,7 +56,7 @@ class DrawCommandBuffer
 			ff = [];
 			ii = [];
 
-			copyOnWrite = true;
+			copyOnWrite = COW_ALL;
 		}
 		else
 		{
@@ -66,7 +75,7 @@ class DrawCommandBuffer
 			this.o = other.o;
 			this.ff = other.ff;
 			this.ii = other.ii;
-			this.copyOnWrite = other.copyOnWrite = true;
+			this.copyOnWrite = other.copyOnWrite = COW_ALL;
 
 			return other;
 		}
@@ -150,7 +159,7 @@ class DrawCommandBuffer
 
 	public function beginBitmapFill(bitmap:BitmapData, matrix:Matrix, repeat:Bool, smooth:Bool):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O | COW_B);
 
 		types.push(BEGIN_BITMAP_FILL);
 		o.push(bitmap);
@@ -178,7 +187,7 @@ class DrawCommandBuffer
 
 	public function beginFill(color:Int, alpha:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_I | COW_F);
 
 		types.push(BEGIN_FILL);
 		i.push(color);
@@ -188,7 +197,7 @@ class DrawCommandBuffer
 	public function beginGradientFill(type:GradientType, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, matrix:Matrix, spreadMethod:SpreadMethod,
 			interpolationMethod:InterpolationMethod, focalPointRatio:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O | COW_II | COW_FF | COW_F);
 
 		types.push(BEGIN_GRADIENT_FILL);
 		o.push(type);
@@ -220,7 +229,7 @@ class DrawCommandBuffer
 
 	public function beginShaderFill(shaderBuffer:ShaderBuffer):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O);
 
 		types.push(BEGIN_SHADER_FILL);
 		o.push(shaderBuffer);
@@ -237,7 +246,7 @@ class DrawCommandBuffer
 		ff = empty.ff;
 		ii = empty.ii;
 
-		copyOnWrite = true;
+		copyOnWrite = COW_ALL;
 	}
 
 	public function copy():DrawCommandBuffer
@@ -249,7 +258,7 @@ class DrawCommandBuffer
 
 	public function cubicCurveTo(controlX1:Float, controlY1:Float, controlX2:Float, controlY2:Float, anchorX:Float, anchorY:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F);
 
 		types.push(CUBIC_CURVE_TO);
 		f.push(controlX1);
@@ -262,7 +271,7 @@ class DrawCommandBuffer
 
 	public function curveTo(controlX:Float, controlY:Float, anchorX:Float, anchorY:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F);
 
 		types.push(CURVE_TO);
 		f.push(controlX);
@@ -287,7 +296,7 @@ class DrawCommandBuffer
 
 	public function drawCircle(x:Float, y:Float, radius:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F);
 
 		types.push(DRAW_CIRCLE);
 		f.push(x);
@@ -297,7 +306,7 @@ class DrawCommandBuffer
 
 	public function drawEllipse(x:Float, y:Float, width:Float, height:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F);
 
 		types.push(DRAW_ELLIPSE);
 		f.push(x);
@@ -308,7 +317,7 @@ class DrawCommandBuffer
 
 	public function drawQuads(rects:Vector<Float>, indices:Vector<Int>, transforms:Vector<Float>):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O);
 
 		types.push(DRAW_QUADS);
 		o.push(rects);
@@ -318,7 +327,7 @@ class DrawCommandBuffer
 
 	public function drawRect(x:Float, y:Float, width:Float, height:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F);
 
 		types.push(DRAW_RECT);
 		f.push(x);
@@ -329,7 +338,7 @@ class DrawCommandBuffer
 
 	public function drawRoundRect(x:Float, y:Float, width:Float, height:Float, ellipseWidth:Float, ellipseHeight:Null<Float>):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F | COW_O);
 
 		types.push(DRAW_ROUND_RECT);
 		f.push(x);
@@ -342,7 +351,7 @@ class DrawCommandBuffer
 
 	public function drawTriangles(vertices:Vector<Float>, indices:Vector<Int>, uvtData:Vector<Float>, culling:TriangleCulling):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O);
 
 		types.push(DRAW_TRIANGLES);
 		o.push(vertices);
@@ -353,14 +362,14 @@ class DrawCommandBuffer
 
 	public function endFill():Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES);
 
 		types.push(END_FILL);
 	}
 
 	public function lineBitmapStyle(bitmap:BitmapData, matrix:Matrix, repeat:Bool, smooth:Bool):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O | COW_B);
 
 		types.push(LINE_BITMAP_STYLE);
 		o.push(bitmap);
@@ -389,7 +398,7 @@ class DrawCommandBuffer
 	public function lineGradientStyle(type:GradientType, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, matrix:Matrix, spreadMethod:SpreadMethod,
 			interpolationMethod:InterpolationMethod, focalPointRatio:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O | COW_II | COW_FF | COW_F);
 
 		types.push(LINE_GRADIENT_STYLE);
 		o.push(type);
@@ -422,7 +431,7 @@ class DrawCommandBuffer
 	public function lineStyle(thickness:Null<Float>, color:Int, alpha:Float, pixelHinting:Bool, scaleMode:LineScaleMode, caps:CapsStyle, joints:JointStyle,
 			miterLimit:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O | COW_I | COW_F | COW_B);
 
 		types.push(LINE_STYLE);
 		o.push(thickness);
@@ -437,7 +446,7 @@ class DrawCommandBuffer
 
 	public function lineTo(x:Float, y:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F);
 
 		types.push(LINE_TO);
 		f.push(x);
@@ -446,32 +455,32 @@ class DrawCommandBuffer
 
 	public function moveTo(x:Float, y:Float):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_F);
 
 		types.push(MOVE_TO);
 		f.push(x);
 		f.push(y);
 	}
 
-	private function prepareWrite():Void
+	private function prepareWrite(mask:Int):Void
 	{
-		if (copyOnWrite)
+		if ((copyOnWrite & mask) != 0)
 		{
-			types = types.copy();
-			b = b.copy();
-			i = i.copy();
-			f = f.copy();
-			o = o.copy();
-			ff = ff.copy();
-			ii = ii.copy();
+			if ((copyOnWrite & COW_TYPES) != 0 && (mask & COW_TYPES) != 0) types = types.copy();
+			if ((copyOnWrite & COW_B) != 0 && (mask & COW_B) != 0) b = b.copy();
+			if ((copyOnWrite & COW_I) != 0 && (mask & COW_I) != 0) i = i.copy();
+			if ((copyOnWrite & COW_F) != 0 && (mask & COW_F) != 0) f = f.copy();
+			if ((copyOnWrite & COW_O) != 0 && (mask & COW_O) != 0) o = o.copy();
+			if ((copyOnWrite & COW_FF) != 0 && (mask & COW_FF) != 0) ff = ff.copy();
+			if ((copyOnWrite & COW_II) != 0 && (mask & COW_II) != 0) ii = ii.copy();
 
-			copyOnWrite = false;
+			copyOnWrite &= ~mask;
 		}
 	}
 
 	public function overrideBlendMode(blendMode:BlendMode):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O);
 
 		types.push(OVERRIDE_BLEND_MODE);
 		o.push(blendMode);
@@ -479,7 +488,7 @@ class DrawCommandBuffer
 
 	public function overrideMatrix(matrix:Matrix):Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES | COW_O);
 
 		types.push(OVERRIDE_MATRIX);
 		if (matrix != null)
@@ -504,14 +513,14 @@ class DrawCommandBuffer
 
 	public function windingEvenOdd():Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES);
 
 		types.push(WINDING_EVEN_ODD);
 	}
 
 	public function windingNonZero():Void
 	{
-		prepareWrite();
+		prepareWrite(COW_TYPES);
 
 		types.push(WINDING_NON_ZERO);
 	}

--- a/tests/graphics/Tests.hx
+++ b/tests/graphics/Tests.hx
@@ -7,6 +7,9 @@ class Tests
 	{
 		var runner = new Runner();
 		runner.addCase(new CapsStyleTest());
+		#if !flash
+		runner.addCase(new DrawCommandBufferTest());
+		#end
 		runner.addCase(new GradientTypeTest());
 		runner.addCase(new GraphicsBitmapFillTest());
 		runner.addCase(new GraphicsEndFillTest());

--- a/tests/graphics/src/DrawCommandBufferTest.hx
+++ b/tests/graphics/src/DrawCommandBufferTest.hx
@@ -1,0 +1,89 @@
+package;
+
+#if !flash
+import openfl.display.GradientType;
+import openfl.display.InterpolationMethod;
+import openfl.display.SpreadMethod;
+import openfl.display._internal.DrawCommandBuffer;
+import utest.Assert;
+import utest.Test;
+
+@:access(openfl.display._internal.DrawCommandBuffer)
+class DrawCommandBufferTest extends Test
+{
+	public function testStorageIsAllocatedOnlyWhenUsed()
+	{
+		var empty = new DrawCommandBuffer();
+		var commands = new DrawCommandBuffer();
+
+		commands.beginFill(0xFF0000, 1);
+
+		Assert.isFalse(commands.types == empty.types);
+		Assert.isFalse(commands.i == empty.i);
+		Assert.isFalse(commands.f == empty.f);
+		Assert.isTrue(commands.b == empty.b);
+		Assert.isTrue(commands.o == empty.o);
+		Assert.isTrue(commands.ff == empty.ff);
+		Assert.isTrue(commands.ii == empty.ii);
+
+		commands.beginBitmapFill(null, null, true, false);
+
+		Assert.isFalse(commands.b == empty.b);
+		Assert.isFalse(commands.o == empty.o);
+		Assert.isTrue(commands.ff == empty.ff);
+		Assert.isTrue(commands.ii == empty.ii);
+
+		commands.beginGradientFill(GradientType.LINEAR, [0], [1], [0], null, SpreadMethod.PAD, InterpolationMethod.RGB, 0);
+
+		Assert.isFalse(commands.ff == empty.ff);
+		Assert.isFalse(commands.ii == empty.ii);
+	}
+
+	public function testCopyOnWriteIsIndependentPerStorage()
+	{
+		var source = new DrawCommandBuffer();
+		source.beginFill(0xFF0000, 1);
+		source.drawRect(0, 0, 10, 10);
+
+		var copy = source.copy();
+
+		Assert.isTrue(source.types == copy.types);
+		Assert.isTrue(source.i == copy.i);
+		Assert.isTrue(source.f == copy.f);
+
+		copy.lineTo(20, 20);
+
+		Assert.isFalse(source.types == copy.types);
+		Assert.isTrue(source.i == copy.i);
+		Assert.isFalse(source.f == copy.f);
+		Assert.equals(2, source.length);
+		Assert.equals(3, copy.length);
+
+		source.beginFill(0x00FF00, 0.5);
+
+		Assert.isFalse(source.i == copy.i);
+		Assert.equals(2, source.i.length);
+		Assert.equals(1, copy.i.length);
+		Assert.equals(3, source.length);
+		Assert.equals(3, copy.length);
+	}
+
+	public function testClearRestoresLazyStorage()
+	{
+		var empty = new DrawCommandBuffer();
+		var commands = new DrawCommandBuffer();
+
+		commands.beginGradientFill(GradientType.LINEAR, [0], [1], [0], null, SpreadMethod.PAD, InterpolationMethod.RGB, 0);
+		commands.clear();
+		commands.beginFill(0xFF0000, 1);
+
+		Assert.isFalse(commands.types == empty.types);
+		Assert.isFalse(commands.i == empty.i);
+		Assert.isFalse(commands.f == empty.f);
+		Assert.isTrue(commands.b == empty.b);
+		Assert.isTrue(commands.o == empty.o);
+		Assert.isTrue(commands.ff == empty.ff);
+		Assert.isTrue(commands.ii == empty.ii);
+	}
+}
+#end


### PR DESCRIPTION
## Summary
`DrawCommandBuffer` stores drawing commands in seven parallel arrays. Its
current copy-on-write implementation detaches all seven arrays on the first
write, even when a command only uses a subset of them.

This changes the copy-on-write state to a per-stream bit mask. Each command now
detaches only the arrays it writes to, while `append()`, `copy()` and `clear()`
keep the existing sharing semantics.

For example:

- `drawRect()` materializes 2 streams instead of 7;
- `beginFill()` plus geometry materializes 3 streams instead of 7;
- line commands using style data materialize 5 streams instead of 7.

## Motivation

Many `Graphics` instances contain only simple geometry or fills. Allocating
unused empty arrays for every command buffer increases both managed memory and
the live object graph traversed by the GC.

## Repro
[OpenFLDrawCommandBufferCOWRepro.zip](https://github.com/user-attachments/files/30400737/OpenFLDrawCommandBufferCOWRepro.zip)
It creates and retains 100,000 `Shape` instances.
Each workload was run in five separate processes on Linux x86_64 with Haxe
4.3.6. Times below are medians; retained heap usage was stable across runs.

| Workload | Metric | `upstream/develop` | Patched |
|---|---|---:|---:|
| Geometry | Materialized streams | 7 | 2 |
| | Retained hxcpp heap | 191.8 MiB | 173.5 MiB |
| | Allocation time | 174 ms | 156 ms |
| | Median compacting GC | 55 ms | 47 ms |
| Fill | Materialized streams | 7 | 3 |
| | Retained hxcpp heap | 197.9 MiB | 183.4 MiB |
| | Allocation time | 177 ms | 164 ms |
| | Median compacting GC | 55 ms | 49 ms |
| Line | Materialized streams | 7 | 5 |
| | Retained hxcpp heap | 214.3 MiB | 207.0 MiB |
| | Allocation time | 215 ms | 205 ms |
| | Median compacting GC | 60 ms | 57 ms |

The command checksums are identical before and after the change.

## Real workload

GC time during active gameplay decreased from approximately 7.63 to 6.52 ms/s,
while marking time decreased from 6.16 to 4.91 ms/s and reclaimed allocation
volume decreased from 16.63 to 15.39 MiB/s.

The runs were not perfectly controlled, so these results should be treated as
supporting real-world evidence rather than a standalone benchmark.

## Tests

Added tests covering:

- allocation of only the streams used by each command;
- independent copy-on-write behavior for copied buffers;
- restoration of lazy shared storage after `clear()`.

The graphics test suite passes on both Neko and C++ with no failures or errors.