### PR TITLE
Fix draft NativeMenu and SQLErrorEvent compile

### DIFF
--- a/lib/draft-api/src/openfl/display/NativeMenu.hx
+++ b/lib/draft-api/src/openfl/display/NativeMenu.hx
@@ -1,8 +1,11 @@
 package openfl.display;
 
-import _internal.native.menu.ContextMenuData;
-import _internal.native.menu.WinMenuUtil;
 import openfl.desktop.NativeApplication;
+import openfl.display._internal.native.menu.ContextMenuData;
+#if windows
+import openfl.display._internal.native.menu.WinMenuUtil;
+import openfl.display._internal.native.window.WinWindowUtil;
+#end
 import openfl.events.Event;
 import openfl.events.EventDispatcher;
 import openfl.events.EventType;
@@ -15,6 +18,7 @@ import haxe.ds.IntMap;
  * @author Christopher Speciale
  */
 @:access(openfl.display.NativeMenuItem)
+@:access(openfl.display.NativeWindow)
 class NativeMenu extends EventDispatcher
 {
 	private static var __hasContextMenuListener:Bool = false;
@@ -115,8 +119,13 @@ class NativeMenu extends EventDispatcher
 	public function display(stage:Stage, stageX:Float, stageY:Float):Void
 	{
 		dispatchEvent(new Event(Event.DISPLAYING));
-		@:privateAccess
-		__setupNativeListener(NativeApplication.nativeApplication.activeWindow.__hWnd);
+		#if windows
+		var nativeWindow = NativeApplication.nativeApplication.activeWindow;
+		if (nativeWindow != null)
+		{
+			__setupNativeListener(WinWindowUtil.getHWND(nativeWindow.__window));
+		}
+		#end
 	}
 
 	public function getItemAt(index:Int):NativeMenuItem
@@ -230,6 +239,7 @@ class NativeMenu extends EventDispatcher
 		window.menu = this;
 	}
 
+	#if windows
 	private function __setupNativeListener(hWnd:Int):Void
 	{
 		if (!__hasContextMenuListener)
@@ -239,6 +249,7 @@ class NativeMenu extends EventDispatcher
 			__hasContextMenuListener = true;
 		}
 	}
+	#end
 
 	private static var __callbacks:IntMap<Function> = new IntMap();
 

--- a/lib/draft-api/src/openfl/display/NativeMenuItem.hx
+++ b/lib/draft-api/src/openfl/display/NativeMenuItem.hx
@@ -1,6 +1,6 @@
 package openfl.display;
 
-import _internal.native.menu.ContextMenuData.ContextMenuItemData;
+import openfl.display._internal.native.menu.ContextMenuData.ContextMenuItemData;
 import openfl.events.Event;
 import openfl.events.EventType;
 import openfl.utils.Object;

--- a/lib/draft-api/src/openfl/display/_internal/native/desktop/WinDesktopUtil.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/desktop/WinDesktopUtil.hx
@@ -1,12 +1,12 @@
-package _internal.native.desktop;
+package openfl.display._internal.native.desktop;
 
-import _internal.native.desktop.extension.WinDesktopUtilExtern;
+import openfl.display._internal.native.desktop.extension.WinDesktopUtilExtern;
 
 /**
  * ...
  * @author Christopher Speciale
  */
