### PR TITLE
Add Sprite.soundTransform and Object.setPropertyIsEnumerable

### DIFF
--- a/src/openfl/display/Sprite.hx
+++ b/src/openfl/display/Sprite.hx
@@ -3,6 +3,7 @@ package openfl.display;
 #if !flash
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
+import openfl.media.SoundTransform;
 import openfl.ui.MouseCursor;
 import openfl.utils._internal.Log;
 import openfl.utils.AssetLibrary;
@@ -103,14 +104,18 @@ class Sprite extends DisplayObjectContainer
 	**/
 	public var hitArea:Sprite;
 
-	#if false
 	/**
 		Controls sound within this sprite.
+
+		A Sprite can have only one SoundTransform object assigned to it. OpenFL
+		stores the volume and pan and returns a copy, matching `SimpleButton`.
+		The transform is not yet mixed into timeline sounds or child
+		`SoundChannel` objects on native and HTML5 targets.
+
 		**Note:** This property does not affect HTML content in an HTMLControl
 		object (in Adobe AIR).
 	**/
-	// @:noCompletion @:dox(hide) public var soundTransform:SoundTransform;
-	#end
+	public var soundTransform(get, set):SoundTransform;
 
 	/**
 		A Boolean value that indicates whether the pointing hand (hand cursor)
@@ -137,6 +142,7 @@ class Sprite extends DisplayObjectContainer
 	@:noCompletion private var __buttonMode:Bool;
 	@:noCompletion private var __pendingBindClassName:String;
 	@:noCompletion private var __pendingBindLibrary:AssetLibrary;
+	@:noCompletion private var __soundTransform:SoundTransform;
 
 	#if openfljs
 	@:noCompletion private static function __init__()
@@ -147,6 +153,10 @@ class Sprite extends DisplayObjectContainer
 				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_buttonMode (v); }")
 			},
 			"graphics": {get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_graphics (); }")},
+			"soundTransform": {
+				get: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function () { return this.get_soundTransform (); }"),
+				set: untyped #if haxe4 js.Syntax.code #else __js__ #end ("function (v) { return this.set_soundTransform (v); }")
+			},
 		});
 	}
 	#end
@@ -403,6 +413,26 @@ class Sprite extends DisplayObjectContainer
 	@:noCompletion private function set_buttonMode(value:Bool):Bool
 	{
 		return __buttonMode = value;
+	}
+
+	@:noCompletion private function get_soundTransform():SoundTransform
+	{
+		openfl.utils._internal.Lib.notImplemented();
+
+		if (__soundTransform == null)
+		{
+			__soundTransform = new SoundTransform();
+		}
+
+		return new SoundTransform(__soundTransform.volume, __soundTransform.pan);
+	}
+
+	@:noCompletion private function set_soundTransform(value:SoundTransform):SoundTransform
+	{
+		openfl.utils._internal.Lib.notImplemented();
+
+		__soundTransform = new SoundTransform(value.volume, value.pan);
+		return value;
 	}
 }
 #else

--- a/src/openfl/utils/Object.hx
+++ b/src/openfl/utils/Object.hx
@@ -2,6 +2,7 @@ package openfl.utils;
 
 import haxe.Constraints.Function;
 import openfl.display.DisplayObjectContainer;
+import openfl.utils._internal.Lib;
 
 @:transitive
 @:callable
@@ -70,6 +71,18 @@ abstract Object(ObjectType) from ObjectType from Dynamic to Dynamic
 		return (this != null
 			&& Reflect.hasField(this, name)
 			&& #if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (Reflect.field(this, name), Iterable_));
+	}
+
+	/**
+		Sets the availability of a dynamic property for `for..in` loops.
+
+		Haxe objects do not store ECMA `[[Enumerable]]` attributes (except on
+		the Flash target, where the native AVM method is used). This method
+		currently does not hide fields from `for..in`.
+	**/
+	public function setPropertyIsEnumerable(name:String, isEnum:Bool = true):Void
+	{
+		Lib.notImplemented();
 	}
 
 	public inline function toLocaleString():String

--- a/tests/displayobject/src/SpriteTest.hx
+++ b/tests/displayobject/src/SpriteTest.hx
@@ -58,6 +58,27 @@ class SpriteTest extends Test
 		Assert.isTrue(exists);
 	}
 
+	public function test_soundTransform()
+	{
+		var sprite = new Sprite();
+
+		var t1 = sprite.soundTransform;
+		var t2 = sprite.soundTransform;
+
+		Assert.notNull(t1);
+		Assert.notNull(t2);
+
+		Assert.notEquals(t1, t2);
+
+		Assert.equals(t1.volume, t2.volume);
+		Assert.equals(t1.pan, t2.pan);
+
+		t1.volume = 0.5;
+		sprite.soundTransform = t1;
+
+		Assert.equals(0.5, sprite.soundTransform.volume);
+	}
+
 	public function test_startDrag()
 	{
 		// TODO: Confirm functionality


### PR DESCRIPTION
- Enable `Sprite.soundTransform` (storage + clone, same shape as `SimpleButton`).
- Add `Object.setPropertyIsEnumerable`.
- Both warn once via `Lib.notImplemented()`.

This is not:
- AIR's Sprite mixer (timeline / child `SoundChannel`).
- A real enumerable-attribute support; `for..in` is unchanged.

The warning keeps the incompleteness explicit.
