### PR TITLE
Add SecurityPanel and a no-op Security.showSettings

### DIFF
--- a/lib/flash-externs/src/flash/system/SecurityPanel.hx
+++ b/lib/flash-externs/src/flash/system/SecurityPanel.hx
@@ -1,15 +1,15 @@
 package flash.system;
 
 #if flash
-extern class SecurityPanel
+#if (haxe_ver >= 4.0) enum #else @:enum #end abstract SecurityPanel(String) from String to String
 {
-	public static var CAMERA(default, never):String;
-	public static var DEFAULT(default, never):String;
-	public static var DISPLAY(default, never):String;
-	public static var LOCAL_STORAGE(default, never):String;
-	public static var MICROPHONE(default, never):String;
-	public static var PRIVACY(default, never):String;
-	public static var SETTINGS_MANAGER(default, never):String;
+	public var CAMERA = "camera";
+	public var DEFAULT = "default";
+	public var DISPLAY = "display";
+	public var LOCAL_STORAGE = "localStorage";
+	public var MICROPHONE = "microphone";
+	public var PRIVACY = "privacy";
+	public var SETTINGS_MANAGER = "settingsManager";
 }
 #else
 typedef SecurityPanel = openfl.system.SecurityPanel;

--- a/lib/flash-externs/src/flash/system/SecurityPanel.hx
+++ b/lib/flash-externs/src/flash/system/SecurityPanel.hx
@@ -1,0 +1,16 @@
+package flash.system;
+
+#if flash
+extern class SecurityPanel
+{
+	public static var CAMERA(default, never):String;
+	public static var DEFAULT(default, never):String;
+	public static var DISPLAY(default, never):String;
+	public static var LOCAL_STORAGE(default, never):String;
+	public static var MICROPHONE(default, never):String;
+	public static var PRIVACY(default, never):String;
+	public static var SETTINGS_MANAGER(default, never):String;
+}
+#else
+typedef SecurityPanel = openfl.system.SecurityPanel;
+#end

--- a/src/openfl/system/Security.hx
+++ b/src/openfl/system/Security.hx
@@ -568,18 +568,17 @@ class Security
 		// var res = haxe.Http.requestUrl( url );
 	}
 
-	#if false
 	/**
 		Displays the Security Settings panel in Flash Player. This method does
 		not apply to content in Adobe AIR; calling it in an AIR application
-		has no effect.
+		has no effect. OpenFL native and HTML5 targets likewise treat this as
+		a no-op.
 
 		@param panel A value from the SecurityPanel class that specifies which
 					 Security Settings panel you want to display. If you omit
 					 this parameter, `SecurityPanel.DEFAULT` is used.
 	**/
-	// @:noCompletion @:dox(hide) public static function showSettings (panel:openfl.system.SecurityPanel = null):Void;
-	#end
+	public static function showSettings(panel:String = null):Void {}
 }
 #else
 typedef Security = flash.system.Security;

--- a/src/openfl/system/Security.hx
+++ b/src/openfl/system/Security.hx
@@ -578,7 +578,7 @@ class Security
 					 Security Settings panel you want to display. If you omit
 					 this parameter, `SecurityPanel.DEFAULT` is used.
 	**/
-	public static function showSettings(panel:String = null):Void {}
+	public static function showSettings(panel:SecurityPanel = null):Void {}
 }
 #else
 typedef Security = flash.system.Security;

--- a/src/openfl/system/SecurityPanel.hx
+++ b/src/openfl/system/SecurityPanel.hx
@@ -1,6 +1,7 @@
 package openfl.system;
 
 #if !flash
+#if !openfljs
 /**
 	The SecurityPanel class provides values for specifying which Security
 	Settings panel to display when `Security.showSettings()` is called.
@@ -8,47 +9,85 @@ package openfl.system;
 	Calling `Security.showSettings()` has no effect in Adobe AIR or on OpenFL
 	native and HTML5 targets.
 **/
-#if !openfl_debug
-@:fileXml('tags="haxe,release"')
-@:noDebug
-#end
-class SecurityPanel
+#if (haxe_ver >= 4.0) enum #else @:enum #end abstract SecurityPanel(Null<Int>)
 {
 	/**
 		The Camera panel.
 	**/
-	public static inline var CAMERA:String = "camera";
+	public var CAMERA = 0;
 
 	/**
 		The default panel.
 	**/
-	public static inline var DEFAULT:String = "default";
+	public var DEFAULT = 1;
 
 	/**
 		The Display panel.
 	**/
-	public static inline var DISPLAY:String = "display";
+	public var DISPLAY = 2;
 
 	/**
 		The Local Storage Settings panel.
 	**/
-	public static inline var LOCAL_STORAGE:String = "localStorage";
+	public var LOCAL_STORAGE = 3;
 
 	/**
 		The Microphone panel.
 	**/
-	public static inline var MICROPHONE:String = "microphone";
+	public var MICROPHONE = 4;
 
 	/**
 		The Privacy panel.
 	**/
-	public static inline var PRIVACY:String = "privacy";
+	public var PRIVACY = 5;
 
 	/**
 		The Settings Manager (Local Settings Manager) panel.
 	**/
-	public static inline var SETTINGS_MANAGER:String = "settingsManager";
+	public var SETTINGS_MANAGER = 6;
+
+	@:from private static function fromString(value:String):SecurityPanel
+	{
+		return switch (value)
+		{
+			case "camera": CAMERA;
+			case "default": DEFAULT;
+			case "display": DISPLAY;
+			case "localStorage": LOCAL_STORAGE;
+			case "microphone": MICROPHONE;
+			case "privacy": PRIVACY;
+			case "settingsManager": SETTINGS_MANAGER;
+			default: null;
+		}
+	}
+
+	@:to private function toString():String
+	{
+		return switch (cast this : SecurityPanel)
+		{
+			case SecurityPanel.CAMERA: "camera";
+			case SecurityPanel.DEFAULT: "default";
+			case SecurityPanel.DISPLAY: "display";
+			case SecurityPanel.LOCAL_STORAGE: "localStorage";
+			case SecurityPanel.MICROPHONE: "microphone";
+			case SecurityPanel.PRIVACY: "privacy";
+			case SecurityPanel.SETTINGS_MANAGER: "settingsManager";
+			default: null;
+		}
+	}
 }
+#else
+@SuppressWarnings("checkstyle:FieldDocComment") #if (haxe_ver >= 4.0) enum #else @:enum #end abstract SecurityPanel(String) from String to String
+{
+	public var CAMERA = "camera";
+	public var DEFAULT = "default";
+	public var DISPLAY = "display";
+	public var LOCAL_STORAGE = "localStorage";
+	public var MICROPHONE = "microphone";
+	public var PRIVACY = "privacy";
+	public var SETTINGS_MANAGER = "settingsManager";
+}
+#end
 #else
 typedef SecurityPanel = flash.system.SecurityPanel;
 #end

--- a/src/openfl/system/SecurityPanel.hx
+++ b/src/openfl/system/SecurityPanel.hx
@@ -1,0 +1,54 @@
+package openfl.system;
+
+#if !flash
+/**
+	The SecurityPanel class provides values for specifying which Security
+	Settings panel to display when `Security.showSettings()` is called.
+
+	Calling `Security.showSettings()` has no effect in Adobe AIR or on OpenFL
+	native and HTML5 targets.
+**/
+#if !openfl_debug
+@:fileXml('tags="haxe,release"')
+@:noDebug
+#end
+class SecurityPanel
+{
+	/**
+		The Camera panel.
+	**/
+	public static inline var CAMERA:String = "camera";
+
+	/**
+		The default panel.
+	**/
+	public static inline var DEFAULT:String = "default";
+
+	/**
+		The Display panel.
+	**/
+	public static inline var DISPLAY:String = "display";
+
+	/**
+		The Local Storage Settings panel.
+	**/
+	public static inline var LOCAL_STORAGE:String = "localStorage";
+
+	/**
+		The Microphone panel.
+	**/
+	public static inline var MICROPHONE:String = "microphone";
+
+	/**
+		The Privacy panel.
+	**/
+	public static inline var PRIVACY:String = "privacy";
+
+	/**
+		The Settings Manager (Local Settings Manager) panel.
+	**/
+	public static inline var SETTINGS_MANAGER:String = "settingsManager";
+}
+#else
+typedef SecurityPanel = flash.system.SecurityPanel;
+#end


### PR DESCRIPTION
- Add `openfl.system.SecurityPanel` (and the matching Flash extern).
- Implement `Security.showSettings` as a no-op on non-Flash targets, which is the AIR behavior.
