### PR TITLE
revert multi-rect batching in isCompatible(), fixes corrupted textures

### DIFF
--- a/src/openfl/display/_internal/Context3DGraphics.hx
+++ b/src/openfl/display/_internal/Context3DGraphics.hx
@@ -41,7 +41,6 @@ class Context3DGraphics
 	private static var tempIndicesVector:Vector<Int> = new Vector<Int>();
 	private static var tempUvtVector:Vector<Float> = new Vector<Float>();
 	private static var tempScale9VerticesVector:Vector<Float>;
-	private static var tempRects:Array<Rectangle> = [];
 
 	private static function buildBuffer(graphics:Graphics, renderer:OpenGLRenderer):Void
 	{
@@ -514,31 +513,6 @@ class Context3DGraphics
 		Matrix.__pool.release(tileTransform);
 	}
 
-	private static function cleanupTempRects():Void
-	{
-		for (rect in tempRects)
-		{
-			Rectangle.__pool.release(rect);
-		}
-		#if haxe4
-		tempRects.resize(0);
-		#else
-		tempRects.splice(0, tempRects.length);
-		#end
-	}
-
-	private static function intersectsTempRects(rect:Rectangle):Bool
-	{
-		for (other in tempRects)
-		{
-			if (other.intersects(rect))
-			{
-				return true;
-			}
-		}
-		return false;
-	}
-
 	private static function isCompatible(graphics:Graphics):Bool
 	{
 		#if (openfl_force_sw_graphics || force_sw_graphics)
@@ -554,15 +528,9 @@ class Context3DGraphics
 
 		var data = new DrawCommandReader(graphics.__commands);
 		var hasColorFill = false, hasBitmapFill = false, hasShaderFill = false;
-
-		// for each fill, allow drawing only shapes with no intersection because
-		// that would require a cutout. fall back to software for intersections
-
-		// for drawRect(), remember the bounds of each rectangle
-		cleanupTempRects();
-
-		// drawTriangles() or drawQuads(): for simplicity, we'll allow only one
-		var hasDrawnComplex = false;
+		// only one filled shape per fill: shapes may intersect and need a cutout, and
+		// DRAW_RECT's bitmap fill only maps UVs for a single rect. fall back otherwise.
+		var hasDrawnFilledShape = false;
 
 		for (type in graphics.__commands.types)
 		{
@@ -573,68 +541,61 @@ class Context3DGraphics
 					if (c.matrix != null)
 					{
 						data.destroy();
-						cleanupTempRects();
 						return false;
 					}
 					hasBitmapFill = true;
 					hasColorFill = false;
 					hasShaderFill = false;
-					cleanupTempRects();
+					hasDrawnFilledShape = false;
 					data.skip(type);
 
 				case BEGIN_FILL:
 					hasBitmapFill = false;
 					hasColorFill = true;
 					hasShaderFill = false;
-					cleanupTempRects();
+					hasDrawnFilledShape = false;
 					data.skip(type);
 
 				case BEGIN_SHADER_FILL:
 					hasBitmapFill = false;
 					hasColorFill = false;
 					hasShaderFill = true;
-					cleanupTempRects();
+					hasDrawnFilledShape = false;
 					data.skip(type);
 
 				case DRAW_QUADS:
-					if (!hasDrawnComplex && tempRects.length == 0 && (hasColorFill || hasBitmapFill || hasShaderFill))
+					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
 					{
-						hasDrawnComplex = true;
+						hasDrawnFilledShape = true;
 						data.skip(type);
 					}
 					else
 					{
 						data.destroy();
-						cleanupTempRects();
 						return false;
 					}
 
 				case DRAW_RECT:
-					var c = data.readDrawRect();
-					var rect = Rectangle.__pool.get();
-					rect.setTo(c.x, c.y, c.width, c.height);
-					if (!hasDrawnComplex && !intersectsTempRects(rect) && (hasColorFill || hasBitmapFill || hasShaderFill))
+					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
 					{
-						tempRects.push(rect);
-					}
-					else
-					{
-						Rectangle.__pool.release(rect);
-						data.destroy();
-						cleanupTempRects();
-						return false;
-					}
-
-				case DRAW_TRIANGLES:
-					if (!hasDrawnComplex && tempRects.length == 0 && (hasColorFill || hasBitmapFill || hasShaderFill))
-					{
-						hasDrawnComplex = true;
+						hasDrawnFilledShape = true;
 						data.skip(type);
 					}
 					else
 					{
 						data.destroy();
-						cleanupTempRects();
+						return false;
+					}
+
+				case DRAW_TRIANGLES:
+					if (!hasDrawnFilledShape && (hasColorFill || hasBitmapFill || hasShaderFill))
+					{
+						hasDrawnFilledShape = true;
+						data.skip(type);
+					}
+					else
+					{
+						data.destroy();
 						return false;
 					}
 
@@ -643,7 +604,6 @@ class Context3DGraphics
 					if (c.thickness != null)
 					{
 						data.destroy();
-						cleanupTempRects();
 						return false;
 					}
 					data.skip(type);
@@ -652,7 +612,7 @@ class Context3DGraphics
 					hasBitmapFill = false;
 					hasColorFill = false;
 					hasShaderFill = false;
-					cleanupTempRects();
+					hasDrawnFilledShape = false;
 					data.skip(type);
 
 				case MOVE_TO:
@@ -663,13 +623,11 @@ class Context3DGraphics
 
 				default:
 					data.destroy();
-					cleanupTempRects();
 					return false;
 			}
 		}
 
 		data.destroy();
-		cleanupTempRects();
 		return true;
 	}
 


### PR DESCRIPTION
714751053 let `isCompatible()` accept multiple non-intersecting `DRAW_RECT`
commands per fill on the hardware path. But `DRAW_RECT`'s bitmap/shader-fill
rendering only ever handles one rect per fill - no per-rect UV mapping - so a
second rect samples the wrong part of the bitmap, causing corrupted/black
textures.

Reverts `isCompatible()` to the original one-shape-per-fill check.

Tested: two non-overlapping bitmap-filled rects rendered corrupted before,
correctly after.


Before:
<img width="1279" height="726" alt="image" src="https://github.com/user-attachments/assets/d24a2c8a-852f-44b0-b936-f759e103f80c" />

After:
<img width="1278" height="725" alt="image" src="https://github.com/user-attachments/assets/38abe3b0-4d23-4ac2-9a67-7a7763342484" />