-@:access(_internal.native.desktop.extension.WinDesktopUtilExtern)
+@:access(openfl.display._internal.native.desktop.extension.WinDesktopUtilExtern)
 class WinDesktopUtil
 {
 	public static function getCursorPos():Array<Int>

--- a/lib/draft-api/src/openfl/display/_internal/native/desktop/extension/WinDesktopUtilExtern.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/desktop/extension/WinDesktopUtilExtern.hx
@@ -1,4 +1,4 @@
-package _internal.native.desktop.extension;
+package openfl.display._internal.native.desktop.extension;
 
 /**
  * ...

--- a/lib/draft-api/src/openfl/display/_internal/native/menu/ContextMenuData.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/menu/ContextMenuData.hx
@@ -1,4 +1,4 @@
-package _internal.native.menu;
+package openfl.display._internal.native.menu;
 
 import openfl.utils.Object;
 

--- a/lib/draft-api/src/openfl/display/_internal/native/menu/WinMenuUtil.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/menu/WinMenuUtil.hx
@@ -1,13 +1,13 @@
-package _internal.native.menu;
+package openfl.display._internal.native.menu;
 
-import _internal.native.menu.extension.WinMenuUtilExtern;
+import openfl.display._internal.native.menu.extension.WinMenuUtilExtern;
 import openfl.Lib;
 
 /**
  * ...
  * @author Christopher Speciale
  */
-@:access(_internal.native.menu.extension.WinMenuUtilExtern)
+@:access(openfl.display._internal.native.menu.extension.WinMenuUtilExtern)
 class WinMenuUtil
 {
 	public static function showPopupMenu(id:Int, menuData:ContextMenuData, x:Int, y:Int):Bool

--- a/lib/draft-api/src/openfl/display/_internal/native/menu/extension/WinMenuUtilExtern.cpp
+++ b/lib/draft-api/src/openfl/display/_internal/native/menu/extension/WinMenuUtilExtern.cpp
@@ -32,7 +32,7 @@ void setupPopupMenu(HMENU hMenu, hx::ObjectPtr<hx::Object> menuData)
 {
 	Dynamic data = menuData;
 
-	std::cout << "function start" << (data == nullptr) << std::endl;
+	std::cout << "function start" << (data == null()) << std::endl;
 
 	Array<hx::ObjectPtr<hx::Object>> items = menuData->__Field(HX_CSTRING("items"), hx::paccAlways);
 
@@ -231,7 +231,7 @@ void setupSystemMenu(HMENU hSystemMenu, hx::ObjectPtr<hx::Object> menuData)
 {
 	Dynamic data = menuData;
 
-	std::cout << "function start" << (data == nullptr) << std::endl;
+	std::cout << "function start" << (data == null()) << std::endl;
 
 	Array<hx::ObjectPtr<hx::Object>> items = menuData->__Field(HX_CSTRING("items"), hx::paccAlways);
 

--- a/lib/draft-api/src/openfl/display/_internal/native/menu/extension/WinMenuUtilExtern.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/menu/extension/WinMenuUtilExtern.hx
@@ -1,6 +1,6 @@
-package _internal.native.menu.extension;
+package openfl.display._internal.native.menu.extension;
 
-import _internal.native.menu.ContextMenuData;
+import openfl.display._internal.native.menu.ContextMenuData;
 import haxe.Constraints.Function;
 
 /**

--- a/lib/draft-api/src/openfl/display/_internal/native/window/LinWindowUtil.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/window/LinWindowUtil.hx
@@ -1,4 +1,4 @@
-package src._internal.native.window;
+package openfl.display._internal.native.window;
 
 /**
  * ...

--- a/lib/draft-api/src/openfl/display/_internal/native/window/MacWindowUtil.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/window/MacWindowUtil.hx
@@ -1,4 +1,4 @@
-package src._internal.native.window;
+package openfl.display._internal.native.window;
 
 /**
  * ...

--- a/lib/draft-api/src/openfl/display/_internal/native/window/WinWindowUtil.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/window/WinWindowUtil.hx
@@ -1,6 +1,6 @@
-package _internal.native.window;
+package openfl.display._internal.native.window;
 
-import _internal.native.window.extension.WinWindowUtilExtern;
+import openfl.display._internal.native.window.extension.WinWindowUtilExtern;
 import haxe.ds.IntMap;
 import lime.tools.GUID;
 import openfl.display.Window;
@@ -9,7 +9,7 @@ import openfl.display.Window;
  * ...
  * @author Christopher Speciale
  */
-@:access(_internal.native.window.extension.WinWindowUtilExtern)
+@:access(openfl.display._internal.native.window.extension.WinWindowUtilExtern)
 class WinWindowUtil
 {
 	private static var systemTrayCallback:Void->Void;

--- a/lib/draft-api/src/openfl/display/_internal/native/window/extension/WinWindowUtilExtern.hx
+++ b/lib/draft-api/src/openfl/display/_internal/native/window/extension/WinWindowUtilExtern.hx
@@ -1,4 +1,4 @@
-package _internal.native.window.extension;
+package openfl.display._internal.native.window.extension;
 
 import haxe.Constraints.Function;
 

--- a/lib/draft-api/src/openfl/events/SQLErrorEvent.hx
+++ b/lib/draft-api/src/openfl/events/SQLErrorEvent.hx
@@ -1,7 +1,6 @@
 package openfl.events;
 
 import openfl.errors.SQLError;
-import openfl.events.Event;
 
 /**
  * ...
@@ -19,8 +18,12 @@ class SQLErrorEvent extends ErrorEvent
 		this.error = error;
 	}
 
-	override public function clone():Event
+	public override function clone():SQLErrorEvent
 	{
-		return new SQLErrorEvent(type, error);
+		var event = new SQLErrorEvent(type, error);
+		event.target = target;
+		event.currentTarget = currentTarget;
+		event.eventPhase = eventPhase;
+		return event;
 	}
 }

--- a/src/openfl/display/NativeWindow.hx
+++ b/src/openfl/display/NativeWindow.hx
@@ -578,6 +578,18 @@ class NativeWindow extends EventDispatcher
 		return __window.title = value;
 	}
 
+	#if draft
+	/**
+		The native menu for this window.
+
+		When `NativeWindow.supportsMenu` is `true`, assigning a `NativeMenu`
+		displays it as the window menu (unless `systemChrome` is `NONE`).
+		Assigning a menu when `supportsMenu` is `false` is allowed, but does
+		nothing.
+	**/
+	public var menu:NativeMenu;
+	#end
+
 	/**
 		Specifies whether this window is visible.
 

--- a/src/openfl/events/Event.hx
+++ b/src/openfl/events/Event.hx
@@ -300,6 +300,21 @@ class Event
 	public static inline var DEACTIVATE:EventType<Event> = "deactivate";
 
 	/**
+		The `Event.DISPLAYING` constant defines the value of the `type`
+		property of a `displaying` event object.
+
+		This event has the following properties:
+
+		| Property | Value |
+		| --- | --- |
+		| `bubbles` | `false` |
+		| `cancelable` | `false`; there is no default behavior to cancel. |
+		| `currentTarget` | The object that is actively processing the Event object with an event listener. |
+		| `target` | The NativeMenu object that is about to display. |
+	**/
+	public static inline var DISPLAYING:EventType<Event> = "displaying";
+
+	/**
 		The `Event.ENTER_FRAME` constant defines the value of the `type`
 		property of an `enterFrame` event object.
 		**Note:** This event has neither a "capture phase" nor a "bubble


### PR DESCRIPTION
- Align draft native helper packages with their path under `openfl.display._internal`, and gate Win32 externs with `#if windows`.
- Fix `SQLErrorEvent.clone()` so it overrides `ErrorEvent.clone():ErrorEvent`.
- Add the AIR pieces NativeMenu already assumed: `Event.DISPLAYING`, `NativeWindow.menu` (`#if draft`), and HWND lookup via `WinWindowUtil.getHWND` instead of a non-existent `__hWnd`.
- Compare `Dynamic` against hxcpp `null()` in `WinMenuUtilExtern.cpp`. MSVC rejects `Dynamic == nullptr` (C2666) once NativeMenu is compiled in.

These modules otherwise don't compile when referenced.