### PR TITLE
Fix LocalConnection rest args and stub non-Windows native targets

### DIFF
--- a/lib/draft-api/src/openfl/net/LocalConnection.hx
+++ b/lib/draft-api/src/openfl/net/LocalConnection.hx
@@ -4,6 +4,7 @@ package openfl.net;
 typedef LocalConnection = flash.net.LocalConnection;
 #elseif (cpp && windows)
 import haxe.Timer;
+import openfl.Lib;
 import openfl.errors.ArgumentError;
 import openfl.events.StatusEvent;
 import openfl.utils.Object;
@@ -12,6 +13,7 @@ import haxe.Serializer;
 import cpp.Pointer;
 import haxe.ds.StringMap;
 import haxe.io.Bytes;
+import haxe.io.BytesBuffer;
 import haxe.io.BytesData;
 import openfl.net._internal.NativeLocalConnection;
 import lime.system.BackgroundWorker;
@@ -34,7 +36,7 @@ class LocalConnection extends EventDispatcher
 
 	private function get_domain():String
 	{
-		Lib.notImplemented("LocalConnection.domain");
+		Lib.notImplemented();
 		return "";
 	}
 
@@ -134,12 +136,12 @@ class LocalConnection extends EventDispatcher
 
 	public function allowDomain(...domains:String):Void
 	{
-		Lib.notImplemented("LocalConnection.allowDomain");
+		Lib.notImplemented();
 	}
 
 	public function allowInsecureDomain(...domains:String):Void
 	{
-		Lib.notImplemented("LocalConnection.allowInsecureDomain");
+		Lib.notImplemented();
 	}
 
 	public static function get_isSupported():Bool

--- a/lib/draft-api/src/openfl/net/LocalConnection.hx
+++ b/lib/draft-api/src/openfl/net/LocalConnection.hx
@@ -1,6 +1,8 @@
 package openfl.net;
 
-#if !(flash || air)
+#if (flash || air)
+typedef LocalConnection = flash.net.LocalConnection;
+#elseif (cpp && windows)
 import haxe.Timer;
 import openfl.errors.ArgumentError;
 import openfl.events.StatusEvent;
@@ -83,7 +85,7 @@ class LocalConnection extends EventDispatcher
 	}
 
 	/** Sends a message to another connection */
-	public function send(connectionName:String, methodName:String, ...arguments):Void
+	public function send(connectionName:String, methodName:String, ...arguments:Dynamic):Void
 	{
 		__resetSeralizer();
 		var status:Bool = false;
@@ -130,12 +132,12 @@ class LocalConnection extends EventDispatcher
 		}
 	}
 
-	public function allowDomain(?domains:Array<String>):Void
+	public function allowDomain(...domains:String):Void
 	{
 		Lib.notImplemented("LocalConnection.allowDomain");
 	}
 
-	public function allowInsecureDomain(?domains:Array<String>):Void
+	public function allowInsecureDomain(...domains:String):Void
 	{
 		Lib.notImplemented("LocalConnection.allowInsecureDomain");
 	}
@@ -392,5 +394,52 @@ class LocalConnection extends EventDispatcher
 	}
 }
 #else
-typedef LocalConnection = flash.net.LocalConnection;
+import openfl.events.EventDispatcher;
+import openfl.events.StatusEvent;
+import openfl.utils.Object;
+
+/**
+	The LocalConnection class lets you send messages between running applications.
+
+	Named-pipe IPC is currently implemented on Windows native targets only. On
+	other targets, `send` dispatches a `StatusEvent` with `level` set to
+	`"error"`, matching Flash Player behavior when no receiver is connected.
+**/
+class LocalConnection extends EventDispatcher
+{
+	public var client:Object;
+
+	public var domain(get, never):String;
+
+	public var isPerUser:Bool;
+
+	private function get_domain():String
+	{
+		return "localhost";
+	}
+
+	public function new()
+	{
+		super();
+		isPerUser = false;
+	}
+
+	public function close():Void {}
+
+	public function connect(connectionName:String):Void {}
+
+	public function send(connectionName:String, methodName:String, ...arguments:Dynamic):Void
+	{
+		dispatchEvent(new StatusEvent(StatusEvent.STATUS, false, false, "0", "error"));
+	}
+
+	public function allowDomain(...domains:String):Void {}
+
+	public function allowInsecureDomain(...domains:String):Void {}
+
+	public static function get_isSupported():Bool
+	{
+		return false;
+	}
+}
 #end


### PR DESCRIPTION
- Align `allowDomain` / `allowInsecureDomain` / `send` with AS3 rest-argument types.
- Keep Win32 named pipes on `cpp && windows`.
- On other native targets, provide a stub so `-D draft` compiles. `isSupported` remains false; `send` dispatches `StatusEvent` with `level` `"error"` (same as no receiver).