### PR TITLE
Fix scale9Grid on mirrored (negatively scaled) objects

### DIFF
--- a/src/openfl/display/_internal/CairoGraphics.hx
+++ b/src/openfl/display/_internal/CairoGraphics.hx
@@ -510,10 +510,17 @@ class CairoGraphics
 
 	private static function toScale9Position(pos:Float, scale9Start:Float, scale9Center:Float, unscaledSize:Float, scale:Float):Float
 	{
-		if (scale <= 0.0)
+		if (scale == 0.0)
 		{
-			// doesn't render if scaled with negative value
+			// a zero scale collapses the object; nothing to lay out
 			return 0.0;
+		}
+		// A negative scale is a mirror, not a degenerate scale. Lay the slices
+		// out at the magnitude and let the sign stay in the display object's
+		// transform, which is where the flip is actually applied.
+		if (scale < 0.0)
+		{
+			scale = -scale;
 		}
 		var scale9End = unscaledSize - scale9Center - scale9Start;
 		var size = unscaledSize * scale;
@@ -1975,8 +1982,11 @@ class CairoGraphics
 		#end
 		if (hasScale9Grid)
 		{
-			graphics.__bitmapScaleX = graphics.__owner.scaleX;
-			graphics.__bitmapScaleY = graphics.__owner.scaleY;
+			// magnitude only: toScale9Position() lays the slices out unmirrored,
+			// so the sign has to stay in __worldTransform. Taking it here too
+			// would cancel the flip and place a mirrored object on the wrong side.
+			graphics.__bitmapScaleX = Math.abs(graphics.__owner.scaleX);
+			graphics.__bitmapScaleY = Math.abs(graphics.__owner.scaleY);
 		}
 		else
 		{

--- a/src/openfl/display/_internal/CanvasGraphics.hx
+++ b/src/openfl/display/_internal/CanvasGraphics.hx
@@ -673,10 +673,17 @@ class CanvasGraphics
 
 	private static function toScale9Position(pos:Float, scale9Start:Float, scale9Center:Float, unscaledSize:Float, scale:Float):Float
 	{
-		if (scale <= 0.0)
+		if (scale == 0.0)
 		{
-			// doesn't render if scaled with negative value
+			// a zero scale collapses the object; nothing to lay out
 			return 0.0;
+		}
+		// A negative scale is a mirror, not a degenerate scale. Lay the slices
+		// out at the magnitude and let the sign stay in the display object's
+		// transform, which is where the flip is actually applied.
+		if (scale < 0.0)
+		{
+			scale = -scale;
 		}
 		var scale9End = unscaledSize - scale9Center - scale9Start;
 		var size = unscaledSize * scale;
@@ -2136,8 +2143,11 @@ class CanvasGraphics
 		#end
 		if (hasScale9Grid)
 		{
-			graphics.__bitmapScaleX = graphics.__owner.scaleX;
-			graphics.__bitmapScaleY = graphics.__owner.scaleY;
+			// magnitude only: toScale9Position() lays the slices out unmirrored,
+			// so the sign has to stay in __worldTransform. Taking it here too
+			// would cancel the flip and place a mirrored object on the wrong side.
+			graphics.__bitmapScaleX = Math.abs(graphics.__owner.scaleX);
+			graphics.__bitmapScaleY = Math.abs(graphics.__owner.scaleY);
 		}
 		else
 		{

--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -89,12 +89,12 @@ class Context3DGraphics
 					if (isX)
 					{
 						tempScale9VerticesVector[i] = toScale9Position(vertices[i], scale9Grid.x, scale9Grid.width, bounds.width,
-							graphics.__owner.scaleX) / graphics.__owner.scaleX;
+							graphics.__owner.scaleX) / Math.abs(graphics.__owner.scaleX);
 					}
 					else
 					{
 						tempScale9VerticesVector[i] = toScale9Position(vertices[i], scale9Grid.y, scale9Grid.height, bounds.height,
-							graphics.__owner.scaleY) / graphics.__owner.scaleY;
+							graphics.__owner.scaleY) / Math.abs(graphics.__owner.scaleY);
 					}
 					i++;
 					isX = !isX;
@@ -1249,10 +1249,17 @@ class Context3DGraphics
 
 	private static function toScale9Position(pos:Float, scale9Start:Float, scale9Center:Float, unscaledSize:Float, scale:Float):Float
 	{
-		if (scale <= 0.0)
+		if (scale == 0.0)
 		{
-			// doesn't render if scaled with negative value
+			// a zero scale collapses the object; nothing to lay out
 			return 0.0;
+		}
+		// A negative scale is a mirror, not a degenerate scale. Lay the slices
+		// out at the magnitude and let the sign stay in the display object's
+		// transform, which is where the flip is actually applied.
+		if (scale < 0.0)
+		{
+			scale = -scale;
 		}
 		var scale9End = unscaledSize - scale9Center - scale9Start;
 		var size = unscaledSize * scale;


### PR DESCRIPTION
### The problem

`toScale9Position()` begins:

```haxe
if (scale <= 0.0)
{
    // doesn't render if scaled with negative value
    return 0.0;
}
```

The premise is incorrect. Flash renders a mirrored nine-slice object normally — a negative `scaleX`/`scaleY` is a flip, not a degenerate scale. The early return collapses every coordinate on the mirrored axis to zero, so the object renders as a zero-width (or zero-height) sliver at its own origin.

This affects Flash-authored content in particular, where mirroring a symbol to make a left/right pair was routine. The defect that led me here is a button whose nine-sliced background is placed at `scaleX = -0.8148`: the background disappears entirely, leaving a vertical sliver at the button's right edge while the label renders normally.

### The fix

Two parts, with the second illustrating why `Math.abs()` in one place isn't enough:

1. Lay the slices out at the magnitude of the scale rather than bailing out.
2. Make `__bitmapScaleX`/`__bitmapScaleY` carry the magnitude only. The sign already lives in the display object's transform, and `CanvasShape` /  `Context3DShape` multiply by `1 / __bitmapScaleX`. Taking the sign in both  places cancels the flip already present in `__worldTransform` and places the  object on the wrong side of its origin.

`Context3DGraphics` divides by `graphics.__owner.scaleX` when building the scale9 vertex buffer, so that takes the magnitude too, for the same reason.

The `scale == 0.0` guard is fine, as it means there's nothing to lay out.

### Reproducing

Any nine-sliced object with a negative scale on either axis. Minimal case, no assets required:

```haxe
var sprite = new Sprite();
sprite.graphics.beginFill(0x3a6ea5);
sprite.graphics.drawRoundRect(0, 0, 145, 38, 24, 24);
sprite.graphics.endFill();
sprite.scale9Grid = new Rectangle(27, 9, 97, 18);
sprite.scaleX = -3; // positive renders; negative does not
addChild(sprite);
```

Environment: Haxe 4.3.4, Lime 8.3.2, openfl `develop` @ 6907b7dbe, macOS 26.5.2, html5 target. The original report came from a Flash-authored SWF regenerated for html5 using `swf` 3.4.0, but as above it does not need one.

### Verification

Reproduced and fixed on `develop` at 6907b7dbe, html5 target, using a Flash-authored SWF containing the mirrored button plus hand-written `drawRoundRect` cases at 1x, 2x, 3x and mirrored.

Before: the mirrored nine-slice background collapses to a sliver, and a mirrored rounded rect does not render at all. After: both render correctly, corner radii constant across scales, only the centre band stretching.

Both builds were checked to confirm the emitted JS carried the expected code before comparing, so the two results are not the same artifact.

### On tests

I could not find a good home for an automated test.

The CI-run unit tests cover `scale9Grid` as a property — `DisplayObjectTest` asserts get/set round-trip, but nothing I could find observes rasterization issues like this. The only coverage that would see it is `tests/functional/src/test/Scale9GridTest1.hx`, and that is currently disabled: commented out in `tests/functional/src/Main.hx`, with its `assets/scale9Grid.swf` library commented out in `tests/functional/project.xml`.

Adding a mirrored case there would be dead code unless the test is re-enabled, and that didn't seem in line with the current direction of the repo.

### Note on overlap

PR #2861 also touches `CairoGraphics.hx`. There is no conflict with `develop` as of `6907b7dbe`, but whichever of the two lands second may want a rebase.

### Not included

While preparing this I noticed `toScale9Position()` measures its slice margins from 0, but `pos` and `scale9Start` are in the object's local space, which begins at `bounds.x`/`bounds.y`. `drawCircle`, `drawEllipse` and `drawRoundRect` already compensate by passing `scale9Grid.x - bounds.x`, but the 32 call sites in `playCommands()` and 10 in `createGradientPattern()` still pass `scale9Grid.x` unrebased, so a symbol whose bounds do not start at (0, 0) gets a mis-sized end margin and drifting interior slice boundaries.

That looked like a refactor in progress rather than something to change underneath you, so I left it out of this PR. Happy to follow up separately if you want help with it.